### PR TITLE
Fix malformed print statement in multi-agent routing notebook

### DIFF
--- a/03_adk_multi_agent_routing.ipynb
+++ b/03_adk_multi_agent_routing.ipynb
@@ -663,7 +663,7 @@
     "print(f\"   Root Agent: {coordinator_agent.name}\")\n",
     "print(f\"\\n🎯 Multi-Agent System Ready!\")\n",
     "print(\"   When users send requests, the coordinator will automatically route\")\n",
-    "   \"   them to the appropriate specialist agent.\")"
+    "print(\"   them to the appropriate specialist agent.\")\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- correct the final print call in `03_adk_multi_agent_routing.ipynb` so the multi-line message renders properly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e3c79e79c4832dbacec307263d4b9b