### PR TITLE
course(M03): sessions, state, events, artifacts

### DIFF
--- a/index.html
+++ b/index.html
@@ -235,14 +235,14 @@
       <div class="status ready">Ready</div>
     </a>
 
-    <div class="module soon">
+    <a class="module" href="slides/module-03-sessions-state/index.html">
       <div class="num">M03</div>
       <div>
         <div class="title">Sessions, State, Events, Artifacts</div>
         <div class="desc">Where the conversation's memory actually lives.</div>
       </div>
-      <div class="status soon">Soon</div>
-    </div>
+      <div class="status ready">Ready</div>
+    </a>
 
     <div class="module soon">
       <div class="num">M04</div>

--- a/notebooks/03_sessions_state.ipynb
+++ b/notebooks/03_sessions_state.ipynb
@@ -1,0 +1,499 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "05d9b3ed",
+   "metadata": {},
+   "source": [
+    "# Module 03 — Sessions, State, Events, Artifacts\n",
+    "\n",
+    "Module 01 gave you the four primitives. Module 02 gave you tools. This module goes deep on **the third primitive — Session — and its contents: state, events, and artifacts.**\n",
+    "\n",
+    "If Module 02 was about what an agent can *do*, Module 03 is about what an agent *remembers*. A stateless agent is a party trick. A stateful agent is infrastructure.\n",
+    "\n",
+    "**What you'll build:**\n",
+    "- An agent that reads and writes session `state` from inside a tool.\n",
+    "- An agent that auto-saves its final response via `output_key=`.\n",
+    "- **The wow demo:** the same user starts two separate sessions — and the agent remembers their preferences in session two because of the `user:` state prefix.\n",
+    "\n",
+    "**Running cost:** under $0.01 on OpenRouter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e9026932",
+   "metadata": {},
+   "source": [
+    "# Setup\n",
+    "\n",
+    "## Install Dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b37831a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -q google-adk==1.28.0 litellm==1.83.4 python-dotenv==1.0.1 nest-asyncio==1.6.0 deprecated==1.2.18 2>/dev/null\n",
+    "\n",
+    "print(\"✅ Packages installed.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f528262",
+   "metadata": {},
+   "source": [
+    "## API Key Configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4a6f7552",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "OPENROUTER_API_KEY = None\n",
+    "try:\n",
+    "    from google.colab import userdata\n",
+    "    OPENROUTER_API_KEY = userdata.get(\"OPENROUTER_API_KEY\")\n",
+    "    print(\"✅ API key loaded from Colab secrets.\")\n",
+    "except Exception:\n",
+    "    try:\n",
+    "        from dotenv import load_dotenv\n",
+    "        load_dotenv()\n",
+    "        OPENROUTER_API_KEY = os.getenv(\"OPENROUTER_API_KEY\")\n",
+    "        if OPENROUTER_API_KEY:\n",
+    "            print(\"✅ API key loaded from .env file.\")\n",
+    "    except ImportError:\n",
+    "        pass\n",
+    "\n",
+    "if not OPENROUTER_API_KEY:\n",
+    "    from getpass import getpass\n",
+    "    print(\"💡 Set OPENROUTER_API_KEY in Colab secrets (🔑 icon) or a local .env file.\")\n",
+    "    OPENROUTER_API_KEY = getpass(\"Enter your OpenRouter API key: \")\n",
+    "\n",
+    "assert OPENROUTER_API_KEY, \"❌ No API key provided.\"\n",
+    "os.environ[\"OPENROUTER_API_KEY\"] = OPENROUTER_API_KEY\n",
+    "\n",
+    "MODEL_STRING = \"openrouter/google/gemini-2.5-flash-lite\"\n",
+    "print(f\"✅ Model: {MODEL_STRING}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca1de7ce",
+   "metadata": {},
+   "source": [
+    "## Import Libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e19843c4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, warnings, asyncio, uuid, logging\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "try:\n",
+    "    sys.stderr.fileno()\n",
+    "except Exception:\n",
+    "    sys.stderr = open(os.devnull, \"w\")\n",
+    "\n",
+    "import nest_asyncio; nest_asyncio.apply()\n",
+    "import litellm; litellm.suppress_debug_info = True\n",
+    "logging.getLogger(\"LiteLLM\").setLevel(logging.WARNING)\n",
+    "\n",
+    "from google.adk.agents import LlmAgent\n",
+    "from google.adk.runners import Runner\n",
+    "from google.adk.sessions import InMemorySessionService\n",
+    "from google.adk.models.lite_llm import LiteLlm\n",
+    "from google.adk.tools.tool_context import ToolContext\n",
+    "from google.genai import types\n",
+    "\n",
+    "print(\"✅ Imports successful.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "247d6613",
+   "metadata": {},
+   "source": [
+    "# Sessions — A Refresher\n",
+    "\n",
+    "A `Session` is identified by a triple: `(app_name, user_id, session_id)`. It holds two things:\n",
+    "\n",
+    "- **A list of events** — the full ordered history of every message, tool call, tool response, and state mutation. Read-only from your code's perspective; ADK appends to it.\n",
+    "- **A state dict** — mutable key-value storage for anything you want the agent to carry between turns.\n",
+    "\n",
+    "Three session services ship with ADK:\n",
+    "\n",
+    "| Service | Backing | When |\n",
+    "|---|---|---|\n",
+    "| `InMemorySessionService` | Python dict | Demos and tests |\n",
+    "| `DatabaseSessionService` | SQLAlchemy (Postgres, SQLite) | Self-hosted production |\n",
+    "| `VertexAiSessionService` | Google Cloud | Vertex deployments |\n",
+    "\n",
+    "We'll use in-memory through M07. When memory becomes the point in M08, we'll swap to the database version."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c64f343",
+   "metadata": {},
+   "source": [
+    "# State — With Scope Prefixes\n",
+    "\n",
+    "The most under-documented feature of ADK, and the one you'll use every day.\n",
+    "\n",
+    "A state dict is just a Python dict, but **the key's prefix decides where it lives and how long it survives.**\n",
+    "\n",
+    "| Prefix | Scope | Survives |\n",
+    "|---|---|---|\n",
+    "| *(none)* | This session only | Until the session is deleted |\n",
+    "| `user:` | This user, across all their sessions | As long as the user exists |\n",
+    "| `app:` | Global across all users of this app | As long as the app exists |\n",
+    "| `temp:` | This invocation only | Thrown away after the current run |\n",
+    "\n",
+    "Four scope rings. Think of it as React state with persistence tiers baked in — local, user profile, global config, throwaway scratch.\n",
+    "\n",
+    "The demos below make this concrete."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46be6eab",
+   "metadata": {},
+   "source": [
+    "# Demo 1 — Writing State From a Tool\n",
+    "\n",
+    "The cleanest way to mutate state is from inside a tool. Tools that take a `tool_context: ToolContext` argument get handed the running context, and `tool_context.state` behaves like a dict you can assign to. ADK records the mutation as an event, and by the next turn the new state is visible to the agent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c6686ac5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "APP = \"m03_demo\"\n",
+    "USER = \"alice\"\n",
+    "session_service = InMemorySessionService()\n",
+    "\n",
+    "def remember_favorite_color(color: str, tool_context: ToolContext) -> dict:\n",
+    "    \"\"\"Record the user's favorite color for future sessions.\n",
+    "\n",
+    "    Args:\n",
+    "        color: A color name like \"teal\", \"crimson\", \"forest green\".\n",
+    "    \"\"\"\n",
+    "    # Note the user: prefix — this makes the value survive beyond this session.\n",
+    "    tool_context.state[\"user:favorite_color\"] = color\n",
+    "    return {\"status\": \"saved\", \"color\": color}\n",
+    "\n",
+    "\n",
+    "def recall_favorite_color(tool_context: ToolContext) -> dict:\n",
+    "    \"\"\"Check whether the user has told us their favorite color before.\"\"\"\n",
+    "    color = tool_context.state.get(\"user:favorite_color\")\n",
+    "    if color:\n",
+    "        return {\"known\": True, \"color\": color}\n",
+    "    return {\"known\": False}\n",
+    "\n",
+    "\n",
+    "color_agent = LlmAgent(\n",
+    "    name=\"color_agent\",\n",
+    "    model=LiteLlm(model=MODEL_STRING),\n",
+    "    description=\"Remembers and recalls the user's favorite color across sessions.\",\n",
+    "    instruction=(\n",
+    "        \"You track the user's favorite color. \"\n",
+    "        \"When they tell you a color, call remember_favorite_color. \"\n",
+    "        \"When they ask what their color is, call recall_favorite_color first. \"\n",
+    "        \"Be brief.\"\n",
+    "    ),\n",
+    "    tools=[remember_favorite_color, recall_favorite_color],\n",
+    "    output_key=\"last_response\",   # also save the final text to state['last_response']\n",
+    ")\n",
+    "\n",
+    "print(\"✅ color_agent ready.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "67f4bd65",
+   "metadata": {},
+   "source": [
+    "## Run Session 1 — tell the agent your color"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ad321b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def chat(agent, prompt: str, sid: str):\n",
+    "    sess = await session_service.get_session(app_name=APP, user_id=USER, session_id=sid)\n",
+    "    if sess is None:\n",
+    "        await session_service.create_session(app_name=APP, user_id=USER, session_id=sid)\n",
+    "    runner = Runner(agent=agent, app_name=APP, session_service=session_service)\n",
+    "    message = types.Content(role=\"user\", parts=[types.Part(text=prompt)])\n",
+    "    print(f\"USER ({sid}): {prompt}\")\n",
+    "    async for event in runner.run_async(user_id=USER, session_id=sid, new_message=message):\n",
+    "        if event.content and event.content.parts:\n",
+    "            for p in event.content.parts:\n",
+    "                if p.text and p.text.strip():\n",
+    "                    tag = \"[FINAL]\" if event.is_final_response() else \"[step]\"\n",
+    "                    print(f\"{tag} {event.author}: {p.text.strip()[:200]}\")\n",
+    "                if p.function_call:\n",
+    "                    print(f\"[tool_call] {p.function_call.name}({dict(p.function_call.args)})\")\n",
+    "                if p.function_response:\n",
+    "                    print(f\"[tool_resp] {p.function_response.response}\")\n",
+    "    print()\n",
+    "\n",
+    "SID_1 = \"session-one\"\n",
+    "await chat(color_agent, \"My favorite color is teal.\", SID_1)\n",
+    "\n",
+    "# Inspect what's in the session's state now.\n",
+    "s1 = await session_service.get_session(app_name=APP, user_id=USER, session_id=SID_1)\n",
+    "print(\"── Session 1 state after the conversation ──\")\n",
+    "for k, v in sorted(dict(s1.state).items()):\n",
+    "    print(f\"  {k!r}: {v!r}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "54101cf5",
+   "metadata": {},
+   "source": [
+    "Two things happened. The tool wrote `user:favorite_color = \"teal\"` into the session's state. Separately, `output_key=\"last_response\"` on the agent auto-saved the model's final text reply under the key `last_response`. Both are now part of the session. Both showed up in the event stream if you scroll up.\n",
+    "\n",
+    "Next: we'll open a **completely separate session** for the same user. The `user:`-prefixed key should carry over. The `last_response` key (unprefixed) should not."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fa68b86a",
+   "metadata": {},
+   "source": [
+    "## Run Session 2 — fresh session, same user"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db9c8f89",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SID_2 = \"session-two\"\n",
+    "\n",
+    "# Create the second session fresh — notice we don't pass any initial state.\n",
+    "await session_service.create_session(app_name=APP, user_id=USER, session_id=SID_2)\n",
+    "s2_initial = await session_service.get_session(app_name=APP, user_id=USER, session_id=SID_2)\n",
+    "\n",
+    "print(\"── Session 2 initial state (before any chat) ──\")\n",
+    "for k, v in sorted(dict(s2_initial.state).items()):\n",
+    "    print(f\"  {k!r}: {v!r}\")\n",
+    "print()\n",
+    "\n",
+    "# Ask the agent in session 2 — does it remember?\n",
+    "await chat(color_agent, \"Hey, what's my favorite color?\", SID_2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fca42d3d",
+   "metadata": {},
+   "source": [
+    "Read the output carefully.\n",
+    "\n",
+    "- Session 2 **starts** with `user:favorite_color: 'teal'` already present — it survived.\n",
+    "- `last_response` from Session 1 is **not** present — it was unprefixed, so it stayed behind.\n",
+    "- The agent called `recall_favorite_color`, which read `user:favorite_color` and returned `\"teal\"` — which the model then reported back.\n",
+    "\n",
+    "This is cross-session memory in 80 lines of code. No database, no vector store, no custom embedding pipeline — just a prefix convention on a dict key.\n",
+    "\n",
+    "**What the scope prefixes give you, in one sentence:** you decide the lifetime of every piece of data with a 5-character prefix, and ADK handles the rest."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a0995c93",
+   "metadata": {},
+   "source": [
+    "# Three Ways to Write State — And One That Doesn't Persist\n",
+    "\n",
+    "You just saw two of them. Here's the complete picture:\n",
+    "\n",
+    "| Pattern | When it runs | Persists? | Use for |\n",
+    "|---|---|---|---|\n",
+    "| `output_key=\"last_response\"` on the agent | After the model produces final text | **Yes** | Caching the last reply, passing output between workflow steps |\n",
+    "| `tool_context.state[key] = value` inside a tool | When the tool executes | **Yes** | Writing structured data during tool calls |\n",
+    "| `session.state[key] = value` directly on a fetched session | As soon as you assign | **No — it does not persist!** | Avoid |\n",
+    "\n",
+    "The third one is the pitfall: if you fetch a session with `get_session()` and mutate its `.state` directly, the mutation **does not persist to the session service**. ADK persists state via events — so mutations from `output_key` and from `tool_context.state` get recorded as events. Direct dict assignment bypasses that, and the next `get_session()` returns the old state.\n",
+    "\n",
+    "**Rule:** use `output_key=` on the agent, or `tool_context.state[...]` inside a tool. Never assign to a returned session's `.state` and expect it to stick."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1510fc29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Demonstrate the pitfall — do NOT copy this pattern.\n",
+    "# Mutate state directly and re-fetch to prove it didn't stick.\n",
+    "sess = await session_service.get_session(app_name=APP, user_id=USER, session_id=SID_2)\n",
+    "sess.state[\"user:mood\"] = \"happy\"                 # direct assignment — WRONG\n",
+    "sess.state[\"this_does_not_persist\"] = \"ghost\"     # unprefixed — also wrong, but doubly so\n",
+    "\n",
+    "sess_fresh = await session_service.get_session(app_name=APP, user_id=USER, session_id=SID_2)\n",
+    "print(\"── Re-fetched session state ──\")\n",
+    "for k, v in sorted(dict(sess_fresh.state).items()):\n",
+    "    print(f\"  {k!r}: {v!r}\")\n",
+    "print()\n",
+    "print(\"Notice: 'user:mood' and 'this_does_not_persist' are NOT in the re-fetched state.\")\n",
+    "print(\"Direct assignment to a returned session's .state does not round-trip.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3914998c",
+   "metadata": {},
+   "source": [
+    "# Events — The Session's Immutable Ledger\n",
+    "\n",
+    "Every turn in a session produces events, and the session keeps them all. You can walk the event history to audit what happened, replay a conversation, or feed it into an evaluation suite.\n",
+    "\n",
+    "The one-line version: **a session's event list is the agent's log file, with structure.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eeb16af0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Show the event history of session 1.\n",
+    "s1 = await session_service.get_session(app_name=APP, user_id=USER, session_id=SID_1)\n",
+    "print(f\"Session 1 has {len(s1.events)} events.\\n\")\n",
+    "for i, ev in enumerate(s1.events):\n",
+    "    author = ev.author or \"(system)\"\n",
+    "    kinds = []\n",
+    "    if ev.content and ev.content.parts:\n",
+    "        for p in ev.content.parts:\n",
+    "            if p.text and p.text.strip():\n",
+    "                kinds.append(f\"text({p.text.strip()[:40]}...)\" if len(p.text.strip()) > 40 else f\"text({p.text.strip()})\")\n",
+    "            if p.function_call:\n",
+    "                kinds.append(f\"tool_call({p.function_call.name})\")\n",
+    "            if p.function_response:\n",
+    "                kinds.append(f\"tool_resp({p.function_response.name if hasattr(p.function_response, 'name') else '?'})\")\n",
+    "    if ev.actions and ev.actions.state_delta:\n",
+    "        kinds.append(f\"state_delta({list(ev.actions.state_delta.keys())})\")\n",
+    "    print(f\"  [{i:>2}] {author:16s} {' | '.join(kinds) if kinds else '(no content)'}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "807f05b9",
+   "metadata": {},
+   "source": [
+    "Notice the `state_delta` entries in the event stream. Every time state was written — by the tool, by `output_key=`, by session initialization — a corresponding event was recorded. The state dict is a *projection* of this event stream. ADK replays events when you fetch a session; the state dict is what you get when those deltas are applied in order.\n",
+    "\n",
+    "This is [event sourcing](https://martinfowler.com/eaaDev/EventSourcing.html). Skimmable today; it'll come back as a design principle in M08 when we replace the in-memory session service with a database."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dac76222",
+   "metadata": {},
+   "source": [
+    "# Artifacts — Binary Blobs Outside the Event Stream\n",
+    "\n",
+    "A quick word on the fourth concept and then we wrap.\n",
+    "\n",
+    "**Artifacts** are for binary data — images, audio clips, PDFs, any large blob — that you want associated with a session but don't want to serialize into events. The analogy is [Git LFS](https://git-lfs.com) for agents: the pointer lives in the event stream; the payload lives in a separate store.\n",
+    "\n",
+    "Three built-in artifact services mirror the session services:\n",
+    "\n",
+    "- `InMemoryArtifactService` — demos and tests.\n",
+    "- `GcsArtifactService` — Google Cloud Storage, for production.\n",
+    "- (and you can implement your own `BaseArtifactService` for S3, Azure Blob, MinIO, etc.)\n",
+    "\n",
+    "You'll typically only need artifacts for multi-modal agents — one that accepts an uploaded image, or one whose tool generates a PDF report. For the text-only agents in Part 1 of this course, you can ignore artifacts entirely. M13 (Live API voice agent) is the first module where artifacts carry real weight."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "08573576",
+   "metadata": {},
+   "source": [
+    "# Interlude — Memory Staleness and Verification\n",
+    "\n",
+    "> *From \"Agentic Design Patterns,\" Chapter 2. Two minutes of theory that pays off for the rest of the course.*\n",
+    "\n",
+    "The wow demo in this module looks clean because the state has not had time to go stale. In production, that is not how this works.\n",
+    "\n",
+    "A user's favorite color from three months ago is probably still their favorite color. Their current project? Maybe not — they might have switched to a new one and never told the agent. The tickets the agent \"remembered\" being open yesterday might all be closed by now. The server IP an MCP tool cached might have been reassigned.\n",
+    "\n",
+    "**Stored memory is a hint, not a fact.**\n",
+    "\n",
+    "Three guidelines, from the publication:\n",
+    "\n",
+    "1. **Prefer retrieval over recall for high-stakes decisions.** If the agent is about to do something that depends on state being accurate (send an email, charge a card, deploy code), it should re-verify the state by calling a read-only tool rather than trusting its own stored state.\n",
+    "2. **Scope your state aggressively.** `temp:` for throwaway scratchpads. Unprefixed for per-session. `user:` for things you're confident change only with explicit user action. Reserve `app:` for genuinely immutable configuration.\n",
+    "3. **Log a reason when you write to `user:` or `app:` state.** Months from now you'll debug an agent that's acting on six-month-old memory; a one-line \"why did this get stored\" note saves hours of investigation.\n",
+    "\n",
+    "The pattern has a memorable name in the publication: **Skeptical Memory.** Treat your own stored context as unverified until proven otherwise. M08 picks up this thread when we move past session state into long-term memory."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4133f6c8",
+   "metadata": {},
+   "source": [
+    "# Your Turn\n",
+    "\n",
+    "Four small changes. Run in new cells below.\n",
+    "\n",
+    "1. **App-scope state.** Write a tool `set_app_mode(mode: str, tool_context)` that stores `tool_context.state[\"app:mode\"] = mode`. Create two separate users (change `USER` between calls). Does `app:mode` survive across users?\n",
+    "2. **Temp state.** Write a tool that stores `tool_context.state[\"temp:scratch\"] = \"...\"`. After the run completes, fetch the session again and inspect the state. Is `temp:scratch` still there?\n",
+    "3. **Replay a conversation.** Write a loop that walks `sess.events` and prints only the user's and agent's text messages in order — a clean transcript.\n",
+    "4. **Intentional staleness.** Make the agent save a favorite color, then manually change `session.state[\"user:favorite_color\"]` to something else via a direct (non-persisting) assignment. Ask the agent what the color is. Which value does it see — the persisted one, or your uncommitted change?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "299222ed",
+   "metadata": {},
+   "source": [
+    "# Key Takeaways\n",
+    "\n",
+    "- A **Session** is a triple `(app_name, user_id, session_id)` that holds events and a state dict.\n",
+    "- **State prefixes** are the most useful under-documented feature: `user:` survives the session, `app:` is global, `temp:` is per-invocation, unprefixed is per-session.\n",
+    "- **Two ways to write state that actually persist:** `output_key=` on the agent, and `tool_context.state[...]` inside a tool. Direct assignment on a returned session's `.state` does NOT round-trip.\n",
+    "- **Events are the session's immutable ledger.** State is a projection of the event stream's state-delta entries.\n",
+    "- **Artifacts** hold binary data outside the event stream. Think Git LFS for agents.\n",
+    "- **Interlude — Skeptical Memory:** stored state is a hint, not a fact. Verify before acting on high-stakes decisions.\n",
+    "\n",
+    "# Next up — M04: The one-line model swap\n",
+    "\n",
+    "You've been using `LiteLlm(model=\"openrouter/google/gemini-2.5-flash-lite\")` the whole time. M04 opens that abstraction up: how LiteLLM actually works, how to route to Claude, GPT, Qwen, and a locally-hosted Ollama model, and the specific gotcha around the `ollama_chat/` prefix that causes infinite tool-call loops if you get it wrong."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/slides/module-03-sessions-state/index.html
+++ b/slides/module-03-sessions-state/index.html
@@ -1,0 +1,218 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ADK Course — M03: Sessions, State, Events, Artifacts</title>
+  <link rel="stylesheet" href="../shared/shared.css">
+  <link rel="stylesheet" href="../shared/slides.css">
+</head>
+<body>
+  <nav class="progress-strip">
+    <a href="../../index.html" class="progress-home">Course</a>
+    <div class="progress-title">M03 — Sessions, State, Events, Artifacts</div>
+    <div class="progress-meta">
+      <span class="slide-counter">1 / 1</span>
+      <button class="theme-toggle">Theme</button>
+    </div>
+  </nav>
+
+  <main class="slide-viewport">
+
+  <div class="slide active" data-module="03" data-type="section-title">
+    <div class="topic-badge">Module 03 &middot; Part 1 Vendor-agnostic</div>
+    <h1>Sessions, State, Events, Artifacts</h1>
+    <h3>Where the conversation's memory actually lives</h3>
+    <p class="highlight-text">The prefix is the lifetime.</p>
+  </div>
+
+  <div class="slide" data-module="03" data-type="keyfact">
+    <h2 class="text-muted" style="border-bottom:none;font-size:1em;text-transform:uppercase;letter-spacing:0.08em;">Stateless agent</h2>
+    <p>A <strong>party trick</strong>.</p>
+    <h2 class="text-muted" style="border-bottom:none;font-size:1em;text-transform:uppercase;letter-spacing:0.08em;margin-top:var(--space-8);">Stateful agent</h2>
+    <p><strong>Infrastructure</strong>.</p>
+  </div>
+
+  <div class="slide" data-module="03">
+    <h2>A session is two things</h2>
+    <ul>
+      <li><strong>A list of events</strong> — the full ordered history of every message, tool call, tool response, and state mutation. Read-only from your code; ADK appends.</li>
+      <li><strong>A state dict</strong> — mutable key-value storage for whatever the agent should remember between turns.</li>
+    </ul>
+    <p>Identified by the triple <code>(app_name, user_id, session_id)</code>. That triple is the primary key for every session in every session store.</p>
+  </div>
+
+  <div class="slide" data-module="03">
+    <h2>Three session services</h2>
+    <table>
+      <thead><tr><th>Service</th><th>Backing</th><th>When</th></tr></thead>
+      <tbody>
+        <tr><td><code>InMemorySessionService</code></td><td>Python dict</td><td>Demos and tests (this course through M07)</td></tr>
+        <tr><td><code>DatabaseSessionService</code></td><td>SQLAlchemy (Postgres, SQLite)</td><td>Self-hosted production</td></tr>
+        <tr><td><code>VertexAiSessionService</code></td><td>Google Cloud</td><td>Vertex deployments only</td></tr>
+      </tbody>
+    </table>
+    <p style="color:var(--text-muted);font-size:0.9em;">Same interface across all three. You swap the service; the agent code doesn't change.</p>
+  </div>
+
+  <div class="slide" data-module="03" data-type="section-title" style="background:linear-gradient(135deg,var(--navy-dark) 0%,var(--navy) 100%);">
+    <div class="topic-badge">The important part</div>
+    <h1>State — with scope prefixes</h1>
+    <p class="highlight-text">Four scope rings, one 5-character prefix.</p>
+  </div>
+
+  <div class="slide" data-module="03">
+    <h2>The state dict has four scope tiers</h2>
+    <table>
+      <thead><tr><th>Prefix</th><th>Scope</th><th>Survives</th></tr></thead>
+      <tbody>
+        <tr><td><em>(none)</em></td><td>This session only</td><td>Until the session is deleted</td></tr>
+        <tr><td><code>user:</code></td><td>This user, across all their sessions</td><td>As long as the user exists</td></tr>
+        <tr><td><code>app:</code></td><td>Global across all users of this app</td><td>As long as the app exists</td></tr>
+        <tr><td><code>temp:</code></td><td>This invocation only</td><td>Thrown away after the run</td></tr>
+      </tbody>
+    </table>
+    <p>React state, but with <strong>persistence tiers</strong> baked into the key.</p>
+  </div>
+
+  <div class="slide" data-module="03">
+    <h2>Mental model — four rings</h2>
+<pre class="diagram">             ┌──────────────────────────────────────┐
+             │  app:  global, across all users       │
+             │  ┌────────────────────────────────┐   │
+             │  │ user:  per user, all sessions  │   │
+             │  │   ┌──────────────────────┐     │   │
+             │  │   │ (unprefixed)         │     │   │
+             │  │   │  this session only   │     │   │
+             │  │   │   ┌──────────────┐   │     │   │
+             │  │   │   │ temp:        │   │     │   │
+             │  │   │   │ this run only│   │     │   │
+             │  │   │   └──────────────┘   │     │   │
+             │  │   └──────────────────────┘     │   │
+             │  └────────────────────────────────┘   │
+             └──────────────────────────────────────┘</pre>
+  </div>
+
+  <div class="slide" data-module="03" data-type="code">
+    <h2>Writing state from a tool</h2>
+<pre><code>def remember_favorite_color(color: str, tool_context: ToolContext) -> dict:
+    """Record the user's favorite color for future sessions."""
+    # user: prefix → survives beyond this session
+    tool_context.state["user:favorite_color"] = color
+    return {"status": "saved", "color": color}</code></pre>
+    <p class="code-caption">Add <code>tool_context: ToolContext</code> as a parameter. ADK injects the running context. <code>tool_context.state</code> behaves like a dict; the assignment is recorded as an event and persisted.</p>
+  </div>
+
+  <div class="slide" data-module="03" data-type="section-title" style="background:linear-gradient(135deg,var(--amber-dark) 0%,var(--amber) 100%);">
+    <h1>Live</h1>
+    <h3>Cross-session memory in 80 lines</h3>
+    <p class="highlight-text" style="color:white;">Notebook cells 11–15</p>
+  </div>
+
+  <div class="slide" data-module="03">
+    <h2>The wow moment</h2>
+<pre class="diagram">Session 1  ─────────────────────────────────────
+  USER:       My favorite color is teal.
+  tool_call:  remember_favorite_color(color='teal')
+  state ←     user:favorite_color = 'teal'
+
+          ═════ session ends, new session starts ═════
+
+Session 2  ─────────────────────────────────────
+  state IS:   user:favorite_color = 'teal'    ← carries over!
+  USER:       Hey, what's my favorite color?
+  tool_call:  recall_favorite_color()
+  tool_resp:  {'known': True, 'color': 'teal'}
+  FINAL:      teal.</pre>
+    <p>No database setup. No vector store. No custom embedding pipeline. Just a prefix convention on a dict key.</p>
+  </div>
+
+  <div class="slide" data-module="03">
+    <h2>Three ways to write state</h2>
+    <table>
+      <thead><tr><th>Pattern</th><th>Persists?</th><th>Use for</th></tr></thead>
+      <tbody>
+        <tr><td><code>output_key="last_response"</code> on the agent</td><td><strong>Yes</strong></td><td>Caching final reply; passing output between workflow steps</td></tr>
+        <tr><td><code>tool_context.state[key] = value</code> in a tool</td><td><strong>Yes</strong></td><td>Writing structured data during tool calls</td></tr>
+        <tr><td><code>session.state[key] = value</code> on a fetched session</td><td><strong>No!</strong></td><td>Avoid. Does not persist.</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="slide" data-module="03" data-type="keyfact">
+    <h2 class="text-muted" style="border-bottom:none;font-size:1em;text-transform:uppercase;letter-spacing:0.08em;">The rule</h2>
+    <p><code>output_key=</code> on the agent.<br><code>tool_context.state[...]</code> in a tool.</p>
+    <p style="font-size:0.75em;color:var(--text-muted);margin-top:var(--space-4);">Direct assignment to a returned session's <code>.state</code> does <strong>not</strong> round-trip. It silently fails to persist.</p>
+  </div>
+
+  <div class="slide" data-module="03" data-type="section-title" style="background:linear-gradient(135deg,var(--navy-dark) 0%,var(--navy) 100%);">
+    <div class="topic-badge">Part 2 of the module</div>
+    <h1>Events and Artifacts</h1>
+    <p class="highlight-text">The session's ledger and its blob store.</p>
+  </div>
+
+  <div class="slide" data-module="03">
+    <h2>Events — the session's immutable ledger</h2>
+    <p>Every turn produces events; the session keeps them all. Walk <code>session.events</code> to audit what happened, replay a conversation, or feed it into an evaluation suite.</p>
+<pre class="diagram">[ 0] user         text(My favorite color is teal.)
+[ 1] color_agent  tool_call(remember_favorite_color)
+[ 2] color_agent  tool_resp | state_delta(['user:favorite_color'])
+[ 3] color_agent  text(Awesome! I'll remember...) | state_delta(['last_response'])</pre>
+    <p style="font-size:0.9em;color:var(--text-muted);">State is a <em>projection</em> of the event stream's <code>state_delta</code> entries. This is event sourcing, and it's how ADK can back a session with a database later without the agent noticing.</p>
+  </div>
+
+  <div class="slide" data-module="03">
+    <h2>Artifacts — binary blobs outside events</h2>
+    <p>Images, audio clips, PDFs, any payload you don't want to serialize into events. Analogy: <strong>Git LFS for agents</strong> — the pointer lives in the event stream; the payload lives in a separate store.</p>
+    <ul>
+      <li><code>InMemoryArtifactService</code> — demos and tests.</li>
+      <li><code>GcsArtifactService</code> — Google Cloud Storage, for production.</li>
+      <li>Or roll your own <code>BaseArtifactService</code> — S3, Azure Blob, MinIO.</li>
+    </ul>
+    <p style="color:var(--text-muted);font-size:0.9em;">Skimmable for now. M13 (Live API voice agent) is where artifacts carry real weight.</p>
+  </div>
+
+  <div class="slide" data-module="03" data-type="section-title" style="background:linear-gradient(135deg,#6A1B9A 0%,#8E24AA 100%);">
+    <div class="topic-badge">Interlude &middot; Agentic Design Patterns</div>
+    <h1>Skeptical Memory</h1>
+    <p class="highlight-text">Stored state is a hint, not a fact.</p>
+  </div>
+
+  <div class="slide" data-module="03">
+    <h2>Memory staleness is real</h2>
+    <p>The demo looks clean because the state hasn't had time to go stale. In production, this is not how it works.</p>
+    <ul>
+      <li>User's favorite color from three months ago? Probably still current.</li>
+      <li>User's current project? Maybe not — they might have moved on without telling the agent.</li>
+      <li>Tickets the agent "remembered" being open yesterday? Possibly all closed.</li>
+      <li>Server IP an MCP tool cached? Could have been reassigned.</li>
+    </ul>
+    <p><strong>Stored memory is a hint.</strong> Not a fact.</p>
+  </div>
+
+  <div class="slide" data-module="03">
+    <h2>Three guidelines from the publication</h2>
+    <ol>
+      <li><strong>Prefer retrieval over recall for high-stakes decisions.</strong> Before the agent sends an email, charges a card, or deploys code, it should call a read-only tool to re-verify — not trust its own stored state.</li>
+      <li><strong>Scope aggressively.</strong> <code>temp:</code> for scratchpads, unprefixed for per-session, <code>user:</code> only for things you're confident change only with explicit user action, <code>app:</code> only for genuinely immutable configuration.</li>
+      <li><strong>Log a reason when you write <code>user:</code> or <code>app:</code> state.</strong> Months from now you will debug an agent acting on six-month-old memory. The one-line "why did this get stored" note saves hours.</li>
+    </ol>
+    <p style="color:var(--text-muted);font-size:0.9em;margin-top:var(--space-4);">The pattern has a name: <strong>Skeptical Memory</strong>. Treat your own stored context as unverified until proven otherwise.</p>
+  </div>
+
+  <div class="slide" data-module="03" data-type="keyfact">
+    <h2 class="text-muted" style="border-bottom:none;font-size:1em;text-transform:uppercase;letter-spacing:0.08em;">What to carry forward</h2>
+    <p>State + Events + Artifacts + Scope prefixes. <br>And: <strong>stored state is a hint, not a fact</strong>.</p>
+  </div>
+
+  <div class="slide" data-module="03" data-type="section-title" style="background:linear-gradient(135deg,var(--navy) 0%,var(--navy-light) 100%);">
+    <div class="topic-badge">Up next</div>
+    <h1>M04 &mdash; The one-line model swap</h1>
+    <p class="highlight-text">How LiteLLM actually works. Claude, GPT, Qwen, Ollama, and the one prefix gotcha that matters.</p>
+  </div>
+
+  </main>
+
+  <script src="../shared/slides.js"></script>
+</body>
+</html>

--- a/slides/module-03-sessions-state/speaker_notes.md
+++ b/slides/module-03-sessions-state/speaker_notes.md
@@ -1,0 +1,183 @@
+# M03 — Speaker notes
+
+Written as spoken delivery. Read one section per slide.
+
+---
+
+## Slide 1 — Title
+
+Module three. Sessions, State, Events, Artifacts. Module one gave you the four primitives; module two gave you tools. This module goes deep on the third primitive — Session — and everything inside it. If module two was about what an agent can do, module three is about what an agent remembers. Get this right and your agents become infrastructure. Get it wrong and they're party tricks that forget everyone's name every Monday.
+
+---
+
+## Slide 2 — Stateless vs stateful
+
+The framing. A stateless agent is a party trick. Each turn starts from zero; it can't remember what you told it five minutes ago, let alone yesterday. A stateful agent is infrastructure. It knows who its users are, what they've asked before, what decisions it's already made. That's the difference between a demo and a product.
+
+---
+
+## Slide 3 — A session is two things
+
+A session is identified by three strings: app name, user ID, session ID. That triple is the primary key for every session in every session store, regardless of backend.
+
+A session holds two things. A list of events — the full ordered history of every message, every tool call, every tool response, every state mutation. You can't append to it from your code; ADK does that. Read-only from your side.
+
+And a state dict — mutable key-value storage for whatever you want the agent to carry between turns. This is where the action is.
+
+---
+
+## Slide 4 — Three session services
+
+ADK ships three session services. In-memory, which backs everything by a Python dict — loses on process restart, perfect for tests and notebooks. Database-backed, using SQLAlchemy, which works against Postgres, MySQL, SQLite — this is the production default. And Vertex-AI-backed, which you only reach for if you're on Google Cloud and committed to it.
+
+The interface is the same across all three. When module eight promotes memory to the subject, we'll swap the in-memory service for the database one and the agent code does not change. That's the point of the abstraction.
+
+---
+
+## Slide 5 — State section header
+
+Now the important part. State with scope prefixes. This is the most useful under-documented feature in ADK, and the one you'll use every single day.
+
+---
+
+## Slide 6 — Four scope tiers
+
+The state dict is a regular Python dict, but the key's prefix decides the lifetime of the value. Four tiers.
+
+Unprefixed keys live in this session only. When the session is deleted, they're gone.
+
+`user:` prefix — pronounced "user colon" — persists across all sessions for this user. If Alice has session one and session two, anything she writes to `user:favorite_color` in session one is visible in session two.
+
+`app:` prefix is global across the application. Every user sees the same `app:` values. Reserve this for genuinely application-wide things.
+
+`temp:` prefix is per-invocation only. The value lives for this one run and gets thrown away when the run ends. Useful for scratch work a tool needs to carry across steps.
+
+Four rings of scope. You pick the ring by choosing the prefix.
+
+---
+
+## Slide 7 — Mental model
+
+Visual version. App state is the outermost ring — everyone sees it. User state is inside, per-user. Session state is inside that — per-session for one user. Temp state is at the center — gone when the run ends.
+
+Pick the right ring when you write. A favorite color is `user:` — it shouldn't leak to other users, but it should survive the session. A system prompt template is `app:` — every user uses the same one. A current turn's scratch computation is `temp:` — nobody else needs to see it, ever.
+
+---
+
+## Slide 8 — Writing state from a tool
+
+Here's the pattern for writing state. The tool function takes an extra parameter — `tool_context: ToolContext`. ADK injects the running context automatically; you don't pass it in. From that context, `tool_context.state` behaves like a dict. Assignments to it are recorded as events and persisted by the session service.
+
+Two things to notice in the code. The parameter is `tool_context` with an underscore — ADK looks for exactly that name, not `context` or `ctx`. And the `user:` prefix on the key is what makes the value survive beyond this session. Drop the prefix, and the value disappears when the session does.
+
+---
+
+## Slide 9 — Live: cross-session memory
+
+Switch to the notebook, cells eleven through fifteen. We create an agent that can remember and recall a favorite color. Session one, we tell it teal. Session two — a fresh session, same user — we ask it what our color is. Watch the event stream.
+
+---
+
+## Slide 10 — The wow moment
+
+Back on the slide. This is what just happened.
+
+Session one: user says "my favorite color is teal." The agent calls `remember_favorite_color` with `color='teal'`. The tool writes `user:favorite_color = 'teal'` into the state. Session ends.
+
+Session two starts. We didn't pass any initial state. But the session's state *starts* with `user:favorite_color: 'teal'` already present. Because the key was prefixed with `user:`, ADK carried it across when it loaded session two.
+
+User asks "what's my favorite color?" The agent calls `recall_favorite_color`, which reads `user:favorite_color`, returns `"teal"`. The model says "teal."
+
+Cross-session memory. No database setup. No vector store. No custom embedding pipeline. A prefix on a dict key.
+
+---
+
+## Slide 11 — Three ways to write state
+
+Three patterns for writing state. Two of them work. One of them doesn't — and it's the one people reach for first.
+
+Pattern one: `output_key=` on the agent. When you construct an LlmAgent, pass `output_key="last_response"`. After every run, the model's final text reply is automatically stored under that key. Useful for caching, and for passing output between workflow agents — which we'll see in module five.
+
+Pattern two: `tool_context.state[key] = value` inside a tool. The pattern you just saw. Works. Persists.
+
+Pattern three: you fetch a session with `get_session()`, get back a session object with a `.state` dict, and you assign to it directly — `session.state["foo"] = "bar"`. This does **not** persist. The next time you call `get_session()` for the same triple, your assignment is gone. Nobody ever tells you this happens. You just wonder why state isn't sticking.
+
+---
+
+## Slide 12 — The rule
+
+The rule, on one slide. Use `output_key=` on the agent. Use `tool_context.state[...]` inside a tool. Do not assign directly to a returned session's `.state` dict. The first two persist because they go through events. The third bypasses events — and events are how ADK persists state.
+
+The notebook has a cell that demonstrates this pitfall explicitly. Run it; you'll see the direct-assignment values vanish on the next fetch.
+
+---
+
+## Slide 13 — Events and Artifacts header
+
+Part two of the module. Events and artifacts. Quicker pass; the state material is the part that matters most in practice.
+
+---
+
+## Slide 14 — Events, immutable ledger
+
+Every turn in a session produces events, and the session keeps them all. Walk `session.events` to audit what happened, replay a conversation, feed it into an evaluation suite.
+
+The diagram shows the event history from the color demo. Four events. User input. Tool call. Tool response with a state delta recording the color write. Final text response with a state delta recording the `output_key` save.
+
+State is a projection of this event stream. When you fetch a session, ADK replays the events in order, applies the state deltas, and hands you the final state. That's event sourcing. It's the reason swapping in-memory sessions for database sessions is seamless in module eight — the data model is the same; only the storage changes.
+
+---
+
+## Slide 15 — Artifacts
+
+Quick word on the fourth concept. Artifacts are for binary data — images, audio, PDFs, any large blob — that you want to associate with a session but don't want to serialize into events.
+
+Analogy: Git LFS for agents. The pointer lives in the event stream; the payload lives in a separate store.
+
+Three artifact services mirror the session services — in-memory, Google Cloud Storage, and a base class you can implement for S3, Azure, MinIO, whatever. You won't need artifacts for the text agents in part one of this course. Module thirteen — the Live API voice agent — is the first module where they earn their keep.
+
+---
+
+## Slide 16 — Interlude header
+
+Two-minute interlude. From the Agentic Design Patterns publication. Chapter two, persistent context. The pattern has a name: Skeptical Memory.
+
+---
+
+## Slide 17 — Staleness is real
+
+The demo looks clean because the state hasn't had time to go stale. In production, this is not how it works.
+
+A user's favorite color from three months ago is probably still current. Their current project? Probably not — they might have moved on without telling the agent. Tickets the agent "remembered" being open yesterday might all be closed. A server IP cached by an MCP tool might have been reassigned.
+
+Stored memory is a hint. Not a fact. If you treat it as a fact, the day it becomes stale is the day your agent does something embarrassing.
+
+---
+
+## Slide 18 — Three guidelines
+
+Three guidelines from the publication.
+
+First: prefer retrieval over recall for high-stakes decisions. Before the agent sends an email, charges a card, or deploys code, it should call a read-only tool to re-verify — not trust its own stored state. The cost of an extra tool call is cheap compared to the cost of acting on stale information.
+
+Second: scope your state aggressively. Temp for scratchpads, unprefixed for per-session, user for things that only change when the user explicitly changes them, app for genuinely immutable configuration. The more narrowly scoped the state, the less staleness it can cause.
+
+Third: when you write to user-scope or app-scope state, log a reason. Months from now, you're debugging an agent acting on six-month-old memory. A one-line "why did this get stored" note saves hours of investigation.
+
+The pattern has a name. Skeptical Memory. Treat your own stored context as unverified until proven otherwise.
+
+---
+
+## Slide 19 — What to carry forward
+
+What to carry forward. Four things.
+
+State, events, artifacts, scope prefixes. The four mechanical tools ADK gives you for making an agent remember things.
+
+And one principle, from the Skeptical Memory pattern: stored state is a hint, not a fact.
+
+---
+
+## Slide 20 — Next
+
+Module four. The one-line model swap. We've been using `LiteLlm` as a black box for three modules. Now we open it up. Claude, GPT, Qwen, a locally-hosted Ollama model — all from the same agent code, all with one line of configuration different. And the specific gotcha around the `ollama_chat` prefix that causes infinite tool-call loops if you get it wrong. See you there.

--- a/textbook/_sources/chapters/03-sessions-state.md
+++ b/textbook/_sources/chapters/03-sessions-state.md
@@ -1,0 +1,182 @@
+# Sessions, State, Events, Artifacts
+
+Module 01 gave you four primitives: Agent, Runner, Event, Session. Module 02 built on the first two. This chapter goes deep on the third, which is where the agent's memory actually lives. A stateless agent is a demo. A stateful agent is infrastructure. The difference is entirely about how you use the Session.
+
+## A session is two things
+
+A session is identified by a triple: `(app_name, user_id, session_id)`. Those three strings are the primary key for every session in every session store, regardless of which backend you're using. Inside the session live two collections.
+
+The first is a **list of events** — the full ordered history of every user message, every model response, every tool call, every tool response, every state mutation. You don't append to this list; ADK does, as things happen. Your code reads it when it wants to audit what happened, replay a conversation, or feed a run into an evaluation suite.
+
+The second is a **state dictionary** — mutable key-value storage for whatever you want the agent to carry between turns. This is where the action is.
+
+ADK ships three session services:
+
+- **`InMemorySessionService`** — backs everything by a Python dict. Loses on process restart. This is what we'll use through Module 07. Perfect for tests, notebooks, and demos.
+- **`DatabaseSessionService`** — SQLAlchemy-backed. Works against Postgres, MySQL, SQLite. This is the production default for self-hosted deployments. Module 08 swaps to it when memory becomes the subject.
+- **`VertexAiSessionService`** — managed, Google-Cloud-only. Mentioned in this course; not taught — the pattern is the same, only the backing store changes.
+
+The interface is identical across all three. The agent code does not change when you swap the service, which is the whole point of the abstraction.
+
+## State with scope prefixes
+
+This is the most useful under-documented feature in ADK, and the one you will use every day.
+
+A state dict is a regular Python dict. But the key's **prefix decides where the value lives and how long it survives.** Four tiers.
+
+| Prefix | Scope | Survives |
+|---|---|---|
+| *(none)* | This session only | Until the session is deleted |
+| `user:` | This user, across all their sessions | As long as the user exists |
+| `app:` | Global across all users of this app | As long as the app exists |
+| `temp:` | This invocation only | Thrown away after the run |
+
+Think of it as React state with persistence tiers baked into the key. You decide the lifetime of every piece of data with a 5-character prefix; ADK handles the routing.
+
+In practice:
+
+- **Unprefixed** is the default. A favorite color you learn mid-conversation and only need for this session's replies. A draft the agent is composing.
+- **`user:`** for per-user persistence. Favorite colors, language preferences, history summaries — anything that's specific to one user but should persist across all their sessions with your app.
+- **`app:`** for global configuration. A daily-changing prompt template every agent should use. A shared rate-limit counter. Rare in practice; reach for it cautiously.
+- **`temp:`** for scratchpads inside a single run. A tool that needs to hand a value to the next tool in the same turn. A calculation the agent would rather not expose in the final event log.
+
+Pick the scope when you write, and ADK handles persistence accordingly.
+
+## Writing state — three ways, one of which is a trap
+
+Three patterns for writing state. Two of them persist. One of them silently fails. It is almost always the one a new developer reaches for first.
+
+**Pattern 1 — `output_key=` on the agent.** When you construct an `LlmAgent`, pass `output_key="last_response"` (or whatever key you want). After every run, the model's final text response is automatically written to `state[output_key]`. This is the cleanest way to cache a final answer, and — more importantly — it's how you pass output between workflow-agent steps, which Module 05 will lean on heavily.
+
+```python
+agent = LlmAgent(
+    name="color_agent",
+    model=LiteLlm(model=MODEL_STRING),
+    instruction="...",
+    tools=[...],
+    output_key="last_response",   # final text auto-saved to state['last_response']
+)
+```
+
+**Pattern 2 — `tool_context.state[key] = value` inside a tool.** Your tool function gets an extra parameter, `tool_context: ToolContext`. ADK injects the running context automatically; you don't pass it in. From inside the tool, `tool_context.state` behaves like a mutable dict. Writes are recorded as events and persisted by the session service.
+
+```python
+def remember_favorite_color(color: str, tool_context: ToolContext) -> dict:
+    """Record the user's favorite color for future sessions."""
+    tool_context.state["user:favorite_color"] = color
+    return {"status": "saved", "color": color}
+```
+
+Two subtleties to notice: the parameter is `tool_context` — ADK looks for exactly that name. And the `user:` prefix on the key is what makes the value survive beyond this session. Drop it, and the value is session-local.
+
+**Pattern 3 — direct assignment to a returned session's `.state` dict. Does NOT persist.** You fetch a session with `session_service.get_session(...)`, get back a Session object with a `.state` dict, and you assign to it:
+
+```python
+session = await session_service.get_session(app_name=APP, user_id=USER, session_id=SID)
+session.state["user:foo"] = "bar"   # ← does not persist
+```
+
+Next time you call `get_session()` for the same triple, your assignment is gone. Nobody tells you. You just wonder why state isn't sticking.
+
+The reason is event sourcing: ADK persists state *via events*. Patterns 1 and 2 both produce state-delta events that the session service writes to the backing store. Pattern 3 is a dict assignment on an in-memory object; no event is generated; nothing is persisted.
+
+**Rule to carry forward:** use `output_key=` on the agent for final-text caching, and `tool_context.state[...]` inside a tool for structured writes. Treat a fetched session's `.state` as read-only.
+
+## The cross-session wow demo
+
+The notebook for this module ships a complete version. Here is the essence.
+
+```python
+APP = "m03_demo"
+USER = "alice"
+
+def remember_favorite_color(color: str, tool_context: ToolContext) -> dict:
+    tool_context.state["user:favorite_color"] = color
+    return {"status": "saved", "color": color}
+
+def recall_favorite_color(tool_context: ToolContext) -> dict:
+    color = tool_context.state.get("user:favorite_color")
+    return {"known": bool(color), "color": color}
+
+agent = LlmAgent(
+    name="color_agent",
+    model=LiteLlm(model=MODEL_STRING),
+    instruction=(
+        "You track the user's favorite color. When they tell you one, call "
+        "remember_favorite_color. When they ask, call recall_favorite_color. "
+        "Be brief."
+    ),
+    tools=[remember_favorite_color, recall_favorite_color],
+)
+```
+
+**Session 1:** the user says "my favorite color is teal." The agent calls `remember_favorite_color("teal")`. The tool writes `user:favorite_color = "teal"` to the state.
+
+**Session 2:** a brand-new session for the same user. No initial state passed. But the session's `.state` *starts* with `user:favorite_color: "teal"` — because the `user:` prefix made the value survive across sessions.
+
+The user asks, "what's my favorite color?" The agent calls `recall_favorite_color()`, which reads the key, returns `"teal"`. The model replies "teal."
+
+Cross-session memory. No database setup. No vector store. No custom embedding pipeline. A prefix on a dict key.
+
+## Events — the session's immutable ledger
+
+Every turn produces events, and the session keeps them all. `session.events` gives you the full audit log: every user message, every model response, every tool call, every tool response, every state mutation recorded as a `state_delta`.
+
+A condensed example from the color demo:
+
+```
+[ 0] user         text(My favorite color is teal.)
+[ 1] color_agent  tool_call(remember_favorite_color)
+[ 2] color_agent  tool_resp | state_delta(['user:favorite_color'])
+[ 3] color_agent  text(Awesome!) | state_delta(['last_response'])
+```
+
+Four events. Two state deltas. The state dict is a **projection** of the event stream — when you fetch a session, ADK replays the events in order, applies the state deltas, and hands you the final state. This is event sourcing, and it's why Module 08 can swap in-memory sessions for database sessions without changing the agent code. The data model is the same; only the storage changes.
+
+Read-only from your code's perspective. You don't build events yourself. You read them when you need to understand what happened, or when you hand them to an evaluation suite (Module 09) for trajectory testing.
+
+## Artifacts — binary blobs outside the event stream
+
+A brief word on the fourth concept.
+
+**Artifacts** are for binary data — images, audio clips, PDFs, any large payload — that you want associated with a session but don't want serialized into events. The analogy: [Git LFS](https://git-lfs.com) for agents. The pointer lives in the event stream; the payload lives in a separate store.
+
+Three artifact services mirror the session services:
+
+- `InMemoryArtifactService` — demos and tests.
+- `GcsArtifactService` — Google Cloud Storage, for production.
+- Roll your own `BaseArtifactService` for S3, Azure Blob, MinIO, whatever.
+
+You won't need artifacts for the text-only agents in Part 1 of this course. Module 13 (Live API voice agent) is the first module where they carry real weight — audio clips need to live somewhere that isn't the event stream.
+
+## Interlude — Skeptical Memory
+
+*From the Agentic Design Patterns publication, Chapter 2: The Persistent Context Problem. The pattern has a name: Skeptical Memory. It is worth two minutes.*
+
+The wow demo in this chapter looks clean because the state has not had time to go stale. In production, this is not how it works.
+
+A user's favorite color from three months ago is probably still their favorite color. Their current project, maybe not — they might have switched projects and never told the agent. The tickets the agent "remembered" being open yesterday might all be closed by now. A server IP an MCP tool cached might have been reassigned. The client name in `user:current_client` might refer to a client the user no longer works with.
+
+**Stored memory is a hint, not a fact.**
+
+Three guidelines, condensed from the publication:
+
+1. **Prefer retrieval over recall for high-stakes decisions.** Before the agent sends an email, charges a card, deploys code, or takes any action with irreversible consequences, it should call a read-only tool to re-verify the relevant state — not act on its own stored memory. The cost of one extra tool call is trivial compared to the cost of acting on stale information.
+2. **Scope your state aggressively.** `temp:` for scratchpads inside a single run. Unprefixed for per-session. `user:` only for things you are confident change only on explicit user action. `app:` only for genuinely immutable configuration. The more narrowly scoped the data, the less staleness it can cause.
+3. **Log a reason when you write `user:` or `app:` state.** Months from now, when you're debugging an agent acting on six-month-old memory, a one-line "why did this get stored" note saves hours of investigation. Future you will thank present you.
+
+The pattern's name captures the spirit: **Skeptical Memory**. Treat your own stored context as unverified hints, not facts. Verify before acting on anything consequential.
+
+Module 08 picks up this thread when we move from session state into long-term memory — where the staleness problem gets its full treatment.
+
+## What to carry forward
+
+From this chapter, five things:
+
+- A **Session** is `(app_name, user_id, session_id)`. It holds events (immutable ledger) and state (mutable dict).
+- **Scope prefixes** on state keys decide lifetime: unprefixed is session-only, `user:` is per-user, `app:` is global, `temp:` is per-invocation.
+- **Two state-write patterns persist**: `output_key=` on the agent, and `tool_context.state[key] = value` inside a tool.
+- **Direct assignment to a fetched session's `.state`** does not round-trip. Use the two patterns above.
+- **Skeptical Memory**: stored state is a hint, not a fact. Verify before acting on high-stakes decisions.
+
+Module 04 opens up the `LiteLlm` wrapper we've been using since M01. The one-line model swap: Claude, GPT, Qwen via OpenRouter, and a locally-hosted Ollama model — same agent code, different provider — plus the one prefix gotcha that causes infinite tool-call loops if you get it wrong.

--- a/textbook/index.html
+++ b/textbook/index.html
@@ -314,6 +314,7 @@ hr {
                 <li><a href="#introduction">Introduction</a></li>
 <li><a href="#why-agents-why-adk">1. Why agents, why ADK</a></li>
 <li><a href="#tools-as-verbs">2. Tools as verbs</a></li>
+<li><a href="#sessions-state-events-artifacts">3. Sessions, State, Events, Artifacts</a></li>
             </ul>
         </nav>
     </aside>
@@ -616,6 +617,162 @@ orchestrator = LlmAgent(
 <p>Tools come in four flavors: <strong>FunctionTool, OpenAPIToolset, McpToolset, AgentTool</strong>. Same abstraction to the model; different integration targets. FunctionTool is the default; reach for the others when you have a specific reason.</p>
 <p>And the design rule from the Agentic Design Patterns interlude: <strong>blast radius matters</strong>. Categorize your tools by how much damage a mis-call can do. Put the guards for irreversible tools in the code, not in the instruction. An instruction is a polite request. Code is a wall.</p>
 <p>Module 03 picks up where the event stream leaves off. Every tool call you just saw went into the session&rsquo;s event history; Module 03 makes sessions, state, and events the subject.</p>
+        </section>
+
+        <section class="chapter" id="sessions-state-events-artifacts">
+            <div class="chapter-number">Chapter 3</div>
+            <h1>Sessions, State, Events, Artifacts</h1>
+<p>Module 01 gave you four primitives: Agent, Runner, Event, Session. Module 02 built on the first two. This chapter goes deep on the third, which is where the agent&rsquo;s memory actually lives. A stateless agent is a demo. A stateful agent is infrastructure. The difference is entirely about how you use the Session.</p>
+<h2>A session is two things</h2>
+<p>A session is identified by a triple: <code>(app_name, user_id, session_id)</code>. Those three strings are the primary key for every session in every session store, regardless of which backend you&rsquo;re using. Inside the session live two collections.</p>
+<p>The first is a <strong>list of events</strong> — the full ordered history of every user message, every model response, every tool call, every tool response, every state mutation. You don&rsquo;t append to this list; ADK does, as things happen. Your code reads it when it wants to audit what happened, replay a conversation, or feed a run into an evaluation suite.</p>
+<p>The second is a <strong>state dictionary</strong> — mutable key-value storage for whatever you want the agent to carry between turns. This is where the action is.</p>
+<p>ADK ships three session services:</p>
+<ul>
+<li><strong><code>InMemorySessionService</code></strong> — backs everything by a Python dict. Loses on process restart. This is what we&rsquo;ll use through Module 07. Perfect for tests, notebooks, and demos.</li>
+<li><strong><code>DatabaseSessionService</code></strong> — SQLAlchemy-backed. Works against Postgres, MySQL, SQLite. This is the production default for self-hosted deployments. Module 08 swaps to it when memory becomes the subject.</li>
+<li><strong><code>VertexAiSessionService</code></strong> — managed, Google-Cloud-only. Mentioned in this course; not taught — the pattern is the same, only the backing store changes.</li>
+</ul>
+<p>The interface is identical across all three. The agent code does not change when you swap the service, which is the whole point of the abstraction.</p>
+<h2>State with scope prefixes</h2>
+<p>This is the most useful under-documented feature in ADK, and the one you will use every day.</p>
+<p>A state dict is a regular Python dict. But the key&rsquo;s <strong>prefix decides where the value lives and how long it survives.</strong> Four tiers.</p>
+<table>
+<thead>
+<tr>
+<th>Prefix</th>
+<th>Scope</th>
+<th>Survives</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><em>(none)</em></td>
+<td>This session only</td>
+<td>Until the session is deleted</td>
+</tr>
+<tr>
+<td><code>user:</code></td>
+<td>This user, across all their sessions</td>
+<td>As long as the user exists</td>
+</tr>
+<tr>
+<td><code>app:</code></td>
+<td>Global across all users of this app</td>
+<td>As long as the app exists</td>
+</tr>
+<tr>
+<td><code>temp:</code></td>
+<td>This invocation only</td>
+<td>Thrown away after the run</td>
+</tr>
+</tbody>
+</table>
+<p>Think of it as React state with persistence tiers baked into the key. You decide the lifetime of every piece of data with a 5-character prefix; ADK handles the routing.</p>
+<p>In practice:</p>
+<ul>
+<li><strong>Unprefixed</strong> is the default. A favorite color you learn mid-conversation and only need for this session&rsquo;s replies. A draft the agent is composing.</li>
+<li><strong><code>user:</code></strong> for per-user persistence. Favorite colors, language preferences, history summaries — anything that&rsquo;s specific to one user but should persist across all their sessions with your app.</li>
+<li><strong><code>app:</code></strong> for global configuration. A daily-changing prompt template every agent should use. A shared rate-limit counter. Rare in practice; reach for it cautiously.</li>
+<li><strong><code>temp:</code></strong> for scratchpads inside a single run. A tool that needs to hand a value to the next tool in the same turn. A calculation the agent would rather not expose in the final event log.</li>
+</ul>
+<p>Pick the scope when you write, and ADK handles persistence accordingly.</p>
+<h2>Writing state — three ways, one of which is a trap</h2>
+<p>Three patterns for writing state. Two of them persist. One of them silently fails. It is almost always the one a new developer reaches for first.</p>
+<p><strong>Pattern 1 — <code>output_key=</code> on the agent.</strong> When you construct an <code>LlmAgent</code>, pass <code>output_key="last_response"</code> (or whatever key you want). After every run, the model&rsquo;s final text response is automatically written to <code>state[output_key]</code>. This is the cleanest way to cache a final answer, and — more importantly — it&rsquo;s how you pass output between workflow-agent steps, which Module 05 will lean on heavily.</p>
+<pre><code class="language-python">agent = LlmAgent(
+    name=&quot;color_agent&quot;,
+    model=LiteLlm(model=MODEL_STRING),
+    instruction=&quot;...&quot;,
+    tools=[...],
+    output_key=&quot;last_response&quot;,   # final text auto-saved to state['last_response']
+)
+</code></pre>
+<p><strong>Pattern 2 — <code>tool_context.state[key] = value</code> inside a tool.</strong> Your tool function gets an extra parameter, <code>tool_context: ToolContext</code>. ADK injects the running context automatically; you don&rsquo;t pass it in. From inside the tool, <code>tool_context.state</code> behaves like a mutable dict. Writes are recorded as events and persisted by the session service.</p>
+<pre><code class="language-python">def remember_favorite_color(color: str, tool_context: ToolContext) -&gt; dict:
+    &quot;&quot;&quot;Record the user's favorite color for future sessions.&quot;&quot;&quot;
+    tool_context.state[&quot;user:favorite_color&quot;] = color
+    return {&quot;status&quot;: &quot;saved&quot;, &quot;color&quot;: color}
+</code></pre>
+<p>Two subtleties to notice: the parameter is <code>tool_context</code> — ADK looks for exactly that name. And the <code>user:</code> prefix on the key is what makes the value survive beyond this session. Drop it, and the value is session-local.</p>
+<p><strong>Pattern 3 — direct assignment to a returned session&rsquo;s <code>.state</code> dict. Does NOT persist.</strong> You fetch a session with <code>session_service.get_session(...)</code>, get back a Session object with a <code>.state</code> dict, and you assign to it:</p>
+<pre><code class="language-python">session = await session_service.get_session(app_name=APP, user_id=USER, session_id=SID)
+session.state[&quot;user:foo&quot;] = &quot;bar&quot;   # ← does not persist
+</code></pre>
+<p>Next time you call <code>get_session()</code> for the same triple, your assignment is gone. Nobody tells you. You just wonder why state isn&rsquo;t sticking.</p>
+<p>The reason is event sourcing: ADK persists state <em>via events</em>. Patterns 1 and 2 both produce state-delta events that the session service writes to the backing store. Pattern 3 is a dict assignment on an in-memory object; no event is generated; nothing is persisted.</p>
+<p><strong>Rule to carry forward:</strong> use <code>output_key=</code> on the agent for final-text caching, and <code>tool_context.state[...]</code> inside a tool for structured writes. Treat a fetched session&rsquo;s <code>.state</code> as read-only.</p>
+<h2>The cross-session wow demo</h2>
+<p>The notebook for this module ships a complete version. Here is the essence.</p>
+<pre><code class="language-python">APP = &quot;m03_demo&quot;
+USER = &quot;alice&quot;
+
+def remember_favorite_color(color: str, tool_context: ToolContext) -&gt; dict:
+    tool_context.state[&quot;user:favorite_color&quot;] = color
+    return {&quot;status&quot;: &quot;saved&quot;, &quot;color&quot;: color}
+
+def recall_favorite_color(tool_context: ToolContext) -&gt; dict:
+    color = tool_context.state.get(&quot;user:favorite_color&quot;)
+    return {&quot;known&quot;: bool(color), &quot;color&quot;: color}
+
+agent = LlmAgent(
+    name=&quot;color_agent&quot;,
+    model=LiteLlm(model=MODEL_STRING),
+    instruction=(
+        &quot;You track the user's favorite color. When they tell you one, call &quot;
+        &quot;remember_favorite_color. When they ask, call recall_favorite_color. &quot;
+        &quot;Be brief.&quot;
+    ),
+    tools=[remember_favorite_color, recall_favorite_color],
+)
+</code></pre>
+<p><strong>Session 1:</strong> the user says &ldquo;my favorite color is teal.&rdquo; The agent calls <code>remember_favorite_color("teal")</code>. The tool writes <code>user:favorite_color = "teal"</code> to the state.</p>
+<p><strong>Session 2:</strong> a brand-new session for the same user. No initial state passed. But the session&rsquo;s <code>.state</code> <em>starts</em> with <code>user:favorite_color: "teal"</code> — because the <code>user:</code> prefix made the value survive across sessions.</p>
+<p>The user asks, &ldquo;what&rsquo;s my favorite color?&rdquo; The agent calls <code>recall_favorite_color()</code>, which reads the key, returns <code>"teal"</code>. The model replies &ldquo;teal.&rdquo;</p>
+<p>Cross-session memory. No database setup. No vector store. No custom embedding pipeline. A prefix on a dict key.</p>
+<h2>Events — the session&rsquo;s immutable ledger</h2>
+<p>Every turn produces events, and the session keeps them all. <code>session.events</code> gives you the full audit log: every user message, every model response, every tool call, every tool response, every state mutation recorded as a <code>state_delta</code>.</p>
+<p>A condensed example from the color demo:</p>
+<pre><code>[ 0] user         text(My favorite color is teal.)
+[ 1] color_agent  tool_call(remember_favorite_color)
+[ 2] color_agent  tool_resp | state_delta(['user:favorite_color'])
+[ 3] color_agent  text(Awesome!) | state_delta(['last_response'])
+</code></pre>
+<p>Four events. Two state deltas. The state dict is a <strong>projection</strong> of the event stream — when you fetch a session, ADK replays the events in order, applies the state deltas, and hands you the final state. This is event sourcing, and it&rsquo;s why Module 08 can swap in-memory sessions for database sessions without changing the agent code. The data model is the same; only the storage changes.</p>
+<p>Read-only from your code&rsquo;s perspective. You don&rsquo;t build events yourself. You read them when you need to understand what happened, or when you hand them to an evaluation suite (Module 09) for trajectory testing.</p>
+<h2>Artifacts — binary blobs outside the event stream</h2>
+<p>A brief word on the fourth concept.</p>
+<p><strong>Artifacts</strong> are for binary data — images, audio clips, PDFs, any large payload — that you want associated with a session but don&rsquo;t want serialized into events. The analogy: <a href="https://git-lfs.com">Git LFS</a> for agents. The pointer lives in the event stream; the payload lives in a separate store.</p>
+<p>Three artifact services mirror the session services:</p>
+<ul>
+<li><code>InMemoryArtifactService</code> — demos and tests.</li>
+<li><code>GcsArtifactService</code> — Google Cloud Storage, for production.</li>
+<li>Roll your own <code>BaseArtifactService</code> for S3, Azure Blob, MinIO, whatever.</li>
+</ul>
+<p>You won&rsquo;t need artifacts for the text-only agents in Part 1 of this course. Module 13 (Live API voice agent) is the first module where they carry real weight — audio clips need to live somewhere that isn&rsquo;t the event stream.</p>
+<h2>Interlude — Skeptical Memory</h2>
+<p><em>From the Agentic Design Patterns publication, Chapter 2: The Persistent Context Problem. The pattern has a name: Skeptical Memory. It is worth two minutes.</em></p>
+<p>The wow demo in this chapter looks clean because the state has not had time to go stale. In production, this is not how it works.</p>
+<p>A user&rsquo;s favorite color from three months ago is probably still their favorite color. Their current project, maybe not — they might have switched projects and never told the agent. The tickets the agent &ldquo;remembered&rdquo; being open yesterday might all be closed by now. A server IP an MCP tool cached might have been reassigned. The client name in <code>user:current_client</code> might refer to a client the user no longer works with.</p>
+<p><strong>Stored memory is a hint, not a fact.</strong></p>
+<p>Three guidelines, condensed from the publication:</p>
+<ol>
+<li><strong>Prefer retrieval over recall for high-stakes decisions.</strong> Before the agent sends an email, charges a card, deploys code, or takes any action with irreversible consequences, it should call a read-only tool to re-verify the relevant state — not act on its own stored memory. The cost of one extra tool call is trivial compared to the cost of acting on stale information.</li>
+<li><strong>Scope your state aggressively.</strong> <code>temp:</code> for scratchpads inside a single run. Unprefixed for per-session. <code>user:</code> only for things you are confident change only on explicit user action. <code>app:</code> only for genuinely immutable configuration. The more narrowly scoped the data, the less staleness it can cause.</li>
+<li><strong>Log a reason when you write <code>user:</code> or <code>app:</code> state.</strong> Months from now, when you&rsquo;re debugging an agent acting on six-month-old memory, a one-line &ldquo;why did this get stored&rdquo; note saves hours of investigation. Future you will thank present you.</li>
+</ol>
+<p>The pattern&rsquo;s name captures the spirit: <strong>Skeptical Memory</strong>. Treat your own stored context as unverified hints, not facts. Verify before acting on anything consequential.</p>
+<p>Module 08 picks up this thread when we move from session state into long-term memory — where the staleness problem gets its full treatment.</p>
+<h2>What to carry forward</h2>
+<p>From this chapter, five things:</p>
+<ul>
+<li>A <strong>Session</strong> is <code>(app_name, user_id, session_id)</code>. It holds events (immutable ledger) and state (mutable dict).</li>
+<li><strong>Scope prefixes</strong> on state keys decide lifetime: unprefixed is session-only, <code>user:</code> is per-user, <code>app:</code> is global, <code>temp:</code> is per-invocation.</li>
+<li><strong>Two state-write patterns persist</strong>: <code>output_key=</code> on the agent, and <code>tool_context.state[key] = value</code> inside a tool.</li>
+<li><strong>Direct assignment to a fetched session&rsquo;s <code>.state</code></strong> does not round-trip. Use the two patterns above.</li>
+<li><strong>Skeptical Memory</strong>: stored state is a hint, not a fact. Verify before acting on high-stakes decisions.</li>
+</ul>
+<p>Module 04 opens up the <code>LiteLlm</code> wrapper we&rsquo;ve been using since M01. The one-line model swap: Claude, GPT, Qwen via OpenRouter, and a locally-hosted Ollama model — same agent code, different provider — plus the one prefix gotcha that causes infinite tool-call loops if you get it wrong.</p>
         </section>
         </main>
     </div>


### PR DESCRIPTION
## Summary

Module 03: the third primitive up close. Sessions, state dict with scope prefixes (`user:`/`app:`/`temp:`), events as immutable ledger, artifacts briefly. Plus the **Skeptical Memory** interlude from *Agentic Design Patterns* Chapter 2.

## What ships

- \`slides/module-03-sessions-state/index.html\` — 21-slide deck
- \`slides/module-03-sessions-state/speaker_notes.md\` — one section per slide
- \`textbook/_sources/chapters/03-sessions-state.md\` — full chapter; textbook now 4 chapters
- \`notebooks/03_sessions_state.ipynb\` — wow demo: cross-session memory via \`user:\` prefix
- \`index.html\` — M03 flipped to Ready

## Wow demo verified

- Session 1: user writes "favorite color is teal". Tool sets \`tool_context.state["user:favorite_color"]\`.
- Session 2 (fresh, same user): state auto-starts with \`user:favorite_color: 'teal'\`. Agent recalls "teal" when asked.

## Also covers

- Three state-write patterns. Two persist (\`output_key=\`, \`tool_context.state[...]\`); one silently fails (direct \`.state\` assignment on a fetched session).
- Event sourcing: state is a projection of the event stream's \`state_delta\` entries.
- Skeptical Memory pattern: stored state is a hint, not a fact. Verify before high-stakes action.

## Test log

```
jupyter nbconvert --execute notebooks/03_sessions_state.ipynb
# → PASS, all 8 code cells produce expected output, cross-session demo works.

python3 textbook/_sources/tools/build_html.py
# → 4 chapters
```

Model: \`openrouter/google/gemini-2.5-flash-lite\`. Cost: ~$0.001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)