### PR TITLE
course(M06): multi-agent hierarchies — sub_agents vs AgentTool

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,14 +262,14 @@
       <div class="status ready">Ready</div>
     </a>
 
-    <div class="module soon">
+    <a class="module" href="slides/module-06-multi-agent/index.html">
       <div class="num">M06</div>
       <div>
         <div class="title">Multi-agent hierarchies</div>
         <div class="desc"><code>sub_agents</code> versus <code>AgentTool</code>.</div>
       </div>
-      <div class="status soon">Soon</div>
-    </div>
+      <div class="status ready">Ready</div>
+    </a>
 
     <div class="module soon">
       <div class="num">M07</div>

--- a/notebooks/06_multi_agent.ipynb
+++ b/notebooks/06_multi_agent.ipynb
@@ -1,0 +1,487 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "851c95c6",
+   "metadata": {},
+   "source": [
+    "# Module 06 — Multi-Agent Hierarchies\n",
+    "\n",
+    "Module 05 gave you workflow agents — **named, declarative** control flow. Sequential, Parallel, Loop. Use them when you can name the workflow.\n",
+    "\n",
+    "This module gives you the other half: **LLM-driven** control flow. When the user's input decides which specialist runs, or when a coordinator should call a specialist like a function, you don't want a workflow agent. You want the LLM to route.\n",
+    "\n",
+    "ADK has two patterns for this. They look superficially similar. They behave very differently once you pay attention to who is in charge of the conversation.\n",
+    "\n",
+    "- **`sub_agents`** — the coordinator *transfers* control to a specialist. The specialist owns the conversation. The org-chart pattern.\n",
+    "- **`AgentTool`** — the coordinator *calls* a specialist like a function. The coordinator stays in charge. The consultant pattern.\n",
+    "\n",
+    "By the end of this notebook you'll have built the same coordinator-plus-two-specialists team both ways. The same input produces the same answer, but the event stream looks noticeably different. Which pattern is right depends on whether the specialist should drive the conversation or hand the mic back.\n",
+    "\n",
+    "**Interlude:** at the end, two minutes on **multi-agent decomposition** — Pattern 8 from *Agentic Design Patterns* — on when multi-agent architectures pay for their coordination tax and when they don't.\n",
+    "\n",
+    "**Running cost:** under $0.01."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c587592",
+   "metadata": {},
+   "source": [
+    "# Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e75a8ecf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -q google-adk==1.28.0 litellm==1.83.4 python-dotenv==1.0.1 nest-asyncio==1.6.0 deprecated==1.2.18 2>/dev/null\n",
+    "\n",
+    "print(\"✅ Packages installed.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ce8c079",
+   "metadata": {},
+   "source": [
+    "## API Key"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ffbed4da",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "OPENROUTER_API_KEY = None\n",
+    "try:\n",
+    "    from google.colab import userdata\n",
+    "    OPENROUTER_API_KEY = userdata.get(\"OPENROUTER_API_KEY\")\n",
+    "    print(\"✅ API key loaded from Colab secrets.\")\n",
+    "except Exception:\n",
+    "    try:\n",
+    "        from dotenv import load_dotenv; load_dotenv()\n",
+    "        OPENROUTER_API_KEY = os.getenv(\"OPENROUTER_API_KEY\")\n",
+    "        if OPENROUTER_API_KEY:\n",
+    "            print(\"✅ API key loaded from .env file.\")\n",
+    "    except ImportError:\n",
+    "        pass\n",
+    "if not OPENROUTER_API_KEY:\n",
+    "    from getpass import getpass\n",
+    "    OPENROUTER_API_KEY = getpass(\"Enter your OpenRouter API key: \")\n",
+    "assert OPENROUTER_API_KEY, \"❌ No API key provided.\"\n",
+    "os.environ[\"OPENROUTER_API_KEY\"] = OPENROUTER_API_KEY\n",
+    "MODEL_STRING = \"openrouter/google/gemini-2.5-flash-lite\"\n",
+    "print(f\"✅ Model: {MODEL_STRING}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "65e6b8b3",
+   "metadata": {},
+   "source": [
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6cdacdc1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, warnings, asyncio, uuid, logging\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "try: sys.stderr.fileno()\n",
+    "except Exception: sys.stderr = open(os.devnull, \"w\")\n",
+    "import nest_asyncio; nest_asyncio.apply()\n",
+    "import litellm; litellm.suppress_debug_info = True\n",
+    "logging.getLogger(\"LiteLLM\").setLevel(logging.WARNING)\n",
+    "\n",
+    "from google.adk.agents import LlmAgent\n",
+    "from google.adk.runners import Runner\n",
+    "from google.adk.sessions import InMemorySessionService\n",
+    "from google.adk.models.lite_llm import LiteLlm\n",
+    "from google.adk.tools.agent_tool import AgentTool\n",
+    "from google.genai import types\n",
+    "\n",
+    "print(\"✅ Imports successful.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "136b1db9",
+   "metadata": {},
+   "source": [
+    "# The Composition Question, Recap\n",
+    "\n",
+    "You have three ways to combine agents in ADK:\n",
+    "\n",
+    "| Pattern | Control flow | When |\n",
+    "|---|---|---|\n",
+    "| **Workflow agent** (M05) | Declarative — Sequential, Parallel, Loop | You can name the workflow |\n",
+    "| **`sub_agents`** (this module) | LLM decides — via transfer | User input shapes the flow; specialist should own the dialog |\n",
+    "| **`AgentTool`** (this module) | LLM decides — via function call | User input shapes the flow; coordinator stays in charge |\n",
+    "\n",
+    "The `sub_agents` and `AgentTool` patterns both let the LLM decide what runs next. The difference is **who is in charge afterward.**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2790438",
+   "metadata": {},
+   "source": [
+    "# Pattern 1 — `sub_agents`: the Org-Chart Transfer\n",
+    "\n",
+    "The coordinator has a list of children in its `sub_agents=` parameter. When the coordinator's LLM decides a specialist is more appropriate, it emits a structured call to a built-in tool called `transfer_to_agent(agent_name=...)`. ADK catches that call and **transfers control to the named child**. The child runs, produces a response, and *the child's response is what the user sees*.\n",
+    "\n",
+    "Think of it as an org chart. The coordinator is the manager; it reads the incoming ticket and routes it. Once routed, the specialist owns the conversation — for this turn, and for future turns in the same session, unless transferred again.\n",
+    "\n",
+    "The mechanism ADK provides:\n",
+    "- The `transfer_to_agent` tool is **automatically available** to any agent that has `sub_agents=`. You don't register it; ADK injects it.\n",
+    "- The child's `description=` is what the coordinator's LLM reads to decide whether to route. Write descriptions carefully — that's the routing schema."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "55a0d718",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Two specialists — greeter and weather_specialist.\n",
+    "greeter = LlmAgent(\n",
+    "    name=\"greeter\",\n",
+    "    model=LiteLlm(model=MODEL_STRING),\n",
+    "    description=\"Handles greetings and casual chat.\",\n",
+    "    instruction=\"You are a friendly greeter. Respond warmly in one short sentence.\",\n",
+    ")\n",
+    "\n",
+    "weather_specialist = LlmAgent(\n",
+    "    name=\"weather_specialist\",\n",
+    "    model=LiteLlm(model=MODEL_STRING),\n",
+    "    description=\"Handles weather questions for any city.\",\n",
+    "    instruction=(\n",
+    "        \"You are a weather assistant. You do not have real weather tools; \"\n",
+    "        \"produce plausible one-sentence weather reports for the city asked about.\"\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "# The coordinator routes via sub_agents.\n",
+    "coordinator_subagents = LlmAgent(\n",
+    "    name=\"coordinator_subagents\",\n",
+    "    model=LiteLlm(model=MODEL_STRING),\n",
+    "    description=\"Coordinator that routes to specialists via transfer.\",\n",
+    "    instruction=\"\"\"You coordinate a small team. You have two specialists available:\n",
+    "- `greeter` for greetings and casual chat.\n",
+    "- `weather_specialist` for weather questions.\n",
+    "\n",
+    "When the user's message fits one of them, use transfer_to_agent to hand over.\n",
+    "Do not answer greetings or weather questions yourself — always delegate.\"\"\",\n",
+    "    sub_agents=[greeter, weather_specialist],\n",
+    ")\n",
+    "\n",
+    "print(\"✅ Coordinator (sub_agents pattern) ready.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bc96121c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "APP = \"m06_demos\"\n",
+    "USER = \"student\"\n",
+    "session_service = InMemorySessionService()\n",
+    "\n",
+    "async def chat(agent, prompt: str, session_id: str = None):\n",
+    "    sid = session_id or f\"s-{uuid.uuid4().hex[:6]}\"\n",
+    "    await session_service.create_session(app_name=APP, user_id=USER, session_id=sid)\n",
+    "    runner = Runner(agent=agent, app_name=APP, session_service=session_service)\n",
+    "    msg = types.Content(role=\"user\", parts=[types.Part(text=prompt)])\n",
+    "    print(f\"USER: {prompt}\\n\")\n",
+    "    async for ev in runner.run_async(user_id=USER, session_id=sid, new_message=msg):\n",
+    "        if ev.content and ev.content.parts:\n",
+    "            for p in ev.content.parts:\n",
+    "                if p.text and p.text.strip():\n",
+    "                    print(f\"[{ev.author}] {p.text.strip()[:200]}\")\n",
+    "                if p.function_call:\n",
+    "                    args = dict(p.function_call.args) if p.function_call.args else {}\n",
+    "                    print(f\"[{ev.author}] → {p.function_call.name}({args})\")\n",
+    "                if p.function_response:\n",
+    "                    resp = str(p.function_response.response)\n",
+    "                    if len(resp) < 200:\n",
+    "                        print(f\"[tool_resp] {resp}\")\n",
+    "\n",
+    "print(\"✅ chat() ready.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "957440f1",
+   "metadata": {},
+   "source": [
+    "## Demo — transfer routing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "711d16ba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await chat(coordinator_subagents, \"Hi there, how are you?\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41e051fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await chat(coordinator_subagents, \"What's the weather in Prague?\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8748db88",
+   "metadata": {},
+   "source": [
+    "Two observations from the event stream.\n",
+    "\n",
+    "- The coordinator emitted `transfer_to_agent(agent_name='...')` as a tool call. ADK caught it and routed to the named child.\n",
+    "- The child's output appears under its own author — `[greeter]` and `[weather_specialist]`, not `[coordinator_subagents]`. **The child produced the final response.** That's the transfer pattern.\n",
+    "\n",
+    "One subtle production fact: after a transfer, the child remains the active agent for the rest of the session by default. If the user asks a follow-up question in the same session, it goes to the specialist, not back to the coordinator. The coordinator can regain control by having its own logic (or the child can transfer back). M03's session state applies here — the active-agent is part of the session."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "214bac16",
+   "metadata": {},
+   "source": [
+    "# Pattern 2 — `AgentTool`: the Consultant Pattern\n",
+    "\n",
+    "Same team, different wiring. Instead of putting the specialists in `sub_agents=`, we wrap each as an `AgentTool` and put them in `tools=`. Now from the coordinator's LLM's perspective, the specialists are **tools**, not transfer targets.\n",
+    "\n",
+    "When the coordinator decides to use a specialist, it emits a regular function call — same mechanism as calling `get_weather` or `search_tickets`. ADK executes the specialist, gets its output, and hands it back as a tool-response event. **The coordinator reads the response and produces the final user-facing reply itself.** The specialist never gets the mic."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d8a50370",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Same specialists; same descriptions; different wiring.\n",
+    "# Use separate instances so they don't accidentally share parent state.\n",
+    "greeter_t = LlmAgent(\n",
+    "    name=\"greeter\",\n",
+    "    model=LiteLlm(model=MODEL_STRING),\n",
+    "    description=\"Handles greetings and casual chat. Input: user message. Output: one warm sentence.\",\n",
+    "    instruction=\"Respond warmly in one short sentence.\",\n",
+    ")\n",
+    "\n",
+    "weather_specialist_t = LlmAgent(\n",
+    "    name=\"weather_specialist\",\n",
+    "    model=LiteLlm(model=MODEL_STRING),\n",
+    "    description=\"Reports weather for any city. Input: the city name. Output: one-sentence weather report.\",\n",
+    "    instruction=\"Produce a plausible one-sentence weather report.\",\n",
+    ")\n",
+    "\n",
+    "coordinator_tools = LlmAgent(\n",
+    "    name=\"coordinator_tools\",\n",
+    "    model=LiteLlm(model=MODEL_STRING),\n",
+    "    description=\"Coordinator that calls specialists as tools.\",\n",
+    "    instruction=\"\"\"You have exactly two tools available, and you must use one of them\n",
+    "for every user message:\n",
+    "\n",
+    "- Call the tool named `greeter` for greetings, small talk, or casual chat.\n",
+    "- Call the tool named `weather_specialist` for any weather question.\n",
+    "\n",
+    "Do NOT invent other tool names. Do NOT answer directly. Always call one of\n",
+    "those two tools, pass it the user's message as the `request` argument, read\n",
+    "the result, and wrap it in your own friendly reply.\"\"\",\n",
+    "    tools=[\n",
+    "        AgentTool(agent=greeter_t),\n",
+    "        AgentTool(agent=weather_specialist_t),\n",
+    "    ],\n",
+    ")\n",
+    "\n",
+    "print(\"✅ Coordinator (AgentTool pattern) ready.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "445537c2",
+   "metadata": {},
+   "source": [
+    "## Demo — consultant calls"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "58b9f217",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await chat(coordinator_tools, \"Hi there, how are you?\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "93f87d06",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await chat(coordinator_tools, \"What's the weather in Prague?\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9032848f",
+   "metadata": {},
+   "source": [
+    "Notice the differences in the event stream.\n",
+    "\n",
+    "- The coordinator emitted a regular tool call — `weather_specialist(...)` — not `transfer_to_agent`.\n",
+    "- A `[tool_resp]` event carries the specialist's output back.\n",
+    "- The **final response author is `[coordinator_tools]`**, not the specialist. The coordinator read the specialist's output, wrapped it in its own voice, and produced the reply.\n",
+    "\n",
+    "This is the consultant pattern. The specialist answered a specific question and stepped back; the coordinator remained in charge."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f16b5f95",
+   "metadata": {},
+   "source": [
+    "# Side-by-Side\n",
+    "\n",
+    "Same input, same team, two different compositions. The event streams tell you which pattern is in use.\n",
+    "\n",
+    "## `sub_agents` — the transfer pattern\n",
+    "\n",
+    "```\n",
+    "USER: What's the weather in Prague?\n",
+    "\n",
+    "[coordinator_subagents] → transfer_to_agent(agent_name='weather_specialist')\n",
+    "[weather_specialist]    Prague is cloudy and cool, with a gentle breeze.\n",
+    "                        ^^^ final response comes from the specialist\n",
+    "```\n",
+    "\n",
+    "## `AgentTool` — the consultant pattern\n",
+    "\n",
+    "```\n",
+    "USER: What's the weather in Prague?\n",
+    "\n",
+    "[coordinator_tools] → weather_specialist(request='...')\n",
+    "[tool_resp]            {'result': 'In Prague, expect a partly cloudy day...'}\n",
+    "[coordinator_tools]    The weather in Prague is partly cloudy with a gentle breeze.\n",
+    "                       ^^^ final response comes from the coordinator,\n",
+    "                           wrapping the specialist's output\n",
+    "```\n",
+    "\n",
+    "**Tell-tale sign:** look at the author of the final response. If it's a specialist, you're looking at a transfer. If it's the coordinator, you're looking at a consultant call."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9e2c48cb",
+   "metadata": {},
+   "source": [
+    "# When to Pick Which\n",
+    "\n",
+    "| Use `sub_agents` (transfer) when... | Use `AgentTool` (consultant) when... |\n",
+    "|---|---|\n",
+    "| The specialist should **own the conversation** after routing | The specialist should **answer one question and step back** |\n",
+    "| The child might take multiple turns with the user before handing back | The child has a clean input/output contract |\n",
+    "| Topic shifts — the specialist is the right conversation partner for the whole topic | The coordinator needs to compose the specialist's output with other sources |\n",
+    "| You want the user to perceive talking to a specialist | You want the user to perceive talking to one assistant that has specialists behind the scenes |\n",
+    "\n",
+    "A practical rule: if the specialist's work is part of a **larger answer** that also incorporates other information, use `AgentTool`. If the specialist's work *is* the answer, use `sub_agents`.\n",
+    "\n",
+    "### A concrete example for each\n",
+    "\n",
+    "**`sub_agents` scenario.** IT support desk with a billing specialist and a hardware specialist. The user says \"my laptop won't boot.\" The coordinator routes to hardware. Over the next five turns of the session, the hardware specialist walks the user through diagnosis. That's an extended conversation the coordinator shouldn't mediate — `sub_agents` is right.\n",
+    "\n",
+    "**`AgentTool` scenario.** Coding assistant whose orchestrator wraps a specialist code-analyzer, a specialist docs-lookup, and a specialist test-runner. The user asks \"why is my test failing?\" The orchestrator calls all three, gets their outputs, synthesizes one answer. Each specialist's contribution is a single structured response; the orchestrator owns composing them. That's `AgentTool`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c50a4a61",
+   "metadata": {},
+   "source": [
+    "# Interlude — Multi-Agent Decomposition\n",
+    "\n",
+    "> *From \"Agentic Design Patterns,\" Chapter 8. Two minutes on when to build multi-agent architectures — and when not to.*\n",
+    "\n",
+    "Multi-agent architectures are fashionable. They're also expensive. Before you decompose a task into several specialist agents, consider whether the coordination tax is worth paying.\n",
+    "\n",
+    "The coordination tax has three parts:\n",
+    "\n",
+    "1. **Extra LLM calls.** Every transfer or `AgentTool` call is an additional model invocation. A two-specialist system makes at least two calls per turn. A five-specialist system can make ten or more. This compounds latency and cost.\n",
+    "2. **Routing errors.** Every routing decision is a chance to pick the wrong specialist. The more specialists, the wider the miss surface.\n",
+    "3. **Context fragmentation.** Each child has its own system prompt. Information you put in the coordinator's instruction doesn't automatically reach the children. Specialists sometimes fail because they lack context the coordinator had.\n",
+    "\n",
+    "The publication proposes three tests before you decompose:\n",
+    "\n",
+    "**Test 1 — Reuse test.** Will any of the specialists be used elsewhere (by a different top-level agent, in a different product)? If yes, decomposing into standalone agents is worth it — the specialists become reusable components. If no, consider keeping everything in one agent with more tools.\n",
+    "\n",
+    "**Test 2 — Model-heterogeneity test.** Does each specialist benefit from a different model? If the routing decision is cheap (route on Haiku) but the answer is hard (resolve on Opus), separate agents let you mix models per task. If they all use the same model, the decomposition buys you less.\n",
+    "\n",
+    "**Test 3 — Instruction-scale test.** Is a single system prompt getting unmanageable? If you're at 500 lines of instructions with overlapping rules, breaking it up across specialists is a legitimate way to reduce each prompt to its core job. But if your single-agent prompt is 30 lines, don't split it just because you can.\n",
+    "\n",
+    "If none of the three tests pass, **keep it to one agent with tools**. A single well-written agent with 8 tools is almost always simpler, cheaper, and faster than a coordinator-plus-specialists architecture doing the same work. Multi-agent is the right answer sometimes; it is not the right answer by default."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a8203a1",
+   "metadata": {},
+   "source": [
+    "# Your Turn\n",
+    "\n",
+    "1. **Refactor the transfer demo to use a third specialist.** Add a `joke_specialist` agent. Route with the `sub_agents` pattern. Ask it three questions — a greeting, a weather query, a joke request — and watch the routing.\n",
+    "2. **Refactor the consultant demo to use two tools at once.** Ask the `coordinator_tools` agent: *\"Greet me, and tell me the weather in Warsaw.\"* Does it call both specialists in one turn? Which order?\n",
+    "3. **The three tests, applied.** Take an agent you've built (M02's guarded-ticket agent, say) and apply the three-tests from the interlude. Would decomposing it into multiple agents be justified? Write 2-3 sentences for each test.\n",
+    "4. **Observe the follow-up-turn behavior.** In the `sub_agents` pattern, after the first turn transfers to a specialist, send a follow-up in the same session. Does it go to the specialist or back to the coordinator? Inspect the session's event stream."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "497d9687",
+   "metadata": {},
+   "source": [
+    "# Key Takeaways\n",
+    "\n",
+    "- **`sub_agents` is the transfer pattern.** Coordinator's LLM emits `transfer_to_agent(name=...)`; ADK routes; the specialist owns the response. Good for topic-shifts and extended specialist dialogs.\n",
+    "- **`AgentTool` is the consultant pattern.** Coordinator calls a specialist like a function; the coordinator composes the final reply. Good for specialists with clean I/O contracts whose work is part of a larger answer.\n",
+    "- **The child's `description=`** is the routing schema the coordinator's LLM reads. Write descriptions for the model to read.\n",
+    "- **Tell-tale sign:** final-response author = specialist → transfer; coordinator → consultant.\n",
+    "- **Interlude — multi-agent decomposition.** There's a coordination tax: extra calls, routing errors, context fragmentation. Decompose only when reuse, model-heterogeneity, or instruction-scale tests pass.\n",
+    "- **Default:** one agent with tools. Multi-agent is a deliberate choice, not a habit.\n",
+    "\n",
+    "# Next up — M07: Callbacks as middleware\n",
+    "\n",
+    "Six lifecycle hooks that wrap every invocation. `before_agent`, `after_agent`, `before_model`, `after_model`, `before_tool`, `after_tool`. Return `None` and things proceed normally; return a response object and you skip the LLM or tool altogether. It's Django middleware, Express middleware, Plugin hooks — for agents. The blocklist guardrail demo is the small-and-visual wow. See you there."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/slides/module-06-multi-agent/index.html
+++ b/slides/module-06-multi-agent/index.html
@@ -1,0 +1,245 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ADK Course — M06: Multi-Agent Hierarchies</title>
+  <link rel="stylesheet" href="../shared/shared.css">
+  <link rel="stylesheet" href="../shared/slides.css">
+</head>
+<body>
+  <nav class="progress-strip">
+    <a href="../../index.html" class="progress-home">Course</a>
+    <div class="progress-title">M06 — Multi-Agent Hierarchies</div>
+    <div class="progress-meta">
+      <span class="slide-counter">1 / 1</span>
+      <button class="theme-toggle">Theme</button>
+    </div>
+  </nav>
+
+  <main class="slide-viewport">
+
+  <div class="slide active" data-module="06" data-type="section-title">
+    <div class="topic-badge">Module 06 &middot; Part 1 Vendor-agnostic</div>
+    <h1>Multi-agent hierarchies</h1>
+    <h3>Two ways to compose agents with LLM-driven routing</h3>
+    <p class="highlight-text"><code>sub_agents</code> (transfer) &nbsp;·&nbsp; <code>AgentTool</code> (consultant)</p>
+  </div>
+
+  <div class="slide" data-module="06">
+    <h2>Three ways to combine agents</h2>
+    <table>
+      <thead><tr><th>Pattern</th><th>Control flow</th><th>When</th></tr></thead>
+      <tbody>
+        <tr><td><strong>Workflow agent</strong> (M05)</td><td>Declarative — Sequential, Parallel, Loop</td><td>You can name the workflow</td></tr>
+        <tr><td><strong><code>sub_agents</code></strong></td><td>LLM decides — via <em>transfer</em></td><td>Specialist should own the dialog</td></tr>
+        <tr><td><strong><code>AgentTool</code></strong></td><td>LLM decides — via <em>function call</em></td><td>Coordinator stays in charge</td></tr>
+      </tbody>
+    </table>
+    <p>Workflow agents were M05. Today: the two LLM-driven patterns.</p>
+  </div>
+
+  <div class="slide" data-module="06" data-type="keyfact">
+    <h2 class="text-muted" style="border-bottom:none;font-size:1em;text-transform:uppercase;letter-spacing:0.08em;">The one question</h2>
+    <p>Who is in charge of the conversation <strong>after</strong> the specialist finishes?</p>
+    <p style="font-size:0.7em;color:var(--text-muted);margin-top:var(--space-4);">That is the only meaningful difference between the two patterns.</p>
+  </div>
+
+  <div class="slide" data-module="06" data-type="section-title" style="background:linear-gradient(135deg,var(--navy-dark) 0%,var(--navy) 100%);">
+    <div class="topic-badge">Pattern 1</div>
+    <h1><code>sub_agents</code></h1>
+    <p class="highlight-text">The org-chart transfer. Specialist owns the response.</p>
+  </div>
+
+  <div class="slide" data-module="06">
+    <h2>How it works</h2>
+    <ul>
+      <li>Coordinator has <code>sub_agents=[...]</code>.</li>
+      <li>ADK automatically injects <code>transfer_to_agent(agent_name=...)</code> as a callable.</li>
+      <li>The coordinator's LLM emits <code>transfer_to_agent('weather_specialist')</code>.</li>
+      <li>ADK <strong>transfers control</strong> to the named child. The child produces the final response.</li>
+      <li>The child remains active for follow-up turns — unless it transfers again.</li>
+    </ul>
+    <p style="color:var(--text-muted);font-size:0.9em;">Think org chart. The coordinator is the manager; the specialist takes the meeting.</p>
+  </div>
+
+  <div class="slide" data-module="06" data-type="code">
+    <h2>Coordinator with <code>sub_agents</code></h2>
+<pre><code>greeter = LlmAgent(name="greeter",
+    description="Handles greetings and casual chat.",
+    instruction="Respond warmly in one short sentence.")
+
+weather_specialist = LlmAgent(name="weather_specialist",
+    description="Handles weather questions for any city.",
+    instruction="Produce a plausible one-sentence weather report.")
+
+coordinator = LlmAgent(
+    name="coordinator",
+    instruction="Delegate greetings to greeter, weather to weather_specialist.",
+    sub_agents=[greeter, weather_specialist],   # ← here
+)</code></pre>
+    <p class="code-caption">The child's <code>description=</code> is what the coordinator's LLM reads to decide routing. Write descriptions for the model.</p>
+  </div>
+
+  <div class="slide" data-module="06" data-type="section-title" style="background:linear-gradient(135deg,var(--amber-dark) 0%,var(--amber) 100%);">
+    <h1>Live</h1>
+    <h3>Transfer routing in action</h3>
+    <p class="highlight-text" style="color:white;">Notebook cells 12-13</p>
+  </div>
+
+  <div class="slide" data-module="06">
+    <h2>The event stream</h2>
+<pre class="diagram">USER: What's the weather in Prague?
+
+[coordinator_subagents] → transfer_to_agent({'agent_name': 'weather_specialist'})
+[weather_specialist]    The weather in Prague is partly cloudy with a gentle
+                        breeze and a temperature of 15 degrees Celsius.
+                        ^^^ final response comes from the SPECIALIST</pre>
+  </div>
+
+  <div class="slide" data-module="06" data-type="section-title" style="background:linear-gradient(135deg,var(--navy-dark) 0%,var(--navy) 100%);">
+    <div class="topic-badge">Pattern 2</div>
+    <h1><code>AgentTool</code></h1>
+    <p class="highlight-text">The consultant pattern. Coordinator stays in charge.</p>
+  </div>
+
+  <div class="slide" data-module="06">
+    <h2>How it works</h2>
+    <ul>
+      <li>Wrap each specialist in <code>AgentTool(agent=...)</code>.</li>
+      <li>Put those in the coordinator's <code>tools=[...]</code>, not <code>sub_agents=[...]</code>.</li>
+      <li>Coordinator's LLM emits a <strong>regular function call</strong> — same mechanism as <code>get_weather</code> or <code>search_tickets</code>.</li>
+      <li>ADK runs the specialist, captures its output as a tool-response event.</li>
+      <li>The coordinator <strong>reads the response and produces the final reply itself</strong>.</li>
+    </ul>
+  </div>
+
+  <div class="slide" data-module="06" data-type="code">
+    <h2>Coordinator with <code>AgentTool</code></h2>
+<pre><code>from google.adk.tools.agent_tool import AgentTool
+
+# Same specialists.
+greeter = LlmAgent(name="greeter", description="...", instruction="...")
+weather_specialist = LlmAgent(name="weather_specialist", ...)
+
+coordinator = LlmAgent(
+    name="coordinator",
+    instruction="Call greeter or weather_specialist; wrap the result.",
+    tools=[
+        AgentTool(agent=greeter),
+        AgentTool(agent=weather_specialist),
+    ],
+)</code></pre>
+    <p class="code-caption">Specialists are in <code>tools=</code>, not <code>sub_agents=</code>. To the coordinator's LLM, they look like function tools.</p>
+  </div>
+
+  <div class="slide" data-module="06" data-type="section-title" style="background:linear-gradient(135deg,var(--amber-dark) 0%,var(--amber) 100%);">
+    <h1>Live</h1>
+    <h3>Consultant call in action</h3>
+    <p class="highlight-text" style="color:white;">Notebook cells 18-19</p>
+  </div>
+
+  <div class="slide" data-module="06">
+    <h2>The event stream — note the author</h2>
+<pre class="diagram">USER: What's the weather in Prague?
+
+[coordinator_tools] → weather_specialist({'request': 'Prague'})
+[tool_resp]            {'result': 'Prague will experience partly cloudy
+                        skies with a high of 18 degrees Celsius today.'}
+[coordinator_tools]    The weather in Prague will be partly cloudy with
+                        a high of 18 degrees Celsius today.
+                        ^^^ final response comes from the COORDINATOR,
+                            wrapping the specialist's output</pre>
+  </div>
+
+  <div class="slide" data-module="06" data-type="keyfact">
+    <h2 class="text-muted" style="border-bottom:none;font-size:1em;text-transform:uppercase;letter-spacing:0.08em;">Tell-tale sign</h2>
+    <p>Look at the <strong>author</strong> of the final response.</p>
+    <p style="font-size:0.8em;color:var(--text-muted);margin-top:var(--space-4);">Specialist → transfer. Coordinator → consultant.</p>
+  </div>
+
+  <div class="slide" data-module="06" data-type="comparison">
+    <h2>When to pick which</h2>
+    <div class="comparison-layout">
+      <div class="vs-left">
+        <h3><code>sub_agents</code> — transfer</h3>
+        <ul style="font-size:0.9em;">
+          <li>Specialist should own the dialog</li>
+          <li>Might take multiple turns before handing back</li>
+          <li>Topic shifts — the specialist is the right partner for the whole topic</li>
+          <li>User <em>perceives</em> talking to a specialist</li>
+        </ul>
+      </div>
+      <div class="vs-divider">vs</div>
+      <div class="vs-right">
+        <h3><code>AgentTool</code> — consultant</h3>
+        <ul style="font-size:0.9em;">
+          <li>Specialist answers one question and steps back</li>
+          <li>Clean input/output contract</li>
+          <li>Coordinator composes specialist output with other sources</li>
+          <li>User <em>perceives</em> one assistant with specialists behind the scenes</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <div class="slide" data-module="06">
+    <h2>Concrete examples</h2>
+    <div class="callout callout-tip">
+      <div class="callout-title"><code>sub_agents</code> scenario — IT support desk</div>
+      <p style="margin:0;font-size:0.95em;">Coordinator routes "laptop won't boot" to hardware specialist. Over the next five turns, hardware specialist walks user through diagnosis. That's an extended conversation the coordinator shouldn't mediate.</p>
+    </div>
+    <div class="callout callout-tip">
+      <div class="callout-title"><code>AgentTool</code> scenario — coding assistant</div>
+      <p style="margin:0;font-size:0.95em;">Orchestrator wraps a code-analyzer, a docs-lookup, a test-runner. User asks "why is my test failing?". Orchestrator calls all three, synthesizes one answer. Each specialist contributes a single structured response.</p>
+    </div>
+  </div>
+
+  <div class="slide" data-module="06" data-type="section-title" style="background:linear-gradient(135deg,#6A1B9A 0%,#8E24AA 100%);">
+    <div class="topic-badge">Interlude &middot; Agentic Design Patterns</div>
+    <h1>Multi-agent decomposition</h1>
+    <p class="highlight-text">Before you decompose, consider the coordination tax.</p>
+  </div>
+
+  <div class="slide" data-module="06">
+    <h2>The coordination tax has three parts</h2>
+    <ol>
+      <li><strong>Extra LLM calls.</strong> Every transfer or <code>AgentTool</code> call is an additional model invocation. Two-specialist system = 2+ calls per turn. Five specialists = 10+. Compounds latency and cost.</li>
+      <li><strong>Routing errors.</strong> Every routing decision is a chance to pick the wrong specialist. More specialists → wider miss surface.</li>
+      <li><strong>Context fragmentation.</strong> Each child has its own system prompt. Information you put in the coordinator doesn't automatically reach children. Specialists fail sometimes because they lack context the coordinator had.</li>
+    </ol>
+  </div>
+
+  <div class="slide" data-module="06">
+    <h2>Three tests before you decompose</h2>
+    <div class="callout callout-tip">
+      <div class="callout-title">Test 1 — Reuse</div>
+      <p style="margin:0;font-size:0.95em;">Will any specialist be used elsewhere — different product, different top-level agent? If yes, decomposition is worth it. If no, consider one agent with more tools.</p>
+    </div>
+    <div class="callout callout-tip">
+      <div class="callout-title">Test 2 — Model heterogeneity</div>
+      <p style="margin:0;font-size:0.95em;">Does each specialist benefit from a <em>different</em> model? Routing on Haiku, resolving on Opus? If yes, separate agents let you mix per task. If all share one model, less payoff.</p>
+    </div>
+    <div class="callout callout-tip">
+      <div class="callout-title">Test 3 — Instruction scale</div>
+      <p style="margin:0;font-size:0.95em;">Is a single system prompt getting unmanageable — 500 lines with overlapping rules? Breaking it up is legitimate. But if your prompt is 30 lines, don't split for sport.</p>
+    </div>
+  </div>
+
+  <div class="slide" data-module="06" data-type="keyfact">
+    <h2 class="text-muted" style="border-bottom:none;font-size:1em;text-transform:uppercase;letter-spacing:0.08em;">If none of the three tests pass</h2>
+    <p>Keep it to <strong>one agent with tools</strong>.</p>
+    <p style="font-size:0.75em;color:var(--text-muted);margin-top:var(--space-4);">Multi-agent is the right answer sometimes. Not by default.</p>
+  </div>
+
+  <div class="slide" data-module="06" data-type="section-title" style="background:linear-gradient(135deg,var(--navy) 0%,var(--navy-light) 100%);">
+    <div class="topic-badge">Up next</div>
+    <h1>M07 &mdash; Callbacks as middleware</h1>
+    <p class="highlight-text">Six lifecycle hooks. Return-to-override. The blocklist-guardrail demo.</p>
+  </div>
+
+  </main>
+
+  <script src="../shared/slides.js"></script>
+</body>
+</html>

--- a/slides/module-06-multi-agent/speaker_notes.md
+++ b/slides/module-06-multi-agent/speaker_notes.md
@@ -1,0 +1,181 @@
+# M06 — Speaker notes
+
+Spoken delivery. One section per slide.
+
+---
+
+## Slide 1 — Title
+
+Module six. Multi-agent hierarchies. Module five gave you named, declarative workflow — Sequential, Parallel, Loop. This module gives you the other half: LLM-driven routing. When the user's input decides which specialist runs, you don't want a workflow agent. You want the LLM to route. ADK has two patterns for exactly this, and they look similar on the surface but behave very differently.
+
+---
+
+## Slide 2 — Three ways to combine agents
+
+Three ways, total, to compose agents in ADK.
+
+Workflow agents — that was module five. Declarative control flow, named primitives, you say Sequential or Parallel or Loop and the framework runs the pattern. Use them when you can name the workflow.
+
+Sub-agents — that's today. LLM-driven routing via transfer. The coordinator's LLM picks which specialist should take over, and ADK hands off control.
+
+AgentTool — also today. LLM-driven routing via function call. The coordinator picks which specialist to call, the specialist runs, the coordinator stays in charge.
+
+Today we focus on the two LLM-driven patterns.
+
+---
+
+## Slide 3 — The one question
+
+The one question that separates the two patterns — the only meaningful difference — is this. After the specialist finishes its work, who is in charge of the conversation? If the specialist is, you want sub_agents. If the coordinator is, you want AgentTool. That's the whole decision.
+
+---
+
+## Slide 4 — sub_agents header
+
+Pattern one. `sub_agents`. The org-chart transfer.
+
+---
+
+## Slide 5 — How sub_agents works
+
+The mechanics. You give the coordinator a `sub_agents=` list. ADK detects this and automatically injects a built-in tool called `transfer_to_agent`. You don't register it; it's just there.
+
+When the coordinator's model reads the user's message and decides a specialist fits, it emits a structured call — `transfer_to_agent(agent_name='weather_specialist')`. ADK catches that call and routes control to the named child. The child runs, produces a response, and that response is what the user sees.
+
+After the transfer, the child remains the active agent for the rest of the session by default. If the user sends a follow-up, it goes to the specialist — not back to the coordinator. The specialist owns the conversation.
+
+Think of it as an org chart. The coordinator is the manager reading the inbox; the specialist takes the meeting.
+
+One production-sensitive detail: the child's `description=` field is what the coordinator's LLM reads to decide whether to route there. Write descriptions for the model, not for a human reviewer. "Handles greetings" is fine; "Agent that greets users warmly and makes them feel welcome" is noise.
+
+---
+
+## Slide 6 — sub_agents code
+
+Here's the shape. Two specialists, each with a name, a description — that's the routing schema — and its own instruction. A coordinator that has both in its `sub_agents=` list. That's it. No routing code; ADK handles the transfer mechanism.
+
+---
+
+## Slide 7 — Live: transfer
+
+Switch to the notebook. Cells twelve and thirteen. Greeting first, weather second. Watch the event stream — you'll see `transfer_to_agent` as a tool call from the coordinator, and the specialist produces the final response.
+
+---
+
+## Slide 8 — Event stream of transfer
+
+Back on the slide. Here's what you saw. The coordinator emitted `transfer_to_agent` with `agent_name='weather_specialist'`. ADK routed. The weather specialist produced the final response.
+
+The key thing to notice is the **author** of the final response. It's the specialist, not the coordinator. That's the tell that this is a transfer pattern.
+
+---
+
+## Slide 9 — AgentTool header
+
+Pattern two. `AgentTool`. The consultant pattern.
+
+---
+
+## Slide 10 — How AgentTool works
+
+Same team, different wiring. Instead of putting the specialists in `sub_agents=`, you wrap each in `AgentTool(agent=...)` and put them in the coordinator's `tools=` list.
+
+Now to the coordinator's LLM, they look like tools — no different from a FunctionTool, an OpenAPI tool, an MCP tool. When the coordinator decides to use a specialist, it emits a regular function call — the same mechanism that triggers `get_weather` or `search_tickets` in earlier modules.
+
+ADK runs the specialist as a fresh LLM call. The specialist produces its output. That output comes back to the coordinator as a tool-response event. The coordinator reads it and produces the final user-facing reply itself.
+
+The specialist never gets the microphone. It answers a structured question, hands the result back, and the coordinator speaks on its behalf.
+
+---
+
+## Slide 11 — AgentTool code
+
+The same specialists we just saw, but now wrapped in `AgentTool` and placed in the coordinator's `tools=` list — not `sub_agents=`. That single word difference in the constructor is the whole behavioral difference.
+
+---
+
+## Slide 12 — Live: consultant
+
+Switch to the notebook. Cells eighteen and nineteen. Same prompts as before — greeting, weather. Watch the event stream carefully. Compare it to the transfer pattern you just saw.
+
+---
+
+## Slide 13 — Event stream — note the author
+
+Back on the slide. The coordinator called `weather_specialist` as a tool. A tool-response event came back with the result. Then the coordinator — not the specialist — produced the final reply.
+
+That's the consultant pattern. The specialist answered a specific question and stepped back. The coordinator remained in charge of speaking to the user.
+
+---
+
+## Slide 14 — Tell-tale sign
+
+The tell-tale sign, on one slide. Look at the author of the final response.
+
+If the specialist is the author, you're looking at a transfer. sub_agents pattern.
+
+If the coordinator is the author, you're looking at a consultant call. AgentTool pattern.
+
+That's the diagnostic. Print the event stream, read the last author, you know which pattern is in use.
+
+---
+
+## Slide 15 — When to pick which
+
+When to pick which.
+
+Use sub_agents — the transfer pattern — when the specialist should own the dialog. When the specialist might take multiple turns with the user before handing back. When a topic shift means the specialist is the right conversation partner for that whole topic. When you want the user to perceive they're talking to a specialist.
+
+Use AgentTool — the consultant pattern — when the specialist answers one question and steps back. When the specialist has a clean input/output contract. When the coordinator needs to compose the specialist's output with other sources — multiple tools, other specialists. When you want the user to perceive they're talking to one assistant that has specialists behind the scenes.
+
+---
+
+## Slide 16 — Concrete examples
+
+Two concrete examples to ground the rules.
+
+Sub_agents scenario. IT support desk with a billing specialist and a hardware specialist. User says "my laptop won't boot." Coordinator routes to hardware. Over the next five turns of the session, the hardware specialist walks the user through diagnosis — power, connections, BIOS, boot order. That's an extended conversation the coordinator shouldn't mediate. Transfer once; let the specialist handle the topic.
+
+AgentTool scenario. Coding assistant whose orchestrator wraps a specialist code-analyzer, a specialist docs-lookup, and a specialist test-runner. User asks "why is my test failing?" The orchestrator decides all three specialists are relevant, calls all three in one turn, reads their three tool-responses, synthesizes one answer. Each specialist contributes a single structured response; the orchestrator owns the composition.
+
+---
+
+## Slide 17 — Interlude header
+
+Two-minute interlude. Agentic Design Patterns, chapter eight. Multi-agent decomposition. Theory on when multi-agent architectures pay for their coordination tax — and when they don't.
+
+---
+
+## Slide 18 — Coordination tax
+
+Multi-agent architectures are fashionable. They're also expensive. Before you decompose a task into specialists, consider the coordination tax. It has three parts.
+
+Extra LLM calls. Every transfer, every AgentTool call, is an additional model invocation. A two-specialist system makes at least two calls per user turn — one to route, one to resolve. A five-specialist system can make ten or more. This compounds latency and cost in production.
+
+Routing errors. Every routing decision is a chance to pick the wrong specialist. The more specialists, the wider the miss surface. You have to design descriptions carefully enough that the coordinator's LLM never gets confused, and — when it inevitably does — your testing has to catch it.
+
+Context fragmentation. Each child has its own system prompt. Information you put in the coordinator's instruction does not automatically reach the children. Specialists sometimes fail because they lack context the coordinator had. In a monolithic single agent, this problem doesn't exist — there's one prompt.
+
+---
+
+## Slide 19 — Three tests
+
+Three tests from the publication to apply before you decompose.
+
+Reuse test. Will any of these specialists be used elsewhere — by a different top-level agent, in a different product, by a different team? If yes, decomposition makes sense because the specialists become reusable components. If no, consider staying with one agent and adding more tools.
+
+Model-heterogeneity test. Does each specialist benefit from a different model? Cheap routing decisions on Haiku, hard resolutions on Opus — that mix is only possible if you decompose. If all your specialists use the same model anyway, the decomposition buys you less.
+
+Instruction-scale test. Is a single system prompt getting unmanageable — five hundred lines with overlapping rules for different scenarios? Breaking it up into specialists with narrower prompts is a legitimate way to reduce each prompt to its core job. But if your single-agent prompt is thirty lines, don't split it just because you can.
+
+---
+
+## Slide 20 — The default
+
+The default, when none of the three tests pass. Keep it to one agent with tools. A single well-written agent with eight tools is almost always simpler, cheaper, and faster than a coordinator-plus-specialists architecture doing the same work. Multi-agent is sometimes the right answer. It is not the right answer by default.
+
+---
+
+## Slide 21 — Next
+
+Module seven. Callbacks as middleware. Six lifecycle hooks that wrap every invocation — before_agent, after_agent, before_model, after_model, before_tool, after_tool. Return None and things proceed normally. Return a response object and you short-circuit the LLM or tool altogether. Django middleware, Express middleware, plugin hooks — for agents. The blocklist-guardrail demo is small, visual, and the cleanest example in the course of code-level safety. See you there.

--- a/textbook/_sources/chapters/06-multi-agent.md
+++ b/textbook/_sources/chapters/06-multi-agent.md
@@ -1,0 +1,177 @@
+# Multi-agent hierarchies
+
+Chapter 05 gave you workflow agents — named, declarative control flow. `SequentialAgent`, `ParallelAgent`, `LoopAgent`. You use them when you can name the workflow: "always summarize, then translate," "always fan out these three researchers," "always refine with critic feedback."
+
+This chapter gives you the other half. **LLM-driven** control flow. When the user's input decides which specialist runs, you don't want a workflow agent. You want the LLM to route. ADK has two patterns for this.
+
+They look superficially similar. Both let the LLM decide which specialist fires next. They behave very differently once you pay attention to who is in charge of the conversation *after* the specialist finishes.
+
+- **`sub_agents`** — the coordinator *transfers* control to a specialist. The specialist owns the conversation. Call it the **org-chart** pattern.
+- **`AgentTool`** — the coordinator *calls* a specialist like a function. The coordinator stays in charge. Call it the **consultant** pattern.
+
+By the end of this chapter the same coordinator-plus-two-specialists team will be wired up both ways. The user's final-facing output looks identical; the event stream tells you which pattern is running.
+
+## The one question that separates them
+
+There is exactly one meaningful difference between `sub_agents` and `AgentTool`. Memorize it now; everything else is mechanics.
+
+**Who is in charge of the conversation after the specialist finishes?**
+
+If the specialist is — use `sub_agents`. If the coordinator is — use `AgentTool`. That's the whole decision.
+
+## Pattern 1 — `sub_agents`: the org-chart transfer
+
+The coordinator has a list of children in its `sub_agents=` parameter. ADK automatically injects a built-in tool called `transfer_to_agent` — you don't register it, it's just there whenever `sub_agents=` is set.
+
+When the coordinator's LLM reads the user's message and decides a specialist is more appropriate, it emits a structured call: `transfer_to_agent(agent_name='weather_specialist')`. ADK catches that call and routes control to the named child. The child runs, produces a response, and **the child's response is what the user sees**.
+
+After the transfer, the child remains the active agent for the rest of the session by default. If the user sends a follow-up, it goes to the specialist — not back to the coordinator. The specialist owns the conversation from that point, unless it itself transfers again.
+
+```python
+greeter = LlmAgent(
+    name="greeter",
+    model=MODEL,
+    description="Handles greetings and casual chat.",
+    instruction="Respond warmly in one short sentence.",
+)
+
+weather_specialist = LlmAgent(
+    name="weather_specialist",
+    model=MODEL,
+    description="Handles weather questions for any city.",
+    instruction="Produce a plausible one-sentence weather report.",
+)
+
+coordinator = LlmAgent(
+    name="coordinator",
+    model=MODEL,
+    description="Routes user queries to specialists.",
+    instruction="Delegate greetings to greeter, weather questions to weather_specialist.",
+    sub_agents=[greeter, weather_specialist],   # ← the org chart
+)
+```
+
+One production-sensitive detail: **the child's `description=` field is what the coordinator's LLM reads to decide routing.** Write descriptions for the model, not for a human reviewer. Ambiguous descriptions produce ambiguous routing.
+
+### The event stream of a transfer
+
+```
+USER: What's the weather in Prague?
+
+[coordinator_subagents] → transfer_to_agent({'agent_name': 'weather_specialist'})
+[weather_specialist]    The weather in Prague is partly cloudy with a gentle
+                        breeze and a temperature of 15 degrees Celsius.
+                        ^^^ final response comes from the SPECIALIST
+```
+
+Two observations. The coordinator emitted `transfer_to_agent` as a tool call; ADK caught it and routed. And the final response's author is `weather_specialist`, not `coordinator`. That is the tell-tale sign of the transfer pattern.
+
+## Pattern 2 — `AgentTool`: the consultant pattern
+
+Same team, different wiring. Instead of placing the specialists in `sub_agents=`, you wrap each as an `AgentTool` and put them in the coordinator's `tools=` list.
+
+Now — from the coordinator's LLM's perspective — the specialists look like **tools**. No different from a `FunctionTool`, an `OpenAPIToolset` entry, an MCP-server tool. When the coordinator decides a specialist is needed, it emits a regular function call. ADK runs the specialist, captures its output as a tool-response event, and feeds that back to the coordinator. **The coordinator reads the response and produces the final user-facing reply itself.**
+
+```python
+from google.adk.tools.agent_tool import AgentTool
+
+coordinator = LlmAgent(
+    name="coordinator",
+    model=MODEL,
+    instruction=(
+        "You have exactly two tools: `greeter` and `weather_specialist`. "
+        "Call one of them per user message; wrap their result in your own reply."
+    ),
+    tools=[
+        AgentTool(agent=greeter),
+        AgentTool(agent=weather_specialist),
+    ],
+)
+```
+
+Specialists in `tools=`, not `sub_agents=`. That single-word difference in the constructor is the whole behavioral difference.
+
+### The event stream of a consultant call
+
+```
+USER: What's the weather in Prague?
+
+[coordinator_tools] → weather_specialist({'request': 'Prague'})
+[tool_resp]            {'result': 'Prague will experience partly cloudy skies
+                        with a high of 18 degrees Celsius today.'}
+[coordinator_tools]    The weather in Prague will be partly cloudy with a
+                        high of 18 degrees Celsius today.
+                        ^^^ final response comes from the COORDINATOR,
+                            wrapping the specialist's output
+```
+
+Same user input. Same team. Different final-response author. The coordinator called the specialist like a function, got the result, and produced the reply itself — wrapping the specialist's output in its own voice.
+
+## The diagnostic
+
+To tell which pattern is running, look at the author of the final response.
+
+- **Specialist → transfer** (`sub_agents`).
+- **Coordinator → consultant** (`AgentTool`).
+
+Print the event stream, read the last author, you know which pattern is in use.
+
+## When to pick which
+
+| Use `sub_agents` (transfer) when... | Use `AgentTool` (consultant) when... |
+|---|---|
+| The specialist should **own the conversation** after routing | The specialist should **answer one question and step back** |
+| The child might take **multiple turns** with the user before handing back | The child has a clean **input/output contract** |
+| **Topic shifts** — the specialist is the right partner for the whole topic | The coordinator needs to **compose** the specialist's output with other sources |
+| User **perceives** talking to a specialist | User **perceives** one assistant with specialists behind the scenes |
+
+**Rule:** if the specialist's work is part of a larger answer that incorporates other information, use `AgentTool`. If the specialist's work *is* the answer, use `sub_agents`.
+
+Two concrete examples to ground the rule.
+
+**`sub_agents` scenario — IT support desk.** Billing specialist and hardware specialist. User says "my laptop won't boot." Coordinator routes to hardware. Over the next five turns of the session, the hardware specialist walks the user through diagnosis — power, cables, BIOS, boot order. That's an extended conversation the coordinator shouldn't mediate. Transfer once; let the specialist own the topic.
+
+**`AgentTool` scenario — coding assistant.** Orchestrator wraps a code-analyzer specialist, a docs-lookup specialist, and a test-runner specialist. User asks "why is my test failing?" The orchestrator decides all three are relevant, calls all three in one turn, reads their three tool-responses, synthesizes one answer. Each specialist contributes a single structured response; the orchestrator owns composition.
+
+## Interlude — Multi-agent decomposition
+
+*From "Agentic Design Patterns," Chapter 8. Two minutes on when to build multi-agent architectures — and when not to.*
+
+Multi-agent architectures are fashionable. They are also expensive. Before you decompose a task into several specialists, consider whether the **coordination tax** is worth paying.
+
+The tax has three parts:
+
+1. **Extra LLM calls.** Every transfer, every `AgentTool` call, is an additional model invocation. A two-specialist system makes at least two calls per turn. A five-specialist system can make ten or more. This compounds latency and API cost in production in ways that don't show up in a demo notebook.
+2. **Routing errors.** Every routing decision is a chance to pick the wrong specialist. The more specialists, the wider the miss surface. You must design descriptions carefully and evaluate routing accuracy separately from answer accuracy.
+3. **Context fragmentation.** Each child has its own system prompt. Information you put in the coordinator doesn't automatically reach the children. Specialists fail sometimes because they lack context the coordinator had.
+
+The publication proposes three tests before you decompose.
+
+### Test 1 — Reuse
+
+Will any of the specialists be used elsewhere — by a different top-level agent, in a different product, by a different team? If yes, decomposition is worth it — the specialists become reusable components with independent interfaces. If no, consider keeping everything in one agent with more tools.
+
+### Test 2 — Model heterogeneity
+
+Does each specialist benefit from a different model? Cheap routing decisions on Haiku, hard resolutions on Opus — that mix is only possible if you decompose. If all your specialists would use the same model anyway, the decomposition buys you less; the main win evaporates.
+
+### Test 3 — Instruction scale
+
+Is a single system prompt getting unmanageable — five hundred lines with overlapping rules for different scenarios? Breaking it up into specialists with narrower prompts is a legitimate way to reduce each prompt to its core job. But if your single-agent prompt is thirty lines, don't split it for sport.
+
+### If none of the three tests pass
+
+**Keep it to one agent with tools.** A single well-written agent with eight tools is almost always simpler, cheaper, and faster than a coordinator-plus-specialists architecture doing the same work. Multi-agent is sometimes the right answer. It is not the right answer by default.
+
+This is the most important takeaway from the chapter, and the one most commonly missed: multi-agent architectures are a means, not an end. The pattern only earns its complexity when at least one of the three tests passes.
+
+## What to carry forward
+
+- **`sub_agents` is the transfer pattern.** Coordinator's LLM emits `transfer_to_agent(name=...)`; ADK routes; the specialist owns the response.
+- **`AgentTool` is the consultant pattern.** Coordinator calls a specialist like a function; the coordinator composes the final reply.
+- **The diagnostic:** final-response author = specialist → transfer; coordinator → consultant.
+- **Child's `description=`** is the routing schema the coordinator's LLM reads. Write descriptions for the model.
+- **Multi-agent decomposition has a coordination tax.** Decompose only when the reuse, model-heterogeneity, or instruction-scale tests pass.
+- **Default:** one agent with tools. Multi-agent is a deliberate choice.
+
+Module 07 picks up callbacks. Six lifecycle hooks — `before_agent`, `after_agent`, `before_model`, `after_model`, `before_tool`, `after_tool` — that let you intercept, log, transform, or short-circuit any step in an agent's lifecycle. It is the cleanest mechanism in the framework for guardrails, caching, PII redaction, and per-agent-specific cross-cutting concerns.

--- a/textbook/index.html
+++ b/textbook/index.html
@@ -317,6 +317,7 @@ hr {
 <li><a href="#sessions-state-events-artifacts">3. Sessions, State, Events, Artifacts</a></li>
 <li><a href="#the-one-line-model-swap">4. The one-line model swap</a></li>
 <li><a href="#workflow-agents">5. Workflow agents</a></li>
+<li><a href="#multi-agent-hierarchies">6. Multi-agent hierarchies</a></li>
             </ul>
         </nav>
     </aside>
@@ -1180,6 +1181,157 @@ pipeline = SequentialAgent(
 <li><strong>Name it if you can.</strong> If you can name the workflow, use a workflow agent. If you can&rsquo;t, that&rsquo;s what M06 is for — LLM-driven routing.</li>
 </ul>
 <p>Module 06 picks up where this one leaves off. Where workflow agents give you control flow by declaration, <code>sub_agents</code> and <code>AgentTool</code> give you control flow driven by the LLM&rsquo;s judgment. Two patterns, different trade-offs, same underlying machinery.</p>
+        </section>
+
+        <section class="chapter" id="multi-agent-hierarchies">
+            <div class="chapter-number">Chapter 6</div>
+            <h1>Multi-agent hierarchies</h1>
+<p>Chapter 05 gave you workflow agents — named, declarative control flow. <code>SequentialAgent</code>, <code>ParallelAgent</code>, <code>LoopAgent</code>. You use them when you can name the workflow: &ldquo;always summarize, then translate,&rdquo; &ldquo;always fan out these three researchers,&rdquo; &ldquo;always refine with critic feedback.&rdquo;</p>
+<p>This chapter gives you the other half. <strong>LLM-driven</strong> control flow. When the user&rsquo;s input decides which specialist runs, you don&rsquo;t want a workflow agent. You want the LLM to route. ADK has two patterns for this.</p>
+<p>They look superficially similar. Both let the LLM decide which specialist fires next. They behave very differently once you pay attention to who is in charge of the conversation <em>after</em> the specialist finishes.</p>
+<ul>
+<li><strong><code>sub_agents</code></strong> — the coordinator <em>transfers</em> control to a specialist. The specialist owns the conversation. Call it the <strong>org-chart</strong> pattern.</li>
+<li><strong><code>AgentTool</code></strong> — the coordinator <em>calls</em> a specialist like a function. The coordinator stays in charge. Call it the <strong>consultant</strong> pattern.</li>
+</ul>
+<p>By the end of this chapter the same coordinator-plus-two-specialists team will be wired up both ways. The user&rsquo;s final-facing output looks identical; the event stream tells you which pattern is running.</p>
+<h2>The one question that separates them</h2>
+<p>There is exactly one meaningful difference between <code>sub_agents</code> and <code>AgentTool</code>. Memorize it now; everything else is mechanics.</p>
+<p><strong>Who is in charge of the conversation after the specialist finishes?</strong></p>
+<p>If the specialist is — use <code>sub_agents</code>. If the coordinator is — use <code>AgentTool</code>. That&rsquo;s the whole decision.</p>
+<h2>Pattern 1 — <code>sub_agents</code>: the org-chart transfer</h2>
+<p>The coordinator has a list of children in its <code>sub_agents=</code> parameter. ADK automatically injects a built-in tool called <code>transfer_to_agent</code> — you don&rsquo;t register it, it&rsquo;s just there whenever <code>sub_agents=</code> is set.</p>
+<p>When the coordinator&rsquo;s LLM reads the user&rsquo;s message and decides a specialist is more appropriate, it emits a structured call: <code>transfer_to_agent(agent_name='weather_specialist')</code>. ADK catches that call and routes control to the named child. The child runs, produces a response, and <strong>the child&rsquo;s response is what the user sees</strong>.</p>
+<p>After the transfer, the child remains the active agent for the rest of the session by default. If the user sends a follow-up, it goes to the specialist — not back to the coordinator. The specialist owns the conversation from that point, unless it itself transfers again.</p>
+<pre><code class="language-python">greeter = LlmAgent(
+    name=&quot;greeter&quot;,
+    model=MODEL,
+    description=&quot;Handles greetings and casual chat.&quot;,
+    instruction=&quot;Respond warmly in one short sentence.&quot;,
+)
+
+weather_specialist = LlmAgent(
+    name=&quot;weather_specialist&quot;,
+    model=MODEL,
+    description=&quot;Handles weather questions for any city.&quot;,
+    instruction=&quot;Produce a plausible one-sentence weather report.&quot;,
+)
+
+coordinator = LlmAgent(
+    name=&quot;coordinator&quot;,
+    model=MODEL,
+    description=&quot;Routes user queries to specialists.&quot;,
+    instruction=&quot;Delegate greetings to greeter, weather questions to weather_specialist.&quot;,
+    sub_agents=[greeter, weather_specialist],   # ← the org chart
+)
+</code></pre>
+<p>One production-sensitive detail: <strong>the child&rsquo;s <code>description=</code> field is what the coordinator&rsquo;s LLM reads to decide routing.</strong> Write descriptions for the model, not for a human reviewer. Ambiguous descriptions produce ambiguous routing.</p>
+<h3>The event stream of a transfer</h3>
+<pre><code>USER: What's the weather in Prague?
+
+[coordinator_subagents] → transfer_to_agent({'agent_name': 'weather_specialist'})
+[weather_specialist]    The weather in Prague is partly cloudy with a gentle
+                        breeze and a temperature of 15 degrees Celsius.
+                        ^^^ final response comes from the SPECIALIST
+</code></pre>
+<p>Two observations. The coordinator emitted <code>transfer_to_agent</code> as a tool call; ADK caught it and routed. And the final response&rsquo;s author is <code>weather_specialist</code>, not <code>coordinator</code>. That is the tell-tale sign of the transfer pattern.</p>
+<h2>Pattern 2 — <code>AgentTool</code>: the consultant pattern</h2>
+<p>Same team, different wiring. Instead of placing the specialists in <code>sub_agents=</code>, you wrap each as an <code>AgentTool</code> and put them in the coordinator&rsquo;s <code>tools=</code> list.</p>
+<p>Now — from the coordinator&rsquo;s LLM&rsquo;s perspective — the specialists look like <strong>tools</strong>. No different from a <code>FunctionTool</code>, an <code>OpenAPIToolset</code> entry, an MCP-server tool. When the coordinator decides a specialist is needed, it emits a regular function call. ADK runs the specialist, captures its output as a tool-response event, and feeds that back to the coordinator. <strong>The coordinator reads the response and produces the final user-facing reply itself.</strong></p>
+<pre><code class="language-python">from google.adk.tools.agent_tool import AgentTool
+
+coordinator = LlmAgent(
+    name=&quot;coordinator&quot;,
+    model=MODEL,
+    instruction=(
+        &quot;You have exactly two tools: `greeter` and `weather_specialist`. &quot;
+        &quot;Call one of them per user message; wrap their result in your own reply.&quot;
+    ),
+    tools=[
+        AgentTool(agent=greeter),
+        AgentTool(agent=weather_specialist),
+    ],
+)
+</code></pre>
+<p>Specialists in <code>tools=</code>, not <code>sub_agents=</code>. That single-word difference in the constructor is the whole behavioral difference.</p>
+<h3>The event stream of a consultant call</h3>
+<pre><code>USER: What's the weather in Prague?
+
+[coordinator_tools] → weather_specialist({'request': 'Prague'})
+[tool_resp]            {'result': 'Prague will experience partly cloudy skies
+                        with a high of 18 degrees Celsius today.'}
+[coordinator_tools]    The weather in Prague will be partly cloudy with a
+                        high of 18 degrees Celsius today.
+                        ^^^ final response comes from the COORDINATOR,
+                            wrapping the specialist's output
+</code></pre>
+<p>Same user input. Same team. Different final-response author. The coordinator called the specialist like a function, got the result, and produced the reply itself — wrapping the specialist&rsquo;s output in its own voice.</p>
+<h2>The diagnostic</h2>
+<p>To tell which pattern is running, look at the author of the final response.</p>
+<ul>
+<li><strong>Specialist → transfer</strong> (<code>sub_agents</code>).</li>
+<li><strong>Coordinator → consultant</strong> (<code>AgentTool</code>).</li>
+</ul>
+<p>Print the event stream, read the last author, you know which pattern is in use.</p>
+<h2>When to pick which</h2>
+<table>
+<thead>
+<tr>
+<th>Use <code>sub_agents</code> (transfer) when&hellip;</th>
+<th>Use <code>AgentTool</code> (consultant) when&hellip;</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>The specialist should <strong>own the conversation</strong> after routing</td>
+<td>The specialist should <strong>answer one question and step back</strong></td>
+</tr>
+<tr>
+<td>The child might take <strong>multiple turns</strong> with the user before handing back</td>
+<td>The child has a clean <strong>input/output contract</strong></td>
+</tr>
+<tr>
+<td><strong>Topic shifts</strong> — the specialist is the right partner for the whole topic</td>
+<td>The coordinator needs to <strong>compose</strong> the specialist&rsquo;s output with other sources</td>
+</tr>
+<tr>
+<td>User <strong>perceives</strong> talking to a specialist</td>
+<td>User <strong>perceives</strong> one assistant with specialists behind the scenes</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Rule:</strong> if the specialist&rsquo;s work is part of a larger answer that incorporates other information, use <code>AgentTool</code>. If the specialist&rsquo;s work <em>is</em> the answer, use <code>sub_agents</code>.</p>
+<p>Two concrete examples to ground the rule.</p>
+<p><strong><code>sub_agents</code> scenario — IT support desk.</strong> Billing specialist and hardware specialist. User says &ldquo;my laptop won&rsquo;t boot.&rdquo; Coordinator routes to hardware. Over the next five turns of the session, the hardware specialist walks the user through diagnosis — power, cables, BIOS, boot order. That&rsquo;s an extended conversation the coordinator shouldn&rsquo;t mediate. Transfer once; let the specialist own the topic.</p>
+<p><strong><code>AgentTool</code> scenario — coding assistant.</strong> Orchestrator wraps a code-analyzer specialist, a docs-lookup specialist, and a test-runner specialist. User asks &ldquo;why is my test failing?&rdquo; The orchestrator decides all three are relevant, calls all three in one turn, reads their three tool-responses, synthesizes one answer. Each specialist contributes a single structured response; the orchestrator owns composition.</p>
+<h2>Interlude — Multi-agent decomposition</h2>
+<p><em>From &ldquo;Agentic Design Patterns,&rdquo; Chapter 8. Two minutes on when to build multi-agent architectures — and when not to.</em></p>
+<p>Multi-agent architectures are fashionable. They are also expensive. Before you decompose a task into several specialists, consider whether the <strong>coordination tax</strong> is worth paying.</p>
+<p>The tax has three parts:</p>
+<ol>
+<li><strong>Extra LLM calls.</strong> Every transfer, every <code>AgentTool</code> call, is an additional model invocation. A two-specialist system makes at least two calls per turn. A five-specialist system can make ten or more. This compounds latency and API cost in production in ways that don&rsquo;t show up in a demo notebook.</li>
+<li><strong>Routing errors.</strong> Every routing decision is a chance to pick the wrong specialist. The more specialists, the wider the miss surface. You must design descriptions carefully and evaluate routing accuracy separately from answer accuracy.</li>
+<li><strong>Context fragmentation.</strong> Each child has its own system prompt. Information you put in the coordinator doesn&rsquo;t automatically reach the children. Specialists fail sometimes because they lack context the coordinator had.</li>
+</ol>
+<p>The publication proposes three tests before you decompose.</p>
+<h3>Test 1 — Reuse</h3>
+<p>Will any of the specialists be used elsewhere — by a different top-level agent, in a different product, by a different team? If yes, decomposition is worth it — the specialists become reusable components with independent interfaces. If no, consider keeping everything in one agent with more tools.</p>
+<h3>Test 2 — Model heterogeneity</h3>
+<p>Does each specialist benefit from a different model? Cheap routing decisions on Haiku, hard resolutions on Opus — that mix is only possible if you decompose. If all your specialists would use the same model anyway, the decomposition buys you less; the main win evaporates.</p>
+<h3>Test 3 — Instruction scale</h3>
+<p>Is a single system prompt getting unmanageable — five hundred lines with overlapping rules for different scenarios? Breaking it up into specialists with narrower prompts is a legitimate way to reduce each prompt to its core job. But if your single-agent prompt is thirty lines, don&rsquo;t split it for sport.</p>
+<h3>If none of the three tests pass</h3>
+<p><strong>Keep it to one agent with tools.</strong> A single well-written agent with eight tools is almost always simpler, cheaper, and faster than a coordinator-plus-specialists architecture doing the same work. Multi-agent is sometimes the right answer. It is not the right answer by default.</p>
+<p>This is the most important takeaway from the chapter, and the one most commonly missed: multi-agent architectures are a means, not an end. The pattern only earns its complexity when at least one of the three tests passes.</p>
+<h2>What to carry forward</h2>
+<ul>
+<li><strong><code>sub_agents</code> is the transfer pattern.</strong> Coordinator&rsquo;s LLM emits <code>transfer_to_agent(name=...)</code>; ADK routes; the specialist owns the response.</li>
+<li><strong><code>AgentTool</code> is the consultant pattern.</strong> Coordinator calls a specialist like a function; the coordinator composes the final reply.</li>
+<li><strong>The diagnostic:</strong> final-response author = specialist → transfer; coordinator → consultant.</li>
+<li><strong>Child&rsquo;s <code>description=</code></strong> is the routing schema the coordinator&rsquo;s LLM reads. Write descriptions for the model.</li>
+<li><strong>Multi-agent decomposition has a coordination tax.</strong> Decompose only when the reuse, model-heterogeneity, or instruction-scale tests pass.</li>
+<li><strong>Default:</strong> one agent with tools. Multi-agent is a deliberate choice.</li>
+</ul>
+<p>Module 07 picks up callbacks. Six lifecycle hooks — <code>before_agent</code>, <code>after_agent</code>, <code>before_model</code>, <code>after_model</code>, <code>before_tool</code>, <code>after_tool</code> — that let you intercept, log, transform, or short-circuit any step in an agent&rsquo;s lifecycle. It is the cleanest mechanism in the framework for guardrails, caching, PII redaction, and per-agent-specific cross-cutting concerns.</p>
         </section>
         </main>
     </div>


### PR DESCRIPTION
## Summary

Module 06 — the two LLM-driven routing patterns side-by-side. \`sub_agents\` (transfer; org-chart) vs \`AgentTool\` (consultant). Same coordinator + two specialists wired both ways so the event-stream contrast is visible. Plus the Agentic Design Patterns Chapter 8 interlude on when multi-agent is worth the coordination tax.

## What ships

- \`slides/module-06-multi-agent/index.html\` — 23-slide deck
- \`slides/module-06-multi-agent/speaker_notes.md\`
- \`textbook/_sources/chapters/06-multi-agent.md\` — textbook now 7 chapters
- \`notebooks/06_multi_agent.ipynb\` — both patterns end-to-end, runs clean
- \`index.html\` — M06 flipped to Ready

## Demos verified

| Pattern | Event stream | Final-response author |
|---|---|---|
| \`sub_agents\` | coordinator → \`transfer_to_agent\` → specialist produces final text | **specialist** |
| \`AgentTool\` | coordinator → \`specialist(request=...)\` → tool_resp → coordinator wraps | **coordinator** |

The diagnostic taught in M06: look at the author of the final response. Specialist → transfer. Coordinator → consultant.

## Interlude — multi-agent decomposition

The coordination tax has three parts: extra LLM calls, routing errors, context fragmentation. Three tests before decomposing:

1. **Reuse** — will specialists be used elsewhere?
2. **Model heterogeneity** — does each benefit from a different model?
3. **Instruction scale** — is one prompt getting unmanageable?

If none pass, default to one agent with tools.

## Test log

\`\`\`
jupyter nbconvert --execute notebooks/06_multi_agent.ipynb
# → PASS, both routing demos produce expected event streams.

python3 textbook/_sources/tools/build_html.py
# → 7 chapters
\`\`\`

Cost: ~\$0.002 on OpenRouter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)