### PR TITLE
course(M09): evaluation — trajectory, ROUGE-1, LLM-as-judge

### DIFF
--- a/index.html
+++ b/index.html
@@ -289,14 +289,14 @@
       <div class="status ready">Ready</div>
     </a>
 
-    <div class="module soon">
+    <a class="module" href="slides/module-09-evaluation/index.html">
       <div class="num">M09</div>
       <div>
         <div class="title">Evaluation</div>
         <div class="desc">Trajectory tests, EvalSets, <code>AgentEvaluator</code>.</div>
       </div>
-      <div class="status soon">Soon</div>
-    </div>
+      <div class="status ready">Ready</div>
+    </a>
 
     <div class="module soon">
       <div class="num">M10</div>

--- a/notebooks/09_evaluation.ipynb
+++ b/notebooks/09_evaluation.ipynb
@@ -1,0 +1,506 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "484d7288",
+   "metadata": {},
+   "source": [
+    "# Module 09 — Evaluation\n",
+    "\n",
+    "Eight modules of \"does the agent work?\" answered by eyeballing the event stream. Module 9 is where we stop doing that.\n",
+    "\n",
+    "ADK ships an evaluation framework. You describe a conversation as a test case — input, expected tool trajectory, expected response — and the framework runs the agent, compares what actually happened against what you expected, and reports a pass/fail. Two metrics out of the box:\n",
+    "\n",
+    "- **`tool_trajectory_avg_score`** — did the agent call the right tools in the right order?\n",
+    "- **`response_match_score`** — how close is the model's actual text to the expected text? (ROUGE-1 overlap.)\n",
+    "\n",
+    "The trajectory metric is the novel one. Most eval frameworks focus on final-output quality; ADK weights *how the agent got there* equally. This is the right framing for tool-heavy agents — a correct answer via the wrong reasoning is a bug waiting to happen.\n",
+    "\n",
+    "**What you'll build:**\n",
+    "- A `.test.json` eval file with an expected tool trajectory and expected response.\n",
+    "- A programmatic call to `AgentEvaluator.evaluate` that scores your agent.\n",
+    "- An honest look at why the default response_match threshold (0.8 ROUGE-1) fails on semantically-correct-but-worded-differently answers — and what you do about it in production (LLM-as-judge).\n",
+    "\n",
+    "**Running cost:** under $0.01."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eedee832",
+   "metadata": {},
+   "source": [
+    "# Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c9f86665",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# google-adk[eval] brings in scikit-learn, rouge-score, and the eval helpers.\n",
+    "!pip install -q 'google-adk[eval]==1.28.0' litellm==1.83.4 python-dotenv==1.0.1 nest-asyncio==1.6.0 deprecated==1.2.18 2>/dev/null\n",
+    "print(\"✅ Packages installed.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38b7fa3e",
+   "metadata": {},
+   "source": [
+    "## API Key"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "484feed0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "OPENROUTER_API_KEY = None\n",
+    "try:\n",
+    "    from google.colab import userdata\n",
+    "    OPENROUTER_API_KEY = userdata.get(\"OPENROUTER_API_KEY\")\n",
+    "    print(\"✅ API key loaded from Colab secrets.\")\n",
+    "except Exception:\n",
+    "    try:\n",
+    "        from dotenv import load_dotenv; load_dotenv()\n",
+    "        OPENROUTER_API_KEY = os.getenv(\"OPENROUTER_API_KEY\")\n",
+    "        if OPENROUTER_API_KEY: print(\"✅ API key loaded from .env file.\")\n",
+    "    except ImportError: pass\n",
+    "if not OPENROUTER_API_KEY:\n",
+    "    from getpass import getpass\n",
+    "    OPENROUTER_API_KEY = getpass(\"Enter your OpenRouter API key: \")\n",
+    "os.environ[\"OPENROUTER_API_KEY\"] = OPENROUTER_API_KEY\n",
+    "print(\"✅ Key configured.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9cf16043",
+   "metadata": {},
+   "source": [
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "50261898",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, warnings, asyncio, logging, tempfile, json, shutil\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "try: sys.stderr.fileno()\n",
+    "except Exception: sys.stderr = open(os.devnull, \"w\")\n",
+    "\n",
+    "import nest_asyncio; nest_asyncio.apply()\n",
+    "import litellm; litellm.suppress_debug_info = True\n",
+    "logging.getLogger(\"LiteLLM\").setLevel(logging.WARNING)\n",
+    "\n",
+    "from google.adk.evaluation import AgentEvaluator\n",
+    "\n",
+    "print(\"✅ Imports successful.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f553d03d",
+   "metadata": {},
+   "source": [
+    "# The Two Metrics\n",
+    "\n",
+    "| Metric | Asks | Scale | Default threshold |\n",
+    "|---|---|---|---|\n",
+    "| `tool_trajectory_avg_score` | Did the agent call the right tools in the right order with the right args? | 0–1 | 1.0 (strict) |\n",
+    "| `response_match_score` | How similar is the actual final response to the expected one? | 0–1 (ROUGE-1) | 0.8 |\n",
+    "\n",
+    "Trajectory is strict: every expected tool call must appear with matching name and args. You'll often run with a slightly lower threshold during development, tighten as the agent matures.\n",
+    "\n",
+    "Response match uses **ROUGE-1** — unigram overlap between expected and actual text. It is an embarrassingly crude metric for natural-language responses. We'll see it fail in a way that demonstrates why."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37e5e48b",
+   "metadata": {},
+   "source": [
+    "# The Agent Module\n",
+    "\n",
+    "`AgentEvaluator.evaluate` expects an **importable Python module** containing a `root_agent`. We'll write that module to a temp directory and then point the evaluator at it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "269e1936",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up a temp directory to hold the agent module + eval file.\n",
+    "EVAL_DIR = tempfile.mkdtemp(prefix=\"adk_m09_\")\n",
+    "AGENT_DIR = os.path.join(EVAL_DIR, \"eval_demo_agent\")\n",
+    "os.makedirs(AGENT_DIR, exist_ok=True)\n",
+    "\n",
+    "# __init__.py makes it an importable package.\n",
+    "with open(os.path.join(AGENT_DIR, \"__init__.py\"), \"w\") as f:\n",
+    "    f.write(\"\")\n",
+    "\n",
+    "# The agent module itself. `root_agent` is the conventional name the evaluator looks for.\n",
+    "AGENT_CODE = (\n",
+    "    \"import os\\n\"\n",
+    "    \"from dotenv import load_dotenv\\n\"\n",
+    "    \"load_dotenv()\\n\"\n",
+    "    \"\\n\"\n",
+    "    \"from google.adk.agents import LlmAgent\\n\"\n",
+    "    \"from google.adk.models.lite_llm import LiteLlm\\n\"\n",
+    "    \"\\n\"\n",
+    "    \"def get_weather(city: str) -> dict:\\n\"\n",
+    "    \"    'Look up today\\u2019s weather for a city.'\\n\"\n",
+    "    \"    db = {\\n\"\n",
+    "    \"        'Bratislava': {'city': 'Bratislava', 'condition': 'Sunny', 'temperature_c': 18},\\n\"\n",
+    "    \"        'Prague': {'city': 'Prague', 'condition': 'Cloudy', 'temperature_c': 14},\\n\"\n",
+    "    \"        'Munich': {'city': 'Munich', 'condition': 'Rainy', 'temperature_c': 11},\\n\"\n",
+    "    \"    }\\n\"\n",
+    "    \"    return db.get(city, {'error': f'No data for {city}'})\\n\"\n",
+    "    \"\\n\"\n",
+    "    \"root_agent = LlmAgent(\\n\"\n",
+    "    \"    name='weather_agent',\\n\"\n",
+    "    \"    model=LiteLlm(model='openrouter/google/gemini-2.5-flash-lite'),\\n\"\n",
+    "    \"    description='Reports weather for European cities.',\\n\"\n",
+    "    \"    instruction=(\\n\"\n",
+    "    \"        'You report weather. Use get_weather to fetch the condition and '\\n\"\n",
+    "    \"        'Celsius temperature. Answer in one sentence.'\\n\"\n",
+    "    \"    ),\\n\"\n",
+    "    \"    tools=[get_weather],\\n\"\n",
+    "    \")\\n\"\n",
+    ")\n",
+    "\n",
+    "with open(os.path.join(AGENT_DIR, \"agent.py\"), \"w\") as f:\n",
+    "    f.write(AGENT_CODE)\n",
+    "\n",
+    "# Make the temp dir importable.\n",
+    "if EVAL_DIR not in sys.path:\n",
+    "    sys.path.insert(0, EVAL_DIR)\n",
+    "\n",
+    "print(f\"✅ Agent module at {AGENT_DIR}\")\n",
+    "print(f\"   Module path: eval_demo_agent.agent\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3db3beb4",
+   "metadata": {},
+   "source": [
+    "# The Eval File — `.test.json`\n",
+    "\n",
+    "The eval-set file is a JSON document with one or more test cases. Each case has a conversation (one or more user turns), each turn declares:\n",
+    "\n",
+    "- **`user_content`** — what the user says.\n",
+    "- **`final_response`** — what you expect the model to ultimately reply with.\n",
+    "- **`intermediate_data.tool_uses`** — what tools you expect called, with args.\n",
+    "- **`session_input`** — optional; pre-populated session state to start from.\n",
+    "\n",
+    "You can author these by hand, or — more practically — **run the agent in `adk web`, then click \"Save as eval\" on a conversation you like**. That exports this exact format. The programmatic path below is the same thing with different ergonomics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d8b28c5b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "EVAL_SET = {\n",
+    "    \"eval_set_id\": \"weather_basic\",\n",
+    "    \"name\": \"weather basic\",\n",
+    "    \"description\": \"One test case for the weather agent.\",\n",
+    "    \"eval_cases\": [\n",
+    "        {\n",
+    "            \"eval_id\": \"case_prague\",\n",
+    "            \"conversation\": [\n",
+    "                {\n",
+    "                    \"invocation_id\": \"inv-1\",\n",
+    "                    \"user_content\": {\n",
+    "                        \"parts\": [{\"text\": \"What is the weather in Prague?\"}],\n",
+    "                        \"role\": \"user\",\n",
+    "                    },\n",
+    "                    \"final_response\": {\n",
+    "                        \"parts\": [{\"text\": \"The weather in Prague is cloudy and 14 degrees Celsius.\"}],\n",
+    "                        \"role\": \"model\",\n",
+    "                    },\n",
+    "                    \"intermediate_data\": {\n",
+    "                        \"tool_uses\": [\n",
+    "                            {\"name\": \"get_weather\", \"args\": {\"city\": \"Prague\"}}\n",
+    "                        ],\n",
+    "                        \"intermediate_responses\": [],\n",
+    "                    },\n",
+    "                }\n",
+    "            ],\n",
+    "            \"session_input\": {\n",
+    "                \"app_name\": \"weather_agent\",\n",
+    "                \"user_id\": \"tester\",\n",
+    "                \"state\": {},\n",
+    "            },\n",
+    "        }\n",
+    "    ],\n",
+    "}\n",
+    "\n",
+    "EVAL_FILE = os.path.join(EVAL_DIR, \"weather.test.json\")\n",
+    "with open(EVAL_FILE, \"w\") as f:\n",
+    "    json.dump(EVAL_SET, f, indent=2)\n",
+    "\n",
+    "print(f\"✅ Eval set written to {EVAL_FILE}\")\n",
+    "print(f\"   {len(EVAL_SET['eval_cases'])} case(s)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c035768e",
+   "metadata": {},
+   "source": [
+    "# Run the Evaluation\n",
+    "\n",
+    "`AgentEvaluator.evaluate()` loads the agent module, loads the eval file, runs the agent against each case, scores the result against the default thresholds, and raises `AssertionError` if anything falls below threshold."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6a067e42",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set a strict threshold to make the ROUGE-1 weakness visible.\n",
+    "# Default is 0.8; we bump to 0.95 — almost impossible for free-form text.\n",
+    "STRICT_CONFIG = {\n",
+    "    \"criteria\": {\n",
+    "        \"tool_trajectory_avg_score\": 1.0,\n",
+    "        \"response_match_score\": 0.95,\n",
+    "    }\n",
+    "}\n",
+    "with open(os.path.join(EVAL_DIR, \"test_config.json\"), \"w\") as f:\n",
+    "    json.dump(STRICT_CONFIG, f, indent=2)\n",
+    "\n",
+    "# Clear the old module from sys.modules so changes are picked up.\n",
+    "for mod in list(sys.modules):\n",
+    "    if mod.startswith(\"eval_demo_agent\"):\n",
+    "        del sys.modules[mod]\n",
+    "\n",
+    "try:\n",
+    "    await AgentEvaluator.evaluate(\n",
+    "        agent_module=\"eval_demo_agent.agent\",\n",
+    "        eval_dataset_file_path_or_dir=EVAL_FILE,\n",
+    "        num_runs=1,\n",
+    "    )\n",
+    "    print(\"\\n✅ All eval cases passed.\")\n",
+    "except AssertionError as e:\n",
+    "    print(f\"\\n❌ Eval failed with a strict threshold — see the table above.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fa784c23",
+   "metadata": {},
+   "source": [
+    "Read the output carefully. Two things will have happened.\n",
+    "\n",
+    "1. **`tool_trajectory_avg_score` passed** — the agent called `get_weather({'city': 'Prague'})`, which matches the expected trajectory. Trajectory is strict; exact tool name and args must match.\n",
+    "2. **`response_match_score` very likely failed** — the agent produced something like *\"The weather in Prague is Cloudy with a temperature of 14°C\"*, the expected was *\"The weather in Prague is cloudy and 14 degrees Celsius\"*. ROUGE-1 overlap is ~0.63 against a threshold of 0.8. **Same information, different words.**\n",
+    "\n",
+    "This is the most important thing to internalize about ADK's default eval: **trajectory testing is useful; ROUGE-1 response matching is weak.** ROUGE-1 punishes legitimate stylistic variation. Don't rely on it for production; it's a sanity check at best."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b69b0d1f",
+   "metadata": {},
+   "source": [
+    "# Adjusting Thresholds — `test_config.json`\n",
+    "\n",
+    "You can drop a `test_config.json` next to your test file to customize thresholds:\n",
+    "\n",
+    "```json\n",
+    "{\n",
+    "  \"criteria\": {\n",
+    "    \"tool_trajectory_avg_score\": 1.0,\n",
+    "    \"response_match_score\": 0.5\n",
+    "  }\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "`0.5` lets through responses with only 50% unigram overlap — permissive, probably too permissive. `1.0` is \"exact match\" — impossible for anything longer than a few words.\n",
+    "\n",
+    "**Working range in practice:** 0.6–0.7 for short responses; give up on `response_match_score` for long-form text. We'll configure a permissive threshold below and watch the test pass."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6d48773c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "CONFIG = {\n",
+    "    \"criteria\": {\n",
+    "        \"tool_trajectory_avg_score\": 1.0,   # stay strict on trajectory\n",
+    "        \"response_match_score\": 0.3,        # very permissive on text match\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "with open(os.path.join(EVAL_DIR, \"test_config.json\"), \"w\") as f:\n",
+    "    json.dump(CONFIG, f, indent=2)\n",
+    "\n",
+    "# Reload and re-run.\n",
+    "for mod in list(sys.modules):\n",
+    "    if mod.startswith(\"eval_demo_agent\"):\n",
+    "        del sys.modules[mod]\n",
+    "\n",
+    "try:\n",
+    "    await AgentEvaluator.evaluate(\n",
+    "        agent_module=\"eval_demo_agent.agent\",\n",
+    "        eval_dataset_file_path_or_dir=EVAL_FILE,\n",
+    "        num_runs=1,\n",
+    "    )\n",
+    "    print(\"\\n✅ All eval cases passed with the permissive threshold.\")\n",
+    "except AssertionError as e:\n",
+    "    print(f\"\\n❌ Still failed:\")\n",
+    "    print(str(e)[:1500])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8698ca88",
+   "metadata": {},
+   "source": [
+    "With the threshold dropped to 0.3, the test passes. This is not a win — it's an admission that ROUGE-1 is the wrong metric. You've gained \"my test turned green\" and lost any signal about response quality.\n",
+    "\n",
+    "For real work, replace `response_match_score` with an **LLM-as-judge** evaluator."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3946fa78",
+   "metadata": {},
+   "source": [
+    "# The Real-World Upgrade — LLM-as-Judge\n",
+    "\n",
+    "Production eval uses an LLM to grade responses. Roughly:\n",
+    "\n",
+    "```python\n",
+    "# Pseudocode — not built into ADK today, but straightforward to wire up\n",
+    "def judge(prompt, expected, actual) -> float:\n",
+    "    judge_llm_response = judge_llm(\n",
+    "        f\"Is this response a reasonable answer to this prompt?\\n\"\n",
+    "        f\"Prompt: {prompt}\\nExpected: {expected}\\nActual: {actual}\\n\"\n",
+    "        f\"Score 0-1 on semantic correctness. Just the number.\"\n",
+    "    )\n",
+    "    return float(judge_llm_response.strip())\n",
+    "```\n",
+    "\n",
+    "ADK 1.29+ ships a Gen AI Evaluation Service integration that does this for you (Public Preview). Vertex AI users can point their ADK eval sets at it and get LLM-graded metrics alongside trajectory. Self-hosters wire the judge themselves with a second LiteLLM call.\n",
+    "\n",
+    "**What matters is the shift in framing:** trajectory tells you *the agent did the right things*; LLM-judge tells you *the agent said the right thing*. Both matter; neither is ROUGE-1."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e2f49ef7",
+   "metadata": {},
+   "source": [
+    "# The `adk eval` CLI Loop\n",
+    "\n",
+    "Everything above ran programmatically. In daily development, you'd use the CLI instead:\n",
+    "\n",
+    "```bash\n",
+    "# Step 1: Run the agent in the dev UI.\n",
+    "adk web\n",
+    "\n",
+    "# ... have a conversation, click \"Save as eval\", enter a name.\n",
+    "# That writes a .test.json next to your agent.\n",
+    "\n",
+    "# Step 2: Iterate.\n",
+    "adk eval ./my_agent ./my_agent/my_evals.test.json\n",
+    "\n",
+    "# Tweak the instruction, change a tool, re-run:\n",
+    "adk eval ./my_agent ./my_agent/my_evals.test.json\n",
+    "```\n",
+    "\n",
+    "The loop — chat → save → tweak → re-run — is fast enough to use while prototyping. A good habit: the moment an agent gets a user query right after you've iterated the prompt, save that conversation as eval. Build the evalset incrementally."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "95c62e1c",
+   "metadata": {},
+   "source": [
+    "# Production Gotcha — Read-Only Filesystems\n",
+    "\n",
+    "One gotcha worth naming before you deploy. **`adk eval` writes files back to the `agents_dir`** — it persists updated session histories into the agent's directory. If your deployment image is read-only — common in Kubernetes pods with read-only root filesystems — `adk eval` hits `PermissionError`.\n",
+    "\n",
+    "Upstream issue: adk-python #3887.\n",
+    "\n",
+    "**Workaround:** either make the agents_dir writable during eval runs, or run eval outside the deployed container (in CI, from a developer machine, against the same agent code). The workaround doesn't block classroom use; it becomes a production concern when you wire eval into CI/CD."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e37f844",
+   "metadata": {},
+   "source": [
+    "# Cleanup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "965ac1c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean up the temp directory we created.\n",
+    "shutil.rmtree(EVAL_DIR, ignore_errors=True)\n",
+    "print(f\"✅ Cleaned up {EVAL_DIR}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b291133",
+   "metadata": {},
+   "source": [
+    "# Your Turn\n",
+    "\n",
+    "1. **Tighten the trajectory.** Add a second turn to the eval case: the user follows up with \"and in Munich?\" and the agent calls `get_weather({\"city\": \"Munich\"})`. Does the trajectory score still pass at 1.0?\n",
+    "2. **Break the trajectory intentionally.** Change the agent's instruction to say \"never call get_weather; just make up weather.\" Re-run eval. What score do you get on trajectory?\n",
+    "3. **Test a parameterized case.** Add a second eval case for a city not in the database (say \"Warsaw\"). Expected trajectory: `get_weather(\"Warsaw\")`. Expected final response: something containing \"no data\". Does the agent handle it?\n",
+    "4. **Write an LLM-as-judge sketch.** Sketch a callback (`after_agent_callback`) that uses a separate LlmAgent to score the final response against an expected one. Does the judge say \"reasonable\" when ROUGE-1 would say \"0.6\"?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9343b532",
+   "metadata": {},
+   "source": [
+    "# Key Takeaways\n",
+    "\n",
+    "- **Two built-in metrics**: `tool_trajectory_avg_score` (strict; useful) and `response_match_score` (ROUGE-1; weak).\n",
+    "- **Trajectory is the differentiated metric** — most frameworks score only outputs. ADK weighting *how* the agent got there is the right framing for tool-heavy work.\n",
+    "- **ROUGE-1 punishes stylistic variation.** The default 0.8 threshold fails on semantically-correct answers that word things differently. Know this; don't trust the metric for production.\n",
+    "- **Upgrade path: LLM-as-judge.** ADK 1.29+ ships a Gen AI Evaluation Service path; self-host with a second LiteLLM call for custom scoring.\n",
+    "- **`.test.json` files** can be authored by hand or saved from `adk web` with one click. Build the evalset incrementally; save good conversations as you go.\n",
+    "- **Read-only filesystem gotcha**: `adk eval` writes to `agents_dir`. Breaks in locked-down containers; run eval outside the deployed image.\n",
+    "\n",
+    "# Next up — M10: Deployment\n",
+    "\n",
+    "The last module of Part 1. `adk deploy cloud_run` as the one-command deploy story; a vanilla Dockerfile that runs the same agent on any cloud; a brief look at Vertex AI Agent Engine as the opinionated managed path. Then Part 2 starts — Gemini-specific features."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/slides/module-09-evaluation/index.html
+++ b/slides/module-09-evaluation/index.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ADK Course — M09: Evaluation</title>
+  <link rel="stylesheet" href="../shared/shared.css">
+  <link rel="stylesheet" href="../shared/slides.css">
+</head>
+<body>
+  <nav class="progress-strip">
+    <a href="../../index.html" class="progress-home">Course</a>
+    <div class="progress-title">M09 — Evaluation</div>
+    <div class="progress-meta">
+      <span class="slide-counter">1 / 1</span>
+      <button class="theme-toggle">Theme</button>
+    </div>
+  </nav>
+
+  <main class="slide-viewport">
+
+  <div class="slide active" data-module="09" data-type="section-title">
+    <div class="topic-badge">Module 09 &middot; Part 1 Vendor-agnostic</div>
+    <h1>Evaluation</h1>
+    <h3>Beyond eyeballing the event stream</h3>
+    <p class="highlight-text">Trajectory testing is the real differentiator.</p>
+  </div>
+
+  <div class="slide" data-module="09" data-type="keyfact">
+    <h2 class="text-muted" style="border-bottom:none;font-size:1em;text-transform:uppercase;letter-spacing:0.08em;">Eight modules of</h2>
+    <p><em>"does the agent work?"</em></p>
+    <h2 class="text-muted" style="border-bottom:none;font-size:1em;text-transform:uppercase;letter-spacing:0.08em;margin-top:var(--space-6);">answered by</h2>
+    <p><strong>eyeballing the event stream</strong>.</p>
+    <p style="font-size:0.7em;color:var(--text-muted);margin-top:var(--space-4);">Module 9 stops doing that.</p>
+  </div>
+
+  <div class="slide" data-module="09">
+    <h2>Two built-in metrics</h2>
+    <table>
+      <thead><tr><th>Metric</th><th>Asks</th><th>Scale</th><th>Default</th></tr></thead>
+      <tbody>
+        <tr><td><code>tool_trajectory_avg_score</code></td><td>Right tools, right order, right args?</td><td>0-1</td><td>1.0 (strict)</td></tr>
+        <tr><td><code>response_match_score</code></td><td>Final text close to expected?</td><td>0-1 (ROUGE-1)</td><td>0.8</td></tr>
+      </tbody>
+    </table>
+    <p><strong>Trajectory is the novel one.</strong> Most eval frameworks score outputs only. ADK weighting <em>how the agent got there</em> matches tool-heavy reality.</p>
+  </div>
+
+  <div class="slide" data-module="09" data-type="keyfact">
+    <h2 class="text-muted" style="border-bottom:none;font-size:1em;text-transform:uppercase;letter-spacing:0.08em;">Why trajectory matters</h2>
+    <p>A correct answer via the wrong reasoning<br>is a <strong>bug waiting to happen</strong>.</p>
+  </div>
+
+  <div class="slide" data-module="09">
+    <h2>The eval loop in daily use</h2>
+<pre class="diagram">┌─────────────────────────────────────────────────────────┐
+│                                                         │
+│   adk web  ──▶ chat with agent                          │
+│                    │                                    │
+│                    ▼                                    │
+│             "Save as eval" button                       │
+│                    │                                    │
+│                    ▼                                    │
+│           .test.json file appears                       │
+│                                                         │
+│   adk eval ./my_agent ./my_agent/tests.test.json        │
+│                    │                                    │
+│                    ▼                                    │
+│             pass / fail report                          │
+│                    │                                    │
+│     tweak agent ──┘ (repeat)                            │
+│                                                         │
+└─────────────────────────────────────────────────────────┘</pre>
+    <p>Chat, save, tweak, re-run. Build the evalset <strong>incrementally</strong> as you iterate on the agent.</p>
+  </div>
+
+  <div class="slide" data-module="09" data-type="code">
+    <h2>A minimal <code>.test.json</code></h2>
+<pre><code>{
+  "eval_cases": [{
+    "eval_id": "case_prague",
+    "conversation": [{
+      "invocation_id": "inv-1",
+      "user_content": {
+        "parts": [{"text": "What is the weather in Prague?"}],
+        "role": "user"
+      },
+      "final_response": {
+        "parts": [{"text": "The weather in Prague is cloudy and 14 degrees Celsius."}],
+        "role": "model"
+      },
+      "intermediate_data": {
+        "tool_uses": [{"name": "get_weather", "args": {"city": "Prague"}}]
+      }
+    }]
+  }]
+}</code></pre>
+    <p class="code-caption">Declares expected user input, expected tool trajectory, expected final response.</p>
+  </div>
+
+  <div class="slide" data-module="09" data-type="section-title" style="background:linear-gradient(135deg,var(--amber-dark) 0%,var(--amber) 100%);">
+    <h1>Live</h1>
+    <h3>Eval with strict threshold — fails on ROUGE-1</h3>
+    <p class="highlight-text" style="color:white;">Notebook cell 13</p>
+  </div>
+
+  <div class="slide" data-module="09">
+    <h2>The failure tells a story</h2>
+<pre class="diagram">expected:  "The weather in Prague is cloudy and 14 degrees Celsius."
+actual:    "The weather in Prague is cloudy, and the temperature is 14 degrees Celsius."
+
+response_match_score: 0.87  (threshold 0.95)  → FAIL</pre>
+    <p><strong>Same information. Different words.</strong> ROUGE-1 counts overlapping unigrams; stylistic variation costs you points.</p>
+    <p style="color:var(--text-muted);font-size:0.9em;">Trajectory score was 1.0 — the agent called the right tool. The failure is pure wording.</p>
+  </div>
+
+  <div class="slide" data-module="09" data-type="keyfact">
+    <h2 class="text-muted" style="border-bottom:none;font-size:1em;text-transform:uppercase;letter-spacing:0.08em;">The honest summary</h2>
+    <p><strong>Trajectory testing is useful.<br>ROUGE-1 response matching is weak.</strong></p>
+    <p style="font-size:0.7em;color:var(--text-muted);margin-top:var(--space-4);">ROUGE-1 punishes legitimate stylistic variation. Don't rely on it for production.</p>
+  </div>
+
+  <div class="slide" data-module="09" data-type="code">
+    <h2>Working range in practice</h2>
+<pre><code>// test_config.json next to your .test.json
+{
+  "criteria": {
+    "tool_trajectory_avg_score": 1.0,    // keep strict
+    "response_match_score": 0.6          // permissive
+  }
+}</code></pre>
+    <p>0.6-0.7 for short responses; give up on <code>response_match_score</code> for long-form text.</p>
+    <p style="color:var(--text-muted);font-size:0.9em;">Dropping the threshold isn't a win — it's an admission the metric is the wrong tool. The real upgrade is LLM-as-judge.</p>
+  </div>
+
+  <div class="slide" data-module="09" data-type="code">
+    <h2>LLM-as-judge — the real upgrade</h2>
+<pre><code># Pseudocode; ADK 1.29+ ships Gen AI Evaluation Service for this
+def judge(prompt, expected, actual) -> float:
+    response = judge_llm(
+        f"Is this a reasonable answer?\n"
+        f"Prompt: {prompt}\n"
+        f"Expected: {expected}\n"
+        f"Actual: {actual}\n"
+        f"Score 0-1 on semantic correctness."
+    )
+    return float(response.strip())</code></pre>
+    <p>Different framing: trajectory asks <em>did the agent do the right things</em>; LLM-judge asks <em>did it say the right thing</em>.</p>
+  </div>
+
+  <div class="slide" data-module="09">
+    <h2>The full picture</h2>
+    <table>
+      <thead><tr><th>Layer</th><th>Answers</th><th>Cost</th></tr></thead>
+      <tbody>
+        <tr><td>Trajectory score</td><td>Did it call the right tools in the right order?</td><td>Free — structural check</td></tr>
+        <tr><td>ROUGE-1 response match</td><td>Is the text lexically close to expected?</td><td>Free — but weak signal</td></tr>
+        <tr><td><strong>LLM-as-judge</strong></td><td>Is the answer semantically correct?</td><td>One extra LLM call per test</td></tr>
+        <tr><td>Human review</td><td>Is the answer actually good?</td><td>Expensive; unavoidable at the tail</td></tr>
+      </tbody>
+    </table>
+    <p>Combine all four at different cadences. Trajectory on every PR, ROUGE-1 for regressions, LLM-judge nightly, human review for flagged cases.</p>
+  </div>
+
+  <div class="slide" data-module="09">
+    <h2>Production gotcha</h2>
+    <div class="callout callout-gotcha">
+      <div class="callout-title"><code>adk eval</code> writes to <code>agents_dir</code></div>
+      <p style="margin:0;">In locked-down containers with read-only root filesystems (common in Kubernetes), the eval run hits <code>PermissionError</code>. Upstream: adk-python #3887.</p>
+    </div>
+    <p><strong>Workaround:</strong> make agents_dir writable during eval, OR run eval outside the deployed image — CI job against the same code, developer machine, separate eval pipeline.</p>
+  </div>
+
+  <div class="slide" data-module="09" data-type="keyfact">
+    <h2 class="text-muted" style="border-bottom:none;font-size:1em;text-transform:uppercase;letter-spacing:0.08em;">What to carry forward</h2>
+    <p>Test <strong>trajectory</strong> strictly.<br>Test <strong>response</strong> with LLM-as-judge.<br>Don't trust ROUGE-1 past the sanity check.</p>
+  </div>
+
+  <div class="slide" data-module="09" data-type="section-title" style="background:linear-gradient(135deg,var(--navy) 0%,var(--navy-light) 100%);">
+    <div class="topic-badge">Up next</div>
+    <h1>M10 &mdash; Deployment</h1>
+    <p class="highlight-text">Last module of Part 1. Cloud Run, vanilla Docker, Vertex AI Agent Engine mention.</p>
+  </div>
+
+  </main>
+
+  <script src="../shared/slides.js"></script>
+</body>
+</html>

--- a/slides/module-09-evaluation/speaker_notes.md
+++ b/slides/module-09-evaluation/speaker_notes.md
@@ -1,0 +1,143 @@
+# M09 — Speaker notes
+
+Spoken delivery. One section per slide.
+
+---
+
+## Slide 1 — Title
+
+Module nine. Evaluation. The first eight modules have all ended with "does it work? let's look at the event stream." That's fine for demos. It doesn't scale. As soon as you have more than one use case, more than one agent, more than one prompt iteration, eyeballing stops being enough. Module nine is where we stop eyeballing.
+
+---
+
+## Slide 2 — Eight modules / eyeballing
+
+The frame. Eight modules of "does the agent work?" answered by looking at printed output. Today we replace that with tests that run automatically, on every change, and report pass-or-fail against named criteria.
+
+---
+
+## Slide 3 — Two metrics
+
+ADK ships two built-in evaluation metrics out of the box.
+
+The first — tool_trajectory_avg_score — asks: did the agent call the right tools in the right order, with the right arguments? Scale zero to one. Default threshold is one-point-zero — strict, exact match.
+
+The second — response_match_score — asks: how close is the agent's actual final response to the expected one? Scale zero to one, calculated as ROUGE-1 unigram overlap. Default threshold is zero-point-eight.
+
+The trajectory metric is the novel one. Most eval frameworks on the market score only outputs — did the agent's final answer look right? ADK adds how-it-got-there as equal-weight information. That matches reality for tool-heavy agents.
+
+---
+
+## Slide 4 — Why trajectory matters
+
+The framing, on one slide. A correct answer reached via the wrong reasoning is a bug waiting to happen. If your agent gave a correct answer today by calling the wrong tool or skipping a required verification step, it will fail on a slightly different input tomorrow — and the failure will be confusing because the previous correct answer fooled you.
+
+Trajectory testing catches this. It locks in the reasoning path, not just the output. If the agent stops using the tool you expected, you see it on the next CI run, not after a customer complains.
+
+---
+
+## Slide 5 — The eval loop
+
+The daily workflow. Three commands and a feedback loop.
+
+Run `adk web` locally. Have a conversation with your agent. When the agent does something good — answers correctly, calls the right tools, handles an edge case — click the "Save as eval" button. That exports the conversation as a dot-test-dot-json file next to your agent code.
+
+Run `adk eval` pointed at your agent directory and the eval file. It runs all the test cases, scores them against the thresholds, reports pass or fail.
+
+Tweak the agent. Change an instruction, add a tool, swap a model. Re-run eval. Repeat.
+
+The loop is fast enough to use while prototyping. Build your evalset incrementally as you iterate. When an agent handles something tricky, save it. Weeks later you have dozens of cases protecting against regressions.
+
+---
+
+## Slide 6 — Minimal test.json
+
+Here's what a test file looks like. Each case has a conversation; each turn has three parts. What the user says. What the agent should ultimately reply with. What tools the agent should call along the way.
+
+You can hand-author these or save them from the dev UI. For a one-off test, hand-author is fine. For a real project, always save from the UI — it captures the exact event structure ADK expects, including invocation IDs and response content shapes you'd otherwise have to read the schema for.
+
+---
+
+## Slide 7 — Live: strict eval fails
+
+Switch to the notebook. Cell thirteen. We run the evaluator with a deliberately strict threshold of 0.95 on response match. Watch what happens.
+
+---
+
+## Slide 8 — The failure tells a story
+
+Back on the slide. Here's what cell thirteen showed.
+
+Expected response — "The weather in Prague is cloudy and 14 degrees Celsius." Actual response — "The weather in Prague is cloudy, and the temperature is 14 degrees Celsius." Response match score: 0.87 against a threshold of 0.95. Failed.
+
+Same information. Different words. "Cloudy and 14 degrees" versus "cloudy, and the temperature is 14 degrees" — if you read those aloud to a human, they'd score them equivalent. ROUGE-1 scores them 0.87.
+
+And notice: the trajectory score was a clean 1.0. The agent did the right thing structurally. The failure is entirely about wording.
+
+---
+
+## Slide 9 — The honest summary
+
+The honest summary. Trajectory testing is useful. ROUGE-1 response matching is weak.
+
+ROUGE-1 punishes legitimate stylistic variation. It's fine as a gross sanity check — did the output contain at least some of the expected words? — but it's not a reliable proxy for correctness. Don't rely on it for production evaluation.
+
+---
+
+## Slide 10 — Working range
+
+What people actually do. A test_config.json next to your test file lets you override the default thresholds.
+
+Keep trajectory strict — 1.0 exact match on tool calls. You want to know immediately if the agent starts doing something different.
+
+For response match, the working range is 0.6 to 0.7 for short text. Below that, almost anything passes. Above that, stylistic variation fails tests. For long-form text — multi-paragraph summaries, explanations — just give up on response_match_score. It's not the right tool for that job.
+
+Dropping the threshold isn't a win. It's an admission the metric is the wrong tool. The real upgrade is LLM-as-judge.
+
+---
+
+## Slide 11 — LLM-as-judge
+
+LLM-as-judge is the production pattern. The pseudocode on the slide: for each test case, run the agent, capture the actual response, call a SECOND LLM with the prompt, the expected answer, and the actual answer. Ask it to score semantic correctness. Get a number back.
+
+ADK 1.29 and later ships a Gen AI Evaluation Service integration that does this built-in — public preview at time of recording. Vertex AI users point their eval sets at it; Google runs the judge for you. For self-hosted work, you wire the judge yourself — a separate LiteLLM call, a grading rubric in the prompt, the score as the output.
+
+The key shift is framing. Trajectory asks: did the agent do the right things? LLM-judge asks: did it say the right thing? Both matter. Neither is ROUGE-1.
+
+---
+
+## Slide 12 — Full picture
+
+The full picture. Four evaluation layers, combined at different cadences in production.
+
+Trajectory score on every pull request. Fast, deterministic, catches structural regressions.
+
+ROUGE-1 as a rough regression check. Don't trust the number; trust the trend.
+
+LLM-as-judge nightly. More expensive — a second LLM call per test case — but it catches the things ROUGE-1 misses. Run it on your full evalset; look at the ones it flags.
+
+Human review at the tail. Unavoidable. For the cases that matter most — new agent deployments, customer-reported issues, high-stakes tasks — a human eyeballs the actual responses. Weekly or per-release cadence.
+
+You don't pick one. You combine them at appropriate cadences.
+
+---
+
+## Slide 13 — Production gotcha
+
+One more gotcha worth naming. `adk eval` writes files back to the agents_dir — it persists updated session histories for the eval runs. If your deployment image is read-only, common in Kubernetes with read-only root filesystems, eval hits a PermissionError.
+
+Upstream issue: adk-python number 3887.
+
+The workaround is straightforward: either mount the agents_dir as writable during eval runs, or run eval outside the deployed image. In CI. On a developer machine. In a separate eval pipeline. The agent code is the same; the runtime environment is different. Doesn't block classroom use; becomes a real concern when you wire eval into CI/CD against a production-shaped container.
+
+---
+
+## Slide 14 — What to carry forward
+
+What to carry forward. Test trajectory strictly — that's the high-value metric ADK gives you that nobody else does as cleanly. Test response quality with LLM-as-judge, not ROUGE-1, for any real work. Don't trust ROUGE-1 past the sanity-check tier.
+
+---
+
+## Slide 15 — Next
+
+Module ten. The last module of Part 1. Deployment. `adk deploy cloud_run` as the one-command story, a vanilla Dockerfile that runs the same agent on any cloud, a brief look at Vertex AI Agent Engine as the opinionated managed path. Then Part 2 begins — Gemini-specific features you lose when you're vendor-neutral.

--- a/textbook/_sources/chapters/09-evaluation.md
+++ b/textbook/_sources/chapters/09-evaluation.md
@@ -1,0 +1,166 @@
+# Evaluation
+
+The first eight chapters have answered "does the agent work?" by printing events and reading them. That works for demos. It stops working the moment you have more than one use case, more than one agent, more than one prompt iteration. Eyeballing doesn't scale; automated evaluation does.
+
+This chapter introduces ADK's evaluation framework. You describe a conversation as a **test case** — input, expected tool trajectory, expected response — the framework runs the agent against it, scores what actually happened against what you expected, and reports pass or fail. Like a unit test suite, but for agent behavior.
+
+ADK ships two built-in metrics, and one of them — trajectory testing — is the genuine differentiator. The other — ROUGE-1 response match — needs honest framing.
+
+## The two metrics
+
+| Metric | Asks | Scale | Default threshold |
+|---|---|---|---|
+| `tool_trajectory_avg_score` | Did the agent call the right tools in the right order with the right args? | 0–1 | 1.0 (strict) |
+| `response_match_score` | How similar is the actual response to the expected one? | 0–1 (ROUGE-1) | 0.8 |
+
+### Trajectory is the novel one
+
+Most evaluation frameworks for LLM agents score only the final output — did the answer look right? ADK weights *how the agent got there* equally. For tool-heavy agents, this is the correct framing.
+
+A correct answer via the wrong reasoning is a bug waiting to happen. If your agent answered correctly today by skipping a verification step or by calling a tool you didn't expect, you were lucky — tomorrow's slightly different input will expose the structural problem. Trajectory testing catches this class of bug immediately; response-only testing misses it.
+
+### Response match uses ROUGE-1 — and ROUGE-1 is weak
+
+ROUGE-1 is unigram overlap between expected and actual text. Great for machine translation benchmarks where the answer space is narrow. Weak for free-form agent responses where the same information can be expressed in many ways.
+
+The default threshold of 0.8 means "80% of the words in the expected response must appear in the actual response." In practice this fails on semantically-correct answers that happen to use different wording — which is most of them. You will fight this metric as you iterate your agent.
+
+The honest summary: **trajectory testing is useful; ROUGE-1 response matching is weak.** Use trajectory strictly. Use response match loosely or not at all, and plan for LLM-as-judge as the real upgrade.
+
+## The `.test.json` format
+
+Eval files are JSON documents with one or more test cases. The canonical shape for a minimal case:
+
+```json
+{
+  "eval_set_id": "weather_basic",
+  "name": "weather basic",
+  "description": "One test case for the weather agent.",
+  "eval_cases": [
+    {
+      "eval_id": "case_prague",
+      "conversation": [
+        {
+          "invocation_id": "inv-1",
+          "user_content": {
+            "parts": [{"text": "What is the weather in Prague?"}],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [{"text": "The weather in Prague is cloudy and 14 degrees Celsius."}],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {"name": "get_weather", "args": {"city": "Prague"}}
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "weather_agent",
+        "user_id": "tester",
+        "state": {}
+      }
+    }
+  ]
+}
+```
+
+Each case has a conversation. Each turn in the conversation has user input, expected final response, and expected intermediate data (the tool calls the agent should make along the way). Optionally, a `session_input` pre-populates the state.
+
+You can hand-author these — fine for a one-off test. In practice, author them from the dev UI: run `adk web`, have a conversation you're happy with, click "Save as eval," enter a name. ADK writes exactly this format. The programmatic path and the UI path produce identical files.
+
+## The eval loop in daily use
+
+Three commands:
+
+```bash
+# Step 1: run the agent in the dev UI
+adk web
+
+# ... chat, click "Save as eval", name it
+
+# Step 2: run the evals
+adk eval ./my_agent ./my_agent/my_evals.test.json
+
+# Step 3: tweak the agent; re-run
+adk eval ./my_agent ./my_agent/my_evals.test.json
+```
+
+Chat, save, tweak, re-run. The loop is fast enough to use while prototyping — a few seconds per eval run on a simple agent. Build your evalset incrementally: when the agent handles something tricky, save it. Over a few weeks you accumulate dozens of cases that protect against regressions.
+
+The programmatic API exposed in the notebook (`AgentEvaluator.evaluate(agent_module=..., eval_dataset_file_path_or_dir=...)`) does the same thing without the CLI. Handy for unit-test integration — the eval becomes a `pytest` case.
+
+## The ROUGE-1 failure mode — live
+
+The notebook runs an eval with a deliberately strict threshold of 0.95. It fails, and the failure is the teaching moment.
+
+```
+expected:  "The weather in Prague is cloudy and 14 degrees Celsius."
+actual:    "The weather in Prague is cloudy, and the temperature is 14 degrees Celsius."
+
+response_match_score: 0.87  (threshold 0.95)  → FAIL
+```
+
+Same information, different words. The trajectory score was 1.0 — the agent called the right tool. The entire failure is stylistic. ROUGE-1 counts overlapping unigrams; "cloudy, and the temperature is" replaces "cloudy and" with more words, and the count drops.
+
+In practice, this means:
+- **Don't use 0.8 as a threshold.** Relax to 0.6 for short responses. Give up on the metric entirely for long-form text.
+- **Don't chase the metric.** Tweaking an agent's prompt to pass ROUGE-1 optimizes for word choice, not correctness. That's backwards.
+- **Do use LLM-as-judge for production.** ROUGE-1 is fine as a structural sanity check — did the agent even produce a response with the right shape? — and nothing more.
+
+## LLM-as-judge: the production upgrade
+
+The pattern: for each test case, after running the agent and capturing the actual response, call a **second** LLM with the prompt, the expected answer, and the actual answer. Ask it to score semantic correctness.
+
+```python
+# Sketch — not built into ADK < 1.29, straightforward to wire up
+def judge(prompt, expected, actual) -> float:
+    response = judge_llm(
+        f"Is this a reasonable answer to the prompt?\n"
+        f"Prompt: {prompt}\n"
+        f"Expected: {expected}\n"
+        f"Actual: {actual}\n"
+        f"Score 0-1 on semantic correctness. Just the number."
+    )
+    return float(response.strip())
+```
+
+ADK 1.29+ ships a Gen AI Evaluation Service integration that does this built-in (public preview). Vertex AI users point their eval sets at it and get LLM-graded metrics alongside trajectory. Self-hosted deployments wire the judge themselves — a second LiteLLM call with a grading rubric.
+
+The framing shift is what matters: trajectory asks *did the agent do the right things*; LLM-judge asks *did it say the right thing*. Both matter; neither is ROUGE-1.
+
+## A full evaluation strategy
+
+In real projects, evaluation is not one layer. It's four, run at different cadences:
+
+| Layer | Answers | Cost | When to run |
+|---|---|---|---|
+| **Trajectory score** | Did it call the right tools in the right order? | Free (structural) | On every PR |
+| **ROUGE-1 response match** | Is the text lexically close? | Free, weak signal | For regressions only |
+| **LLM-as-judge** | Is the answer semantically correct? | One extra LLM call per case | Nightly or pre-release |
+| **Human review** | Is it actually good? | Expensive; unavoidable | For flagged cases, high-stakes deployments |
+
+You don't pick one. You combine them. Trajectory gives fast, deterministic CI signal. LLM-as-judge gives semantic scoring at moderate cost. Human review is the tail — the cases the automated layers flag as uncertain, plus new-agent deployments, plus customer-reported issues.
+
+## Production gotcha — read-only filesystems
+
+Worth naming before you deploy. `adk eval` **writes files back to the `agents_dir`** during eval runs — it persists updated session histories into the directory containing your agent. If your deployment image has a read-only root filesystem — a common Kubernetes hardening pattern — eval runs hit `PermissionError`.
+
+Upstream issue: adk-python #3887.
+
+**Workaround:** either make the `agents_dir` writable during eval runs (mount a writable volume), or run eval **outside** the deployed image. Most real deployments do the latter: the agent code is the same in production and in CI, but eval runs in CI against a fresh checkout, not inside the locked-down production image. Doesn't block classroom use; becomes a real concern as you wire eval into a production CI/CD pipeline.
+
+## What to carry forward
+
+- **Two built-in metrics**: `tool_trajectory_avg_score` (strict, useful) and `response_match_score` (ROUGE-1, weak).
+- **Trajectory is ADK's differentiated contribution to eval.** Use it strictly. Lock in the tool-call path.
+- **ROUGE-1 punishes stylistic variation.** Don't chase the default 0.8 threshold. Relax, or replace with LLM-as-judge.
+- **LLM-as-judge is the production upgrade.** ADK 1.29+ ships a Gen AI Evaluation Service path; self-host with a second LiteLLM call.
+- **`.test.json`** authored by hand or saved from `adk web`. Build evalsets incrementally as you iterate.
+- **`adk eval`** writes to `agents_dir` — breaks in read-only containers. Run eval outside the deployed image.
+- **Full strategy**: trajectory on every PR; LLM-judge nightly; human review at the tail. Don't pick one.
+
+Module 10 — the last module of Part 1 — picks up **deployment**. `adk deploy cloud_run` as the one-command story, a vanilla Dockerfile that runs the same agent on any cloud, Vertex AI Agent Engine mentioned as the opinionated managed path. Then Part 2 begins: Gemini-specific features you lose when you're vendor-neutral.

--- a/textbook/index.html
+++ b/textbook/index.html
@@ -320,6 +320,7 @@ hr {
 <li><a href="#multi-agent-hierarchies">6. Multi-agent hierarchies</a></li>
 <li><a href="#callbacks-as-middleware">7. Callbacks as middleware</a></li>
 <li><a href="#memory">8. Memory</a></li>
+<li><a href="#evaluation">9. Evaluation</a></li>
             </ul>
         </nav>
     </aside>
@@ -1672,6 +1673,181 @@ memory_agent = LlmAgent(
 <li><strong>The framing to carry</strong>: long-term memory is a journal, not a cache.</li>
 </ul>
 <p>Module 09 picks up <strong>evaluation</strong>. The first eight modules have been &ldquo;does the agent work?&rdquo; answered by eyeballing the event stream. Module 09 introduces ADK&rsquo;s evaluation framework — <code>AgentEvaluator</code>, <code>EvalSet</code>, trajectory metrics (did the agent call the right tools in the right order?), and the <code>adk eval</code> CLI loop (chat, save evalset, tweak prompt, rerun). Honest about ROUGE-1&rsquo;s limitations for production; gestures at LLM-as-judge as the upgrade path.</p>
+        </section>
+
+        <section class="chapter" id="evaluation">
+            <div class="chapter-number">Chapter 9</div>
+            <h1>Evaluation</h1>
+<p>The first eight chapters have answered &ldquo;does the agent work?&rdquo; by printing events and reading them. That works for demos. It stops working the moment you have more than one use case, more than one agent, more than one prompt iteration. Eyeballing doesn&rsquo;t scale; automated evaluation does.</p>
+<p>This chapter introduces ADK&rsquo;s evaluation framework. You describe a conversation as a <strong>test case</strong> — input, expected tool trajectory, expected response — the framework runs the agent against it, scores what actually happened against what you expected, and reports pass or fail. Like a unit test suite, but for agent behavior.</p>
+<p>ADK ships two built-in metrics, and one of them — trajectory testing — is the genuine differentiator. The other — ROUGE-1 response match — needs honest framing.</p>
+<h2>The two metrics</h2>
+<table>
+<thead>
+<tr>
+<th>Metric</th>
+<th>Asks</th>
+<th>Scale</th>
+<th>Default threshold</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>tool_trajectory_avg_score</code></td>
+<td>Did the agent call the right tools in the right order with the right args?</td>
+<td>0–1</td>
+<td>1.0 (strict)</td>
+</tr>
+<tr>
+<td><code>response_match_score</code></td>
+<td>How similar is the actual response to the expected one?</td>
+<td>0–1 (ROUGE-1)</td>
+<td>0.8</td>
+</tr>
+</tbody>
+</table>
+<h3>Trajectory is the novel one</h3>
+<p>Most evaluation frameworks for LLM agents score only the final output — did the answer look right? ADK weights <em>how the agent got there</em> equally. For tool-heavy agents, this is the correct framing.</p>
+<p>A correct answer via the wrong reasoning is a bug waiting to happen. If your agent answered correctly today by skipping a verification step or by calling a tool you didn&rsquo;t expect, you were lucky — tomorrow&rsquo;s slightly different input will expose the structural problem. Trajectory testing catches this class of bug immediately; response-only testing misses it.</p>
+<h3>Response match uses ROUGE-1 — and ROUGE-1 is weak</h3>
+<p>ROUGE-1 is unigram overlap between expected and actual text. Great for machine translation benchmarks where the answer space is narrow. Weak for free-form agent responses where the same information can be expressed in many ways.</p>
+<p>The default threshold of 0.8 means &ldquo;80% of the words in the expected response must appear in the actual response.&rdquo; In practice this fails on semantically-correct answers that happen to use different wording — which is most of them. You will fight this metric as you iterate your agent.</p>
+<p>The honest summary: <strong>trajectory testing is useful; ROUGE-1 response matching is weak.</strong> Use trajectory strictly. Use response match loosely or not at all, and plan for LLM-as-judge as the real upgrade.</p>
+<h2>The <code>.test.json</code> format</h2>
+<p>Eval files are JSON documents with one or more test cases. The canonical shape for a minimal case:</p>
+<pre><code class="language-json">{
+  &quot;eval_set_id&quot;: &quot;weather_basic&quot;,
+  &quot;name&quot;: &quot;weather basic&quot;,
+  &quot;description&quot;: &quot;One test case for the weather agent.&quot;,
+  &quot;eval_cases&quot;: [
+    {
+      &quot;eval_id&quot;: &quot;case_prague&quot;,
+      &quot;conversation&quot;: [
+        {
+          &quot;invocation_id&quot;: &quot;inv-1&quot;,
+          &quot;user_content&quot;: {
+            &quot;parts&quot;: [{&quot;text&quot;: &quot;What is the weather in Prague?&quot;}],
+            &quot;role&quot;: &quot;user&quot;
+          },
+          &quot;final_response&quot;: {
+            &quot;parts&quot;: [{&quot;text&quot;: &quot;The weather in Prague is cloudy and 14 degrees Celsius.&quot;}],
+            &quot;role&quot;: &quot;model&quot;
+          },
+          &quot;intermediate_data&quot;: {
+            &quot;tool_uses&quot;: [
+              {&quot;name&quot;: &quot;get_weather&quot;, &quot;args&quot;: {&quot;city&quot;: &quot;Prague&quot;}}
+            ],
+            &quot;intermediate_responses&quot;: []
+          }
+        }
+      ],
+      &quot;session_input&quot;: {
+        &quot;app_name&quot;: &quot;weather_agent&quot;,
+        &quot;user_id&quot;: &quot;tester&quot;,
+        &quot;state&quot;: {}
+      }
+    }
+  ]
+}
+</code></pre>
+<p>Each case has a conversation. Each turn in the conversation has user input, expected final response, and expected intermediate data (the tool calls the agent should make along the way). Optionally, a <code>session_input</code> pre-populates the state.</p>
+<p>You can hand-author these — fine for a one-off test. In practice, author them from the dev UI: run <code>adk web</code>, have a conversation you&rsquo;re happy with, click &ldquo;Save as eval,&rdquo; enter a name. ADK writes exactly this format. The programmatic path and the UI path produce identical files.</p>
+<h2>The eval loop in daily use</h2>
+<p>Three commands:</p>
+<pre><code class="language-bash"># Step 1: run the agent in the dev UI
+adk web
+
+# ... chat, click &quot;Save as eval&quot;, name it
+
+# Step 2: run the evals
+adk eval ./my_agent ./my_agent/my_evals.test.json
+
+# Step 3: tweak the agent; re-run
+adk eval ./my_agent ./my_agent/my_evals.test.json
+</code></pre>
+<p>Chat, save, tweak, re-run. The loop is fast enough to use while prototyping — a few seconds per eval run on a simple agent. Build your evalset incrementally: when the agent handles something tricky, save it. Over a few weeks you accumulate dozens of cases that protect against regressions.</p>
+<p>The programmatic API exposed in the notebook (<code>AgentEvaluator.evaluate(agent_module=..., eval_dataset_file_path_or_dir=...)</code>) does the same thing without the CLI. Handy for unit-test integration — the eval becomes a <code>pytest</code> case.</p>
+<h2>The ROUGE-1 failure mode — live</h2>
+<p>The notebook runs an eval with a deliberately strict threshold of 0.95. It fails, and the failure is the teaching moment.</p>
+<pre><code>expected:  &quot;The weather in Prague is cloudy and 14 degrees Celsius.&quot;
+actual:    &quot;The weather in Prague is cloudy, and the temperature is 14 degrees Celsius.&quot;
+
+response_match_score: 0.87  (threshold 0.95)  → FAIL
+</code></pre>
+<p>Same information, different words. The trajectory score was 1.0 — the agent called the right tool. The entire failure is stylistic. ROUGE-1 counts overlapping unigrams; &ldquo;cloudy, and the temperature is&rdquo; replaces &ldquo;cloudy and&rdquo; with more words, and the count drops.</p>
+<p>In practice, this means:
+- <strong>Don&rsquo;t use 0.8 as a threshold.</strong> Relax to 0.6 for short responses. Give up on the metric entirely for long-form text.
+- <strong>Don&rsquo;t chase the metric.</strong> Tweaking an agent&rsquo;s prompt to pass ROUGE-1 optimizes for word choice, not correctness. That&rsquo;s backwards.
+- <strong>Do use LLM-as-judge for production.</strong> ROUGE-1 is fine as a structural sanity check — did the agent even produce a response with the right shape? — and nothing more.</p>
+<h2>LLM-as-judge: the production upgrade</h2>
+<p>The pattern: for each test case, after running the agent and capturing the actual response, call a <strong>second</strong> LLM with the prompt, the expected answer, and the actual answer. Ask it to score semantic correctness.</p>
+<pre><code class="language-python"># Sketch — not built into ADK &lt; 1.29, straightforward to wire up
+def judge(prompt, expected, actual) -&gt; float:
+    response = judge_llm(
+        f&quot;Is this a reasonable answer to the prompt?\n&quot;
+        f&quot;Prompt: {prompt}\n&quot;
+        f&quot;Expected: {expected}\n&quot;
+        f&quot;Actual: {actual}\n&quot;
+        f&quot;Score 0-1 on semantic correctness. Just the number.&quot;
+    )
+    return float(response.strip())
+</code></pre>
+<p>ADK 1.29+ ships a Gen AI Evaluation Service integration that does this built-in (public preview). Vertex AI users point their eval sets at it and get LLM-graded metrics alongside trajectory. Self-hosted deployments wire the judge themselves — a second LiteLLM call with a grading rubric.</p>
+<p>The framing shift is what matters: trajectory asks <em>did the agent do the right things</em>; LLM-judge asks <em>did it say the right thing</em>. Both matter; neither is ROUGE-1.</p>
+<h2>A full evaluation strategy</h2>
+<p>In real projects, evaluation is not one layer. It&rsquo;s four, run at different cadences:</p>
+<table>
+<thead>
+<tr>
+<th>Layer</th>
+<th>Answers</th>
+<th>Cost</th>
+<th>When to run</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Trajectory score</strong></td>
+<td>Did it call the right tools in the right order?</td>
+<td>Free (structural)</td>
+<td>On every PR</td>
+</tr>
+<tr>
+<td><strong>ROUGE-1 response match</strong></td>
+<td>Is the text lexically close?</td>
+<td>Free, weak signal</td>
+<td>For regressions only</td>
+</tr>
+<tr>
+<td><strong>LLM-as-judge</strong></td>
+<td>Is the answer semantically correct?</td>
+<td>One extra LLM call per case</td>
+<td>Nightly or pre-release</td>
+</tr>
+<tr>
+<td><strong>Human review</strong></td>
+<td>Is it actually good?</td>
+<td>Expensive; unavoidable</td>
+<td>For flagged cases, high-stakes deployments</td>
+</tr>
+</tbody>
+</table>
+<p>You don&rsquo;t pick one. You combine them. Trajectory gives fast, deterministic CI signal. LLM-as-judge gives semantic scoring at moderate cost. Human review is the tail — the cases the automated layers flag as uncertain, plus new-agent deployments, plus customer-reported issues.</p>
+<h2>Production gotcha — read-only filesystems</h2>
+<p>Worth naming before you deploy. <code>adk eval</code> <strong>writes files back to the <code>agents_dir</code></strong> during eval runs — it persists updated session histories into the directory containing your agent. If your deployment image has a read-only root filesystem — a common Kubernetes hardening pattern — eval runs hit <code>PermissionError</code>.</p>
+<p>Upstream issue: adk-python #3887.</p>
+<p><strong>Workaround:</strong> either make the <code>agents_dir</code> writable during eval runs (mount a writable volume), or run eval <strong>outside</strong> the deployed image. Most real deployments do the latter: the agent code is the same in production and in CI, but eval runs in CI against a fresh checkout, not inside the locked-down production image. Doesn&rsquo;t block classroom use; becomes a real concern as you wire eval into a production CI/CD pipeline.</p>
+<h2>What to carry forward</h2>
+<ul>
+<li><strong>Two built-in metrics</strong>: <code>tool_trajectory_avg_score</code> (strict, useful) and <code>response_match_score</code> (ROUGE-1, weak).</li>
+<li><strong>Trajectory is ADK&rsquo;s differentiated contribution to eval.</strong> Use it strictly. Lock in the tool-call path.</li>
+<li><strong>ROUGE-1 punishes stylistic variation.</strong> Don&rsquo;t chase the default 0.8 threshold. Relax, or replace with LLM-as-judge.</li>
+<li><strong>LLM-as-judge is the production upgrade.</strong> ADK 1.29+ ships a Gen AI Evaluation Service path; self-host with a second LiteLLM call.</li>
+<li><strong><code>.test.json</code></strong> authored by hand or saved from <code>adk web</code>. Build evalsets incrementally as you iterate.</li>
+<li><strong><code>adk eval</code></strong> writes to <code>agents_dir</code> — breaks in read-only containers. Run eval outside the deployed image.</li>
+<li><strong>Full strategy</strong>: trajectory on every PR; LLM-judge nightly; human review at the tail. Don&rsquo;t pick one.</li>
+</ul>
+<p>Module 10 — the last module of Part 1 — picks up <strong>deployment</strong>. <code>adk deploy cloud_run</code> as the one-command story, a vanilla Dockerfile that runs the same agent on any cloud, Vertex AI Agent Engine mentioned as the opinionated managed path. Then Part 2 begins: Gemini-specific features you lose when you&rsquo;re vendor-neutral.</p>
         </section>
         </main>
     </div>


### PR DESCRIPTION
Module 09 — ADK's eval framework. Trajectory testing (the differentiator) + ROUGE-1 response match (honestly named as weak). Live demo shows the strict 0.95 threshold failing on 0.87 stylistic variation — that's the teaching moment. Covers LLM-as-judge as the real upgrade path and the read-only-filesystem gotcha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)