### PR TITLE
course(M12): thinking budgets

### DIFF
--- a/index.html
+++ b/index.html
@@ -324,14 +324,14 @@
       <div class="status ready">Ready</div>
     </a>
 
-    <div class="module soon">
+    <a class="module" href="slides/module-12-thinking-budgets/index.html">
       <div class="num">M12</div>
       <div>
         <div class="title">Thinking budgets</div>
         <div class="desc"><code>ThinkingConfig</code> MIN/LOW/MED/HIGH.</div>
       </div>
-      <div class="status soon">Soon</div>
-    </div>
+      <div class="status ready">Ready</div>
+    </a>
 
     <div class="module soon">
       <div class="num">M13</div>

--- a/notebooks/12_thinking_budgets.ipynb
+++ b/notebooks/12_thinking_budgets.ipynb
@@ -1,0 +1,357 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c5e98ccf",
+   "metadata": {},
+   "source": [
+    "# Module 12 — Thinking Budgets\n",
+    "\n",
+    "The second Gemini-only unlock in Part 2. Simpler than grounding + caching; one knob, big effect.\n",
+    "\n",
+    "Gemini 2.5+ models support **thinking** — an internal reasoning pass the model does before producing its final answer. The tokens consumed during thinking don't appear in the output text; they're billed as a separate category (`thoughts_token_count`) and they take real wall-clock time.\n",
+    "\n",
+    "**`ThinkingConfig.thinking_budget`** is the knob. Set it to 0 for instant responses (no internal reasoning); set it to 2048 or higher for hard problems where reasoning pays off. The trade-off is explicit — you spend tokens and latency in exchange for answer quality on reasoning-heavy tasks.\n",
+    "\n",
+    "**What you'll leave with:**\n",
+    "- Run the same problem at `thinking_budget=0` vs `thinking_budget=4096` and see the latency + thought-token counts.\n",
+    "- Understand when thinking earns its keep (complex multi-step reasoning, hard math, code debugging) and when it doesn't (factual lookup, simple questions).\n",
+    "- Wire `ThinkingConfig` into an ADK agent via `BuiltInPlanner`.\n",
+    "\n",
+    "**Running cost:** under $0.01."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8c35b948",
+   "metadata": {},
+   "source": [
+    "# Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4acc2f7d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -q google-adk==1.28.0 google-genai litellm==1.83.4 python-dotenv==1.0.1 nest-asyncio==1.6.0 deprecated==1.2.18 2>/dev/null\n",
+    "print(\"✅ Packages installed.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "568dbe6f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os, sys, warnings, time, uuid\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "try: sys.stderr.fileno()\n",
+    "except Exception: sys.stderr = open(os.devnull, \"w\")\n",
+    "\n",
+    "GOOGLE_API_KEY = None\n",
+    "try:\n",
+    "    from google.colab import userdata\n",
+    "    GOOGLE_API_KEY = userdata.get(\"GOOGLE_API_KEY\")\n",
+    "except Exception:\n",
+    "    try:\n",
+    "        from dotenv import load_dotenv; load_dotenv()\n",
+    "        GOOGLE_API_KEY = os.getenv(\"GOOGLE_API_KEY\")\n",
+    "    except ImportError: pass\n",
+    "if not GOOGLE_API_KEY:\n",
+    "    from getpass import getpass\n",
+    "    GOOGLE_API_KEY = getpass(\"Enter your Google AI Studio API key: \")\n",
+    "os.environ[\"GOOGLE_API_KEY\"] = GOOGLE_API_KEY\n",
+    "os.environ[\"GOOGLE_GENAI_USE_VERTEXAI\"] = \"FALSE\"\n",
+    "print(\"✅ Environment ready.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c7c43a29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import asyncio, logging\n",
+    "import nest_asyncio; nest_asyncio.apply()\n",
+    "logging.getLogger(\"LiteLLM\").setLevel(logging.WARNING)\n",
+    "\n",
+    "from google import genai\n",
+    "from google.genai import types\n",
+    "from google.adk.agents import LlmAgent\n",
+    "from google.adk.runners import Runner\n",
+    "from google.adk.sessions import InMemorySessionService\n",
+    "from google.adk.planners import BuiltInPlanner\n",
+    "\n",
+    "print(\"✅ Imports successful.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "92400d60",
+   "metadata": {},
+   "source": [
+    "# How Thinking Works\n",
+    "\n",
+    "When you give Gemini 2.5+ a thinking budget greater than zero, the model internally does a reasoning pass before producing its final answer. The internal reasoning is not returned in the `text` field. It's counted separately as `thoughts_token_count` in the usage metadata.\n",
+    "\n",
+    "Two ways to control thinking:\n",
+    "\n",
+    "| Setting | Type | Meaning |\n",
+    "|---|---|---|\n",
+    "| `thinking_budget=0` | int | Disable thinking. Instant response. |\n",
+    "| `thinking_budget=N` | int | Allow up to N thought-tokens (higher = more reasoning) |\n",
+    "| `thinking_level=LOW/MEDIUM/HIGH` | enum | Gemini 3+ only; coarser preset |\n",
+    "\n",
+    "For this notebook we use `thinking_budget` (int) — works on Gemini 2.5."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d40c6a4e",
+   "metadata": {},
+   "source": [
+    "# Demo 1 — Direct google-genai A/B Comparison\n",
+    "\n",
+    "Same problem at `thinking_budget=0` (no reasoning) and `thinking_budget=4096` (up to 4K reasoning tokens). Same model. Compare latency and answer quality."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19776e14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = genai.Client(api_key=GOOGLE_API_KEY)\n",
+    "\n",
+    "# A reasoning-heavy problem — multiple steps, easy to get wrong.\n",
+    "PROBLEM = \"\"\"A small bakery sells three types of bread:\n",
+    "- Sourdough: 4.50 EUR, takes 30 minutes labor\n",
+    "- Rye: 3.80 EUR, takes 25 minutes labor\n",
+    "- Whole wheat: 4.10 EUR, takes 20 minutes labor\n",
+    "\n",
+    "Flour costs are:\n",
+    "- Sourdough: 1.20 EUR per loaf\n",
+    "- Rye: 1.00 EUR per loaf\n",
+    "- Whole wheat: 0.90 EUR per loaf\n",
+    "\n",
+    "Labor costs 0.40 EUR per minute (including overhead).\n",
+    "\n",
+    "Which bread has the highest profit margin per loaf in percentage terms (profit / revenue × 100)?\n",
+    "Show your calculation for each and state the winner.\"\"\"\n",
+    "\n",
+    "for budget in [0, 4096]:\n",
+    "    print(f\"\\n── thinking_budget={budget} ──\")\n",
+    "    t0 = time.time()\n",
+    "    resp = client.models.generate_content(\n",
+    "        model=\"gemini-2.5-flash\",\n",
+    "        contents=PROBLEM,\n",
+    "        config=types.GenerateContentConfig(\n",
+    "            thinking_config=types.ThinkingConfig(\n",
+    "                thinking_budget=budget,\n",
+    "                include_thoughts=False,\n",
+    "            ),\n",
+    "        ),\n",
+    "    )\n",
+    "    elapsed = time.time() - t0\n",
+    "    usage = resp.usage_metadata\n",
+    "    thoughts = getattr(usage, \"thoughts_token_count\", None) or 0\n",
+    "    print(f\"latency: {elapsed:.2f}s\")\n",
+    "    print(f\"tokens — input: {usage.prompt_token_count}, thoughts: {thoughts}, output: {usage.candidates_token_count}\")\n",
+    "    print(f\"answer:\\n{resp.text}\")\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3468fe85",
+   "metadata": {},
+   "source": [
+    "Read the two outputs carefully. Three things to compare:\n",
+    "\n",
+    "1. **Latency.** budget=0 is well under a second; budget=4096 takes several seconds. The difference is real reasoning time the model is spending internally.\n",
+    "2. **Thought tokens.** budget=0 uses 0 (or near-0) thought tokens. budget=4096 uses however many the model decided the problem needed — often less than the budget cap; that's the budget behaving as a ceiling, not a target.\n",
+    "3. **Answer quality.** On a multi-step numerical problem like this, `thinking_budget=4096` produces a cleaner, better-organized, usually more accurate answer. budget=0 sometimes skips steps, mis-does arithmetic, or picks the wrong winner.\n",
+    "\n",
+    "The cost model: you pay for thought tokens the same rate as output tokens. 527 thought tokens at Flash's $0.30/M = ~$0.00016 per invocation. Worth it for hard problems; wasted for easy ones."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5412791",
+   "metadata": {},
+   "source": [
+    "# Demo 2 — Thinking Budgets Inside an ADK Agent\n",
+    "\n",
+    "`BuiltInPlanner` wraps a `ThinkingConfig` so you can apply it to an `LlmAgent`. Same API; ADK plumbs it through to the underlying Gemini call."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aaeb90d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# An agent that uses thinking explicitly\n",
+    "thinking_agent = LlmAgent(\n",
+    "    name=\"thinking_agent\",\n",
+    "    model=\"gemini-2.5-flash\",\n",
+    "    description=\"Reasoning agent with a generous thinking budget.\",\n",
+    "    instruction=\"Answer user questions. For multi-step problems, reason carefully.\",\n",
+    "    planner=BuiltInPlanner(\n",
+    "        thinking_config=types.ThinkingConfig(thinking_budget=2048),\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "# A counterpart with thinking disabled\n",
+    "fast_agent = LlmAgent(\n",
+    "    name=\"fast_agent\",\n",
+    "    model=\"gemini-2.5-flash\",\n",
+    "    description=\"Fast agent; no internal reasoning.\",\n",
+    "    instruction=\"Answer user questions concisely.\",\n",
+    "    planner=BuiltInPlanner(\n",
+    "        thinking_config=types.ThinkingConfig(thinking_budget=0),\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "APP = \"m12\"\n",
+    "USER = \"student\"\n",
+    "session_service = InMemorySessionService()\n",
+    "\n",
+    "async def ask_agent(agent, prompt: str, label: str):\n",
+    "    sid = f\"s-{uuid.uuid4().hex[:6]}\"\n",
+    "    await session_service.create_session(app_name=APP, user_id=USER, session_id=sid)\n",
+    "    runner = Runner(agent=agent, app_name=APP, session_service=session_service)\n",
+    "    msg = types.Content(role=\"user\", parts=[types.Part(text=prompt)])\n",
+    "    t0 = time.time()\n",
+    "    final = \"\"\n",
+    "    async for ev in runner.run_async(user_id=USER, session_id=sid, new_message=msg):\n",
+    "        if ev.is_final_response() and ev.content and ev.content.parts:\n",
+    "            for p in ev.content.parts:\n",
+    "                if p.text:\n",
+    "                    final = p.text.strip()\n",
+    "    print(f\"── {label} ({time.time() - t0:.2f}s) ──\")\n",
+    "    print(final[:400])\n",
+    "    print()\n",
+    "\n",
+    "QUESTION = \"What is the sum of all prime numbers between 20 and 50?\"\n",
+    "\n",
+    "await ask_agent(fast_agent,     QUESTION, \"fast_agent (thinking=0)\")\n",
+    "await ask_agent(thinking_agent, QUESTION, \"thinking_agent (thinking=2048)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89a0f24d",
+   "metadata": {},
+   "source": [
+    "For a problem like this — requiring you to enumerate primes and sum them — `thinking_agent` tends to get the correct answer (23 + 29 + 31 + 37 + 41 + 43 + 47 = 251). `fast_agent` sometimes misses a prime, or makes an arithmetic error. The quality difference on reasoning-heavy tasks is real.\n",
+    "\n",
+    "For simple factual queries (*\"What's the capital of France?\"*), thinking adds latency with no benefit. The knob should be turned high for hard problems and low for easy ones. Per-agent is the reasonable granularity — a single coordinator with specialist sub-agents can route hard queries to a high-thinking specialist and trivia to a fast one."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8fc972bf",
+   "metadata": {},
+   "source": [
+    "# When Thinking Earns Its Keep\n",
+    "\n",
+    "Thinking budgets are not free. Tokens cost money. Latency costs user patience. Crank the budget for:\n",
+    "\n",
+    "- **Multi-step reasoning** — the example problems above. Numerical reasoning, logic puzzles, scheduling.\n",
+    "- **Code debugging** — the model has to trace logic; thinking helps significantly.\n",
+    "- **Hard math** — arithmetic, algebra, proofs.\n",
+    "- **Multi-constraint planning** — itinerary-building, resource allocation, dependency-aware scheduling.\n",
+    "\n",
+    "Skip thinking for:\n",
+    "\n",
+    "- **Factual lookups** — \"capital of France\", \"weather in Prague\". The model already knows; no reasoning needed.\n",
+    "- **Text transformations** — summarization, translation, style rewriting.\n",
+    "- **Simple classification** — \"is this email spam?\" Usually pattern-matching, not reasoning.\n",
+    "\n",
+    "A good production heuristic: **route on query type**. A router agent (cheap, fast, no thinking) inspects the user's question and delegates to either a thinking-heavy specialist or a fast specialist. We built exactly this composition pattern in M06."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4cb22498",
+   "metadata": {},
+   "source": [
+    "# Gemini 3+ — Thinking Levels\n",
+    "\n",
+    "On Gemini 3+, the API gains a coarser-grained control:\n",
+    "\n",
+    "| Setting | Maps to roughly |\n",
+    "|---|---|\n",
+    "| `thinking_level=MINIMAL` | Off / very low budget |\n",
+    "| `thinking_level=LOW` | ~1K thoughts |\n",
+    "| `thinking_level=MEDIUM` | ~4K thoughts |\n",
+    "| `thinking_level=HIGH` | Unlimited (model decides) |\n",
+    "\n",
+    "Use `thinking_level` on Gemini 3+ when you don't want to tune a number; use `thinking_budget` on 2.5 (and 3+) when you want precise control.\n",
+    "\n",
+    "One caveat worth knowing: **thought signatures persist across multi-turn tool calls on Gemini** — which means the thinking budget can be *reused* mid-conversation without reloading the reasoning. This is a Gemini-only property; no other frontier model ships it as of April 2026."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9f3b42d1",
+   "metadata": {},
+   "source": [
+    "# LiteLLM Parity — Partial\n",
+    "\n",
+    "Other providers ship something similar, with different vocabularies:\n",
+    "\n",
+    "- **OpenAI GPT-5 / o3**: `reasoning_effort` parameter (low/medium/high). Passes through LiteLLM.\n",
+    "- **Anthropic Claude 4.5+**: extended thinking via `thinking={\"type\": \"enabled\", \"budget_tokens\": N}`. Partial through LiteLLM — works for basic reasoning, breaks on tool calls.\n",
+    "- **Qwen / DeepSeek**: reasoning variants (e.g. `qwen3-32b-thinking`) have reasoning on by default; some support a `reasoning.effort` parameter.\n",
+    "\n",
+    "**None are as clean as Gemini's `ThinkingConfig`.** If reasoning budgets are a first-class requirement for your agent, native Gemini is where you get the most control."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7992d112",
+   "metadata": {},
+   "source": [
+    "# Your Turn\n",
+    "\n",
+    "1. **A problem where thinking matters.** Pose a 4-step logic puzzle to both `fast_agent` and `thinking_agent`. Does the fast one miss steps? Which gets the right answer?\n",
+    "2. **A problem where thinking doesn't matter.** Ask both agents for the capital of France. Is the latency difference noticeable? Is the answer the same?\n",
+    "3. **Scale the budget.** Create agents with budgets at 0, 512, 2048, 8192. Ask them a hard math problem. At what budget does quality stop improving?\n",
+    "4. **Include thoughts.** Set `include_thoughts=True` in a ThinkingConfig and check the response for thought tokens. What does the model's internal reasoning look like?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45526a2c",
+   "metadata": {},
+   "source": [
+    "# Key Takeaways\n",
+    "\n",
+    "- **Gemini 2.5+ supports `ThinkingConfig`** — a knob that allocates up to N internal reasoning tokens before the final answer.\n",
+    "- **`thinking_budget=0`** disables reasoning (instant, maybe wrong on hard problems). **`thinking_budget=2048+`** enables real reasoning (slower, more accurate on hard problems).\n",
+    "- **Cost model:** thought tokens billed at the output-token rate. Modest per-invocation cost; worth it for hard problems.\n",
+    "- **`BuiltInPlanner`** plumbs `ThinkingConfig` through to an `LlmAgent`. Same API from ADK's perspective.\n",
+    "- **Gemini 3+ adds `thinking_level`** (MINIMAL / LOW / MEDIUM / HIGH) — a coarser preset for when you don't want to tune a number.\n",
+    "- **Thought signatures persist across multi-turn tool calls** — Gemini-only. Reasoning carries through without reload.\n",
+    "- **Production pattern:** router decides between a thinking-heavy agent and a fast agent per query.\n",
+    "- **LiteLLM parity is partial.** OpenAI has `reasoning_effort`; Claude has `thinking=...`; Qwen has reasoning variants. None as clean as Gemini's `ThinkingConfig`.\n",
+    "\n",
+    "# Next up — M13: Live API voice agent\n",
+    "\n",
+    "The third Gemini unlock. Bidirectional audio streaming — voice-in, voice-out — with voice activity detection and interruption handling. The most differentiated Gemini-only capability on the market as of April 2026. Heads up: the Live API is genuinely fragile in some environments. If the demo doesn't run end-to-end on your machine, see `DEMOS_BROKEN.md` for the fallback."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/slides/module-12-thinking-budgets/index.html
+++ b/slides/module-12-thinking-budgets/index.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ADK Course — M12: Thinking Budgets</title>
+  <link rel="stylesheet" href="../shared/shared.css">
+  <link rel="stylesheet" href="../shared/slides.css">
+</head>
+<body>
+  <nav class="progress-strip">
+    <a href="../../index.html" class="progress-home">Course</a>
+    <div class="progress-title">M12 — Thinking Budgets</div>
+    <div class="progress-meta">
+      <span class="slide-counter">1 / 1</span>
+      <button class="theme-toggle">Theme</button>
+    </div>
+  </nav>
+
+  <main class="slide-viewport">
+
+  <div class="slide active" data-module="12" data-type="section-title">
+    <div class="topic-badge">Module 12 &middot; Part 2 Gemini unlocks</div>
+    <h1>Thinking budgets</h1>
+    <h3>Trade latency for reasoning quality</h3>
+    <p class="highlight-text">One knob, big effect.</p>
+  </div>
+
+  <div class="slide" data-module="12">
+    <h2>What thinking is</h2>
+    <p>Gemini 2.5+ models do an <strong>internal reasoning pass</strong> before producing the final answer. The reasoning tokens don't appear in the output; they're counted separately as <code>thoughts_token_count</code>.</p>
+    <p>You set a <strong>budget</strong> — a ceiling on internal reasoning — and Gemini spends up to that much thinking.</p>
+    <pre class="diagram">user prompt ──▶ [internal thinking: up to N tokens] ──▶ final answer
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                      invisible in output; billed separately</pre>
+  </div>
+
+  <div class="slide" data-module="12">
+    <h2>The knob</h2>
+<pre class="diagram">ThinkingConfig(
+    thinking_budget=N,       # 0 = off; 2048+ = serious reasoning
+    include_thoughts=False,  # set True to see the reasoning in output
+)</pre>
+    <p>Or, on Gemini 3+, the coarser preset:</p>
+<pre class="diagram">ThinkingConfig(thinking_level=MINIMAL | LOW | MEDIUM | HIGH)</pre>
+    <p style="color:var(--text-muted);font-size:0.9em;">We use <code>thinking_budget</code> (int) — works on 2.5 and later.</p>
+  </div>
+
+  <div class="slide" data-module="12" data-type="section-title" style="background:linear-gradient(135deg,var(--amber-dark) 0%,var(--amber) 100%);">
+    <h1>Live</h1>
+    <h3>Same problem at budget=0 vs budget=4096</h3>
+    <p class="highlight-text" style="color:white;">Notebook cell 7</p>
+  </div>
+
+  <div class="slide" data-module="12">
+    <h2>Direct comparison</h2>
+<pre class="diagram">Problem: multi-step profit-margin calculation, 3 breads.
+
+── thinking_budget=0 ──
+latency: &lt;1s
+tokens — input: 158, thoughts: 0, output: 702
+
+── thinking_budget=4096 ──
+latency: 11.06s
+tokens — input: 158, thoughts: 1109, output: 702</pre>
+    <p><strong>Same input. Same output length. Big latency + token gap.</strong> The 1109 thoughts are reasoning the model did internally.</p>
+  </div>
+
+  <div class="slide" data-module="12">
+    <h2>The even-better demo</h2>
+<pre class="diagram">USER: What is the sum of all prime numbers between 20 and 50?
+
+── fast_agent (thinking=0)    0.76s
+   Answer: 255  ← wrong
+
+── thinking_agent (thinking=2048)    9.98s
+   Answer: enumerated primes (23, 29, 31, 37, 41, 43, 47),
+           sum = 251  ← correct</pre>
+    <p><strong>The fast agent got a different — and wrong — answer.</strong> That's the quality difference, visible.</p>
+  </div>
+
+  <div class="slide" data-module="12" data-type="code">
+    <h2>Inside an ADK agent — <code>BuiltInPlanner</code></h2>
+<pre><code>from google.adk.planners import BuiltInPlanner
+from google.genai import types
+
+thinking_agent = LlmAgent(
+    name="thinking_agent",
+    model="gemini-2.5-flash",
+    instruction="Reason carefully for multi-step problems.",
+    planner=BuiltInPlanner(
+        thinking_config=types.ThinkingConfig(thinking_budget=2048),
+    ),
+)</code></pre>
+    <p class="code-caption"><code>BuiltInPlanner</code> wraps <code>ThinkingConfig</code> so ADK plumbs it through to Gemini. Everything else about the agent is unchanged.</p>
+  </div>
+
+  <div class="slide" data-module="12">
+    <h2>When thinking earns its keep</h2>
+    <div class="callout callout-tip">
+      <div class="callout-title">Crank the budget for</div>
+      <ul style="margin:0;">
+        <li>Multi-step reasoning (the profit-margin problem)</li>
+        <li>Code debugging (trace through logic)</li>
+        <li>Hard math, proofs, arithmetic</li>
+        <li>Multi-constraint planning / scheduling</li>
+      </ul>
+    </div>
+    <div class="callout callout-success">
+      <div class="callout-title">Skip thinking for</div>
+      <ul style="margin:0;">
+        <li>Factual lookups ("capital of France")</li>
+        <li>Text transformations (summarize, translate, rewrite)</li>
+        <li>Simple classification (spam? yes/no)</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="slide" data-module="12" data-type="keyfact">
+    <h2 class="text-muted" style="border-bottom:none;font-size:1em;text-transform:uppercase;letter-spacing:0.08em;">Production pattern</h2>
+    <p>Route <strong>on query type</strong>.</p>
+    <p style="font-size:0.75em;color:var(--text-muted);margin-top:var(--space-4);">Cheap, fast router with thinking=0.<br>Delegates to a thinking-heavy specialist or a fast one per query.<br>M06 composition.</p>
+  </div>
+
+  <div class="slide" data-module="12">
+    <h2>Gemini 3+ — thinking_level</h2>
+    <table>
+      <thead><tr><th>Setting</th><th>Maps to roughly</th></tr></thead>
+      <tbody>
+        <tr><td><code>thinking_level=MINIMAL</code></td><td>Off / very low budget</td></tr>
+        <tr><td><code>thinking_level=LOW</code></td><td>~1K thought tokens</td></tr>
+        <tr><td><code>thinking_level=MEDIUM</code></td><td>~4K thought tokens</td></tr>
+        <tr><td><code>thinking_level=HIGH</code></td><td>Unlimited; model decides</td></tr>
+      </tbody>
+    </table>
+    <p>Use <code>thinking_level</code> on 3+ when you don't want to pick a number. Use <code>thinking_budget</code> on 2.5 (and 3+) when you want precise control.</p>
+  </div>
+
+  <div class="slide" data-module="12" data-type="keyfact">
+    <h2 class="text-muted" style="border-bottom:none;font-size:1em;text-transform:uppercase;letter-spacing:0.08em;">Gemini-only property</h2>
+    <p>Thought signatures <strong>persist across multi-turn tool calls</strong>.</p>
+    <p style="font-size:0.75em;color:var(--text-muted);margin-top:var(--space-4);">No reasoning reload. Thinking carries through the conversation.<br>No other frontier model ships this as of April 2026.</p>
+  </div>
+
+  <div class="slide" data-module="12">
+    <h2>LiteLLM parity — partial</h2>
+    <table>
+      <thead><tr><th>Provider</th><th>Equivalent</th><th>LiteLLM works?</th></tr></thead>
+      <tbody>
+        <tr><td>OpenAI (GPT-5, o3)</td><td><code>reasoning_effort=low/medium/high</code></td><td>✅ Passes through</td></tr>
+        <tr><td>Anthropic (Claude 4.5+)</td><td><code>thinking=...</code></td><td>⚠️ Works basic; breaks on tool calls</td></tr>
+        <tr><td>Qwen / DeepSeek</td><td>Reasoning variants; some accept <code>reasoning.effort</code></td><td>⚠️ Varies</td></tr>
+      </tbody>
+    </table>
+    <p>None as clean as Gemini's <code>ThinkingConfig</code>. If reasoning control is a first-class requirement, native Gemini wins.</p>
+  </div>
+
+  <div class="slide" data-module="12" data-type="keyfact">
+    <h2 class="text-muted" style="border-bottom:none;font-size:1em;text-transform:uppercase;letter-spacing:0.08em;">What to carry forward</h2>
+    <p><strong>Thinking is a knob, not a default.</strong></p>
+    <p style="font-size:0.75em;color:var(--text-muted);margin-top:var(--space-4);">Crank it for hard problems. Leave it at 0 for easy ones. Route per query.</p>
+  </div>
+
+  <div class="slide" data-module="12" data-type="section-title" style="background:linear-gradient(135deg,var(--navy) 0%,var(--navy-light) 100%);">
+    <div class="topic-badge">Up next</div>
+    <h1>M13 &mdash; Live API voice agent</h1>
+    <p class="highlight-text">Bidirectional audio streaming. The biggest Gemini unlock.</p>
+  </div>
+
+  </main>
+
+  <script src="../shared/slides.js"></script>
+</body>
+</html>

--- a/slides/module-12-thinking-budgets/speaker_notes.md
+++ b/slides/module-12-thinking-budgets/speaker_notes.md
@@ -1,0 +1,133 @@
+# M12 — Speaker notes
+
+Spoken delivery. One section per slide.
+
+---
+
+## Slide 1 — Title
+
+Module twelve. Thinking budgets. The second Gemini-only unlock in Part 2. Simpler than grounding and caching; one knob, big effect on reasoning-heavy tasks.
+
+---
+
+## Slide 2 — What thinking is
+
+Gemini 2.5 and later models do an internal reasoning pass before they produce the final answer. You don't see the reasoning in the text — it's not part of the output field. It's counted separately as `thoughts_token_count` in the usage metadata, and it takes real wall-clock time.
+
+You set a budget — a ceiling on how many internal reasoning tokens the model can spend — and Gemini spends up to that much thinking before writing its answer.
+
+The picture: user prompt goes in. Up to N invisible reasoning tokens get consumed internally. Then the final answer comes out. The reasoning is billed separately and doesn't appear in what the user reads.
+
+---
+
+## Slide 3 — The knob
+
+The API. `ThinkingConfig(thinking_budget=N, include_thoughts=False)`. `thinking_budget=0` turns reasoning off; `thinking_budget=2048` or higher enables real reasoning. `include_thoughts=True` makes the reasoning tokens visible in the output — useful for debugging.
+
+Gemini 3 and later add a coarser control, `thinking_level`, with MINIMAL, LOW, MEDIUM, HIGH presets. On 3-plus use whichever fits your preference for explicit control versus preset simplicity.
+
+---
+
+## Slide 4 — Live: budget comparison
+
+Switch to the notebook. Cell seven. We run the same multi-step profit-margin problem twice — once with `thinking_budget=0`, once with `thinking_budget=4096`. Same prompt. Same model. Watch the latency, the thought-token count, and the answer quality.
+
+---
+
+## Slide 5 — Direct comparison
+
+Back on the slide. Here's what you saw. Same input tokens — 158 both runs. Same output tokens — 702 both runs. 
+
+With budget=0: latency under a second, zero thought tokens.
+
+With budget=4096: eleven seconds of latency, 1109 thought tokens consumed — well within the budget but still substantial reasoning.
+
+Same inputs, same outputs, big latency and token gap. The 1109 thought tokens are reasoning the model did internally that never reached the user.
+
+---
+
+## Slide 6 — Prime-sum demo
+
+The even better demo, from cell ten. Simple question: what's the sum of primes between 20 and 50?
+
+fast_agent with thinking=0: answers in under a second. Says 255. That's wrong.
+
+thinking_agent with thinking=2048: takes ten seconds. Enumerates the primes — 23, 29, 31, 37, 41, 43, 47 — sums them, arrives at 251. Correct.
+
+One agent got the right answer; the other got a wrong answer. The difference was the thinking budget. That's the reasoning quality delta, made visible.
+
+---
+
+## Slide 7 — BuiltInPlanner code
+
+Wiring it into an ADK agent. `BuiltInPlanner(thinking_config=...)` passed as the `planner` argument. Everything else about the agent — name, model, instruction, tools — works the same way we've been doing it for twelve modules.
+
+The planner is how ADK exposes features that affect how the model thinks, without adding them to the agent constructor. Future planners can add other pre-reasoning patterns; today, it's the thinking budget.
+
+---
+
+## Slide 8 — When to use thinking
+
+When thinking earns its keep. Crank the budget for multi-step reasoning — the profit-margin problem, logic puzzles, scheduling, dependency-aware planning. Crank it for code debugging where the model has to trace logic. Crank it for hard math, proofs, arithmetic problems.
+
+Skip thinking for factual lookups — "capital of France" — the model already knows; no reasoning needed. Skip it for text transformations — summarization, translation, style rewriting — those are pattern matches, not reasoning. Skip it for simple classification like spam detection.
+
+The heuristic: does the problem require the model to work something out step by step? Crank the budget. Does it require the model to retrieve something it already knows? Skip.
+
+---
+
+## Slide 9 — Production pattern
+
+The production pattern on one slide. Route on query type.
+
+A cheap, fast router agent with thinking=0 inspects the user's question. It doesn't answer; it just decides which specialist to call. Then it delegates — to a thinking-heavy agent for hard problems, to a fast agent for easy ones.
+
+You already know how to build this. It's the M06 composition pattern. A coordinator, two specialists — one thinking-heavy, one fast. Use `AgentTool` so the coordinator calls them like functions and stays in charge of the conversation.
+
+Payoff: you get the reasoning quality of a thinking-heavy agent for the queries that need it, and the latency of a fast agent for the queries that don't. Best of both worlds, per query.
+
+---
+
+## Slide 10 — Gemini 3+ levels
+
+On Gemini 3 and later, a coarser preset-based API. `thinking_level=MINIMAL` is roughly off. LOW is about a thousand thought tokens. MEDIUM is about four thousand. HIGH is unlimited — the model decides how much to think.
+
+Use levels on 3+ when you don't care about the exact number. Use budgets on 2.5 or 3+ when you want precise control. Both APIs coexist on 3+.
+
+---
+
+## Slide 11 — Thought signature persistence
+
+One more Gemini-only property worth naming. Thought signatures persist across multi-turn tool calls in a conversation.
+
+What that means practically: if the model reasoned through a problem in turn one, and turn two involves a follow-up question that depends on the same reasoning, Gemini preserves the reasoning context without re-thinking from scratch. The thinking budget isn't spent again; the prior reasoning carries through.
+
+No other frontier model ships this as of April 2026. OpenAI's reasoning_effort starts fresh each turn. Claude's extended thinking resets. Gemini carries forward.
+
+For agents that have multi-turn tool-heavy conversations on hard problems — coding assistants, research agents, debugging bots — this is meaningful. You pay the reasoning cost once per session, not per turn.
+
+---
+
+## Slide 12 — LiteLLM parity
+
+Other providers ship similar knobs with different vocabularies.
+
+OpenAI GPT-5 and o3 have `reasoning_effort` — a low-medium-high preset. Passes through LiteLLM cleanly; you set it in the same place you'd set thinking_level on Gemini.
+
+Anthropic's Claude 4.5 and later have extended thinking via `thinking={"type": "enabled", "budget_tokens": N}`. Partial through LiteLLM — works for basic reasoning calls, breaks on calls that involve tools. If you need thinking on Claude with tool calls, check the LiteLLM issue tracker.
+
+Qwen and DeepSeek have reasoning-variant models where reasoning is on by default. Some accept a `reasoning.effort` parameter; varies.
+
+None are as clean as Gemini's `ThinkingConfig`. If reasoning control is a first-class requirement for your agent, native Gemini is where you get the most reliable API for it.
+
+---
+
+## Slide 13 — Carry forward
+
+What to carry forward. Thinking is a knob, not a default. Crank it for hard problems. Leave it at zero for easy ones. Route per query via M06 composition.
+
+---
+
+## Slide 14 — Next
+
+Module thirteen. The third and final Gemini unlock. Live API voice agent. Bidirectional audio streaming — voice in, voice out — with voice activity detection and interruption handling. Genuinely the most differentiated capability on the market as of April 2026. Fair warning: the Live API is the most fragile of the three unlocks. If the demo doesn't run in your environment, there's a DEMOS_BROKEN.md entry with the fallback path. See you there.

--- a/textbook/_sources/chapters/12-thinking-budgets.md
+++ b/textbook/_sources/chapters/12-thinking-budgets.md
@@ -1,0 +1,189 @@
+# Thinking budgets
+
+The second Gemini-only unlock. Simpler than grounding and caching; one knob, big effect.
+
+Gemini 2.5+ models support **thinking** — an internal reasoning pass the model does before producing the final answer. The tokens consumed during thinking don't appear in the output text; they're billed as a separate category (`thoughts_token_count`) and they take real wall-clock time.
+
+`ThinkingConfig.thinking_budget` is the knob. Set it to 0 for instant responses (no internal reasoning); set it to 2048+ for hard problems where reasoning pays off. The trade-off is explicit — you spend tokens and latency in exchange for answer quality on reasoning-heavy tasks.
+
+## How thinking works
+
+When you give Gemini 2.5+ a `thinking_budget` greater than zero, the model internally does a reasoning pass before generating the visible response. That reasoning is a real LLM operation — tokens are consumed, time is spent — but it's kept separate from the output text. The usage-metadata object ADK returns surfaces three token counts:
+
+- `prompt_token_count` — what you sent in.
+- `thoughts_token_count` — internal reasoning (only present when thinking was enabled).
+- `candidates_token_count` — visible output text.
+
+All three are billed at the respective model rates. Thought tokens bill at the output-token rate (e.g., $0.30/M on Flash). Modest per-invocation cost; worth it for hard problems.
+
+Two ways to control thinking:
+
+| Setting | Type | Use |
+|---|---|---|
+| `thinking_budget=0` | int | Disable thinking. Instant response. |
+| `thinking_budget=N` | int | Allow up to N thought tokens. Gemini may use less. |
+| `thinking_level=LOW/MEDIUM/HIGH` | enum | Gemini 3+ only; coarser preset. |
+
+The `thinking_level` form is the Gemini-3 addition. Use it when you don't want to pick a number; use `thinking_budget` when you want precise control.
+
+## Direct comparison — same problem, two budgets
+
+The notebook runs a reasoning-heavy problem through Gemini twice — once with `thinking_budget=0`, once with `thinking_budget=4096`.
+
+```python
+from google import genai
+from google.genai import types
+
+client = genai.Client(api_key=GOOGLE_API_KEY)
+
+PROBLEM = """A small bakery sells three types of bread with different revenue,
+labor time, and flour cost. Which has the highest profit margin? ..."""
+
+for budget in [0, 4096]:
+    resp = client.models.generate_content(
+        model="gemini-2.5-flash",
+        contents=PROBLEM,
+        config=types.GenerateContentConfig(
+            thinking_config=types.ThinkingConfig(thinking_budget=budget),
+        ),
+    )
+    print(f"budget={budget}: latency={...}s, thoughts={resp.usage_metadata.thoughts_token_count}")
+```
+
+Typical output:
+
+```
+── thinking_budget=0 ──
+latency: <1s
+tokens — input: 158, thoughts: 0, output: 702
+
+── thinking_budget=4096 ──
+latency: 11.06s
+tokens — input: 158, thoughts: 1109, output: 702
+```
+
+Same inputs, same outputs in size — 702 tokens both times. Big latency and thought-token gap. The 1109 thought tokens are reasoning the model did internally that never reached the user's screen.
+
+## The even better demo — visible quality delta
+
+For a tighter example, ask both a thinking-disabled agent and a thinking-enabled agent:
+
+> What is the sum of all prime numbers between 20 and 50?
+
+The correct answer is `251` (primes are 23, 29, 31, 37, 41, 43, 47).
+
+Typical results:
+
+```
+── fast_agent (thinking=0)    0.76s
+   Answer: 255   ← wrong
+
+── thinking_agent (thinking=2048)    9.98s
+   Answer: enumerated primes, sum = 251   ← correct
+```
+
+One agent got the right answer; one got a wrong answer. The difference was the thinking budget. Quality delta made visible.
+
+This doesn't happen every time — sometimes `thinking=0` gets reasoning problems right by accident. But in a statistically meaningful sample, the thinking-enabled agent is reliably better on tasks that require step-by-step work. That's the property you're paying for.
+
+## Wiring thinking into an ADK agent — `BuiltInPlanner`
+
+ADK exposes thinking via a `planner=` argument on `LlmAgent`. The concrete planner class is `BuiltInPlanner`, which wraps a `ThinkingConfig`:
+
+```python
+from google.adk.agents import LlmAgent
+from google.adk.planners import BuiltInPlanner
+from google.genai import types
+
+thinking_agent = LlmAgent(
+    name="thinking_agent",
+    model="gemini-2.5-flash",
+    description="Reasoning agent with a generous thinking budget.",
+    instruction="Answer user questions. Reason carefully for multi-step problems.",
+    planner=BuiltInPlanner(
+        thinking_config=types.ThinkingConfig(thinking_budget=2048),
+    ),
+)
+```
+
+Everything else about the agent — tools, sub-agents, callbacks, memory, output_key — works the same. The planner is a plug-in point for features that affect how the model thinks, without expanding the constructor signature. Future planners may add other pre-reasoning patterns; today, the built-in one exposes the thinking budget.
+
+## When thinking earns its keep
+
+Thinking budgets are not free. Tokens cost money; latency costs user patience. Crank the budget for:
+
+- **Multi-step reasoning.** The bakery profit-margin problem. Logic puzzles. Chain-of-inference questions.
+- **Code debugging.** The model has to trace through code logic; thinking helps significantly.
+- **Hard math.** Arithmetic, algebra, proofs, combinatorics.
+- **Multi-constraint planning.** Itinerary-building, resource allocation, scheduling with dependencies.
+
+Skip thinking for:
+
+- **Factual lookups.** "Capital of France", "weather in Prague". The model already knows — no reasoning needed.
+- **Text transformations.** Summarization, translation, style rewriting. These are pattern-matches, not reasoning.
+- **Simple classification.** "Is this email spam?" Usually pattern-recognition, rarely benefits from step-by-step thought.
+
+The simple heuristic: **does the problem require the model to work something out step by step?** Crank the budget. Does it require retrieving something the model already knows? Skip.
+
+## Production pattern — route on query type
+
+The practical composition: a cheap, fast **router agent** with `thinking=0` inspects the user's query. It doesn't answer; it classifies. Based on the classification, it delegates to either:
+
+- A **thinking-heavy specialist** for reasoning-intensive queries (math, debugging, planning).
+- A **fast specialist** for retrieval-style queries (facts, definitions, simple chat).
+
+This is the M06 composition pattern applied to thinking. Use `AgentTool` so the router calls the specialists like functions and stays in charge of composition. The result: reasoning quality on the queries that need it, low latency on the ones that don't.
+
+```python
+# Sketch
+router = LlmAgent(
+    model="gemini-2.5-flash",
+    planner=BuiltInPlanner(thinking_config=types.ThinkingConfig(thinking_budget=0)),
+    instruction="Classify the query. Call fast_specialist for lookups, "
+                "thinking_specialist for reasoning problems.",
+    tools=[AgentTool(agent=fast_specialist),
+           AgentTool(agent=thinking_specialist)],
+)
+```
+
+The router spends zero thinking tokens — its job is pattern-recognition — and delegates the hard problems to the specialist with the budget to solve them.
+
+## Gemini-only property — thought-signature persistence
+
+One more Gemini-only fact worth naming. **Thought signatures persist across multi-turn tool calls** within a conversation.
+
+What that means practically: if the model reasoned through a problem in turn one, and turn two involves a follow-up that depends on the same reasoning, Gemini preserves the reasoning context without re-thinking from scratch. The thinking budget isn't consumed again; the prior reasoning carries through.
+
+No other frontier model ships this as of April 2026. OpenAI's `reasoning_effort` starts fresh each turn. Claude's extended thinking resets. Gemini carries forward.
+
+For agents that have multi-turn tool-heavy conversations on hard problems — coding assistants, research agents, debugging bots — this is meaningful. You pay the reasoning cost once per session, not per turn.
+
+## LiteLLM parity — partial
+
+Other providers ship similar knobs. None are as clean as Gemini's `ThinkingConfig`:
+
+| Provider | Equivalent | Works through LiteLLM? |
+|---|---|---|
+| **OpenAI** (GPT-5, o3) | `reasoning_effort=low/medium/high` | ✅ Passes through |
+| **Anthropic** (Claude 4.5+) | `thinking={"type": "enabled", "budget_tokens": N}` | ⚠️ Works basic; breaks on tool calls |
+| **Qwen / DeepSeek** | Reasoning-variant models; some accept `reasoning.effort` | ⚠️ Varies by variant |
+
+If reasoning budgets are a first-class requirement for your agent architecture, native Gemini is where you get the most reliable API. For everything else, LiteLLM's partial parity is fine.
+
+## What to carry forward
+
+- **Thinking is a knob, not a default.** Crank it for hard problems; leave it at 0 for easy ones.
+- **`thinking_budget`** (int) is Gemini 2.5's control; **`thinking_level`** (enum) is Gemini 3+'s coarser preset.
+- **Cost**: thought tokens billed at the output-token rate. Modest per-invocation cost.
+- **`BuiltInPlanner`** plumbs `ThinkingConfig` through to an `LlmAgent` via the `planner=` argument.
+- **Production pattern**: router with thinking=0 delegates to specialists (thinking-heavy or fast) per query type.
+- **Gemini-only property**: thought signatures persist across multi-turn tool calls. No other frontier model does this.
+- **LiteLLM parity is partial.** OpenAI's `reasoning_effort` works cleanly; Claude's thinking breaks on tool calls.
+
+## Your turn
+
+1. **A problem where thinking matters.** Pose a 4-step logic puzzle to both `fast_agent` and `thinking_agent`. Does the fast one miss steps?
+2. **Scale the budget.** Agents at budgets 0, 512, 2048, 8192. Hard math problem. At what budget does quality stop improving?
+3. **Include thoughts.** Set `include_thoughts=True` in a `ThinkingConfig` and inspect the response. What does the model's internal reasoning look like?
+
+Module 13 — the last of the three Gemini unlocks — covers the **Live API**: bidirectional voice streaming with voice activity detection and interruption. It's the single most differentiated Gemini-only capability on the market as of April 2026. Fair warning: the Live API is genuinely fragile in some environments. If the notebook demo doesn't run end-to-end on your machine, the course's `DEMOS_BROKEN.md` logs the fallback path.

--- a/textbook/index.html
+++ b/textbook/index.html
@@ -323,6 +323,7 @@ hr {
 <li><a href="#evaluation">9. Evaluation</a></li>
 <li><a href="#deployment">10. Deployment</a></li>
 <li><a href="#gemini-unlocks-grounding-and-context-caching">11. Gemini unlocks — grounding and context caching</a></li>
+<li><a href="#thinking-budgets">12. Thinking budgets</a></li>
             </ul>
         </nav>
     </aside>
@@ -2287,6 +2288,196 @@ storage: 50K × 1h × $0.01/1M = $0.0005
 <li><strong>Production pattern</strong>: LiteLLM-wrapped for portable routine work, native Gemini for grounding/caching/Live. Compose them with <code>sub_agents</code> or <code>AgentTool</code>.</li>
 </ul>
 <p>Module 12 picks up the third Gemini-only capability: <strong>thinking budgets</strong>. A knob you set on the model that trades latency for reasoning quality. Same problem at <code>thinking_budget=0</code> (instant, maybe wrong) versus <code>thinking_budget=8192</code> (slower, probably right). We&rsquo;ll run the same math problem at both and watch the answer change along with the latency.</p>
+        </section>
+
+        <section class="chapter" id="thinking-budgets">
+            <div class="chapter-number">Chapter 12</div>
+            <h1>Thinking budgets</h1>
+<p>The second Gemini-only unlock. Simpler than grounding and caching; one knob, big effect.</p>
+<p>Gemini 2.5+ models support <strong>thinking</strong> — an internal reasoning pass the model does before producing the final answer. The tokens consumed during thinking don&rsquo;t appear in the output text; they&rsquo;re billed as a separate category (<code>thoughts_token_count</code>) and they take real wall-clock time.</p>
+<p><code>ThinkingConfig.thinking_budget</code> is the knob. Set it to 0 for instant responses (no internal reasoning); set it to 2048+ for hard problems where reasoning pays off. The trade-off is explicit — you spend tokens and latency in exchange for answer quality on reasoning-heavy tasks.</p>
+<h2>How thinking works</h2>
+<p>When you give Gemini 2.5+ a <code>thinking_budget</code> greater than zero, the model internally does a reasoning pass before generating the visible response. That reasoning is a real LLM operation — tokens are consumed, time is spent — but it&rsquo;s kept separate from the output text. The usage-metadata object ADK returns surfaces three token counts:</p>
+<ul>
+<li><code>prompt_token_count</code> — what you sent in.</li>
+<li><code>thoughts_token_count</code> — internal reasoning (only present when thinking was enabled).</li>
+<li><code>candidates_token_count</code> — visible output text.</li>
+</ul>
+<p>All three are billed at the respective model rates. Thought tokens bill at the output-token rate (e.g., $0.30/M on Flash). Modest per-invocation cost; worth it for hard problems.</p>
+<p>Two ways to control thinking:</p>
+<table>
+<thead>
+<tr>
+<th>Setting</th>
+<th>Type</th>
+<th>Use</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>thinking_budget=0</code></td>
+<td>int</td>
+<td>Disable thinking. Instant response.</td>
+</tr>
+<tr>
+<td><code>thinking_budget=N</code></td>
+<td>int</td>
+<td>Allow up to N thought tokens. Gemini may use less.</td>
+</tr>
+<tr>
+<td><code>thinking_level=LOW/MEDIUM/HIGH</code></td>
+<td>enum</td>
+<td>Gemini 3+ only; coarser preset.</td>
+</tr>
+</tbody>
+</table>
+<p>The <code>thinking_level</code> form is the Gemini-3 addition. Use it when you don&rsquo;t want to pick a number; use <code>thinking_budget</code> when you want precise control.</p>
+<h2>Direct comparison — same problem, two budgets</h2>
+<p>The notebook runs a reasoning-heavy problem through Gemini twice — once with <code>thinking_budget=0</code>, once with <code>thinking_budget=4096</code>.</p>
+<pre><code class="language-python">from google import genai
+from google.genai import types
+
+client = genai.Client(api_key=GOOGLE_API_KEY)
+
+PROBLEM = &quot;&quot;&quot;A small bakery sells three types of bread with different revenue,
+labor time, and flour cost. Which has the highest profit margin? ...&quot;&quot;&quot;
+
+for budget in [0, 4096]:
+    resp = client.models.generate_content(
+        model=&quot;gemini-2.5-flash&quot;,
+        contents=PROBLEM,
+        config=types.GenerateContentConfig(
+            thinking_config=types.ThinkingConfig(thinking_budget=budget),
+        ),
+    )
+    print(f&quot;budget={budget}: latency={...}s, thoughts={resp.usage_metadata.thoughts_token_count}&quot;)
+</code></pre>
+<p>Typical output:</p>
+<pre><code>── thinking_budget=0 ──
+latency: &lt;1s
+tokens — input: 158, thoughts: 0, output: 702
+
+── thinking_budget=4096 ──
+latency: 11.06s
+tokens — input: 158, thoughts: 1109, output: 702
+</code></pre>
+<p>Same inputs, same outputs in size — 702 tokens both times. Big latency and thought-token gap. The 1109 thought tokens are reasoning the model did internally that never reached the user&rsquo;s screen.</p>
+<h2>The even better demo — visible quality delta</h2>
+<p>For a tighter example, ask both a thinking-disabled agent and a thinking-enabled agent:</p>
+<blockquote>
+<p>What is the sum of all prime numbers between 20 and 50?</p>
+</blockquote>
+<p>The correct answer is <code>251</code> (primes are 23, 29, 31, 37, 41, 43, 47).</p>
+<p>Typical results:</p>
+<pre><code>── fast_agent (thinking=0)    0.76s
+   Answer: 255   ← wrong
+
+── thinking_agent (thinking=2048)    9.98s
+   Answer: enumerated primes, sum = 251   ← correct
+</code></pre>
+<p>One agent got the right answer; one got a wrong answer. The difference was the thinking budget. Quality delta made visible.</p>
+<p>This doesn&rsquo;t happen every time — sometimes <code>thinking=0</code> gets reasoning problems right by accident. But in a statistically meaningful sample, the thinking-enabled agent is reliably better on tasks that require step-by-step work. That&rsquo;s the property you&rsquo;re paying for.</p>
+<h2>Wiring thinking into an ADK agent — <code>BuiltInPlanner</code></h2>
+<p>ADK exposes thinking via a <code>planner=</code> argument on <code>LlmAgent</code>. The concrete planner class is <code>BuiltInPlanner</code>, which wraps a <code>ThinkingConfig</code>:</p>
+<pre><code class="language-python">from google.adk.agents import LlmAgent
+from google.adk.planners import BuiltInPlanner
+from google.genai import types
+
+thinking_agent = LlmAgent(
+    name=&quot;thinking_agent&quot;,
+    model=&quot;gemini-2.5-flash&quot;,
+    description=&quot;Reasoning agent with a generous thinking budget.&quot;,
+    instruction=&quot;Answer user questions. Reason carefully for multi-step problems.&quot;,
+    planner=BuiltInPlanner(
+        thinking_config=types.ThinkingConfig(thinking_budget=2048),
+    ),
+)
+</code></pre>
+<p>Everything else about the agent — tools, sub-agents, callbacks, memory, output_key — works the same. The planner is a plug-in point for features that affect how the model thinks, without expanding the constructor signature. Future planners may add other pre-reasoning patterns; today, the built-in one exposes the thinking budget.</p>
+<h2>When thinking earns its keep</h2>
+<p>Thinking budgets are not free. Tokens cost money; latency costs user patience. Crank the budget for:</p>
+<ul>
+<li><strong>Multi-step reasoning.</strong> The bakery profit-margin problem. Logic puzzles. Chain-of-inference questions.</li>
+<li><strong>Code debugging.</strong> The model has to trace through code logic; thinking helps significantly.</li>
+<li><strong>Hard math.</strong> Arithmetic, algebra, proofs, combinatorics.</li>
+<li><strong>Multi-constraint planning.</strong> Itinerary-building, resource allocation, scheduling with dependencies.</li>
+</ul>
+<p>Skip thinking for:</p>
+<ul>
+<li><strong>Factual lookups.</strong> &ldquo;Capital of France&rdquo;, &ldquo;weather in Prague&rdquo;. The model already knows — no reasoning needed.</li>
+<li><strong>Text transformations.</strong> Summarization, translation, style rewriting. These are pattern-matches, not reasoning.</li>
+<li><strong>Simple classification.</strong> &ldquo;Is this email spam?&rdquo; Usually pattern-recognition, rarely benefits from step-by-step thought.</li>
+</ul>
+<p>The simple heuristic: <strong>does the problem require the model to work something out step by step?</strong> Crank the budget. Does it require retrieving something the model already knows? Skip.</p>
+<h2>Production pattern — route on query type</h2>
+<p>The practical composition: a cheap, fast <strong>router agent</strong> with <code>thinking=0</code> inspects the user&rsquo;s query. It doesn&rsquo;t answer; it classifies. Based on the classification, it delegates to either:</p>
+<ul>
+<li>A <strong>thinking-heavy specialist</strong> for reasoning-intensive queries (math, debugging, planning).</li>
+<li>A <strong>fast specialist</strong> for retrieval-style queries (facts, definitions, simple chat).</li>
+</ul>
+<p>This is the M06 composition pattern applied to thinking. Use <code>AgentTool</code> so the router calls the specialists like functions and stays in charge of composition. The result: reasoning quality on the queries that need it, low latency on the ones that don&rsquo;t.</p>
+<pre><code class="language-python"># Sketch
+router = LlmAgent(
+    model=&quot;gemini-2.5-flash&quot;,
+    planner=BuiltInPlanner(thinking_config=types.ThinkingConfig(thinking_budget=0)),
+    instruction=&quot;Classify the query. Call fast_specialist for lookups, &quot;
+                &quot;thinking_specialist for reasoning problems.&quot;,
+    tools=[AgentTool(agent=fast_specialist),
+           AgentTool(agent=thinking_specialist)],
+)
+</code></pre>
+<p>The router spends zero thinking tokens — its job is pattern-recognition — and delegates the hard problems to the specialist with the budget to solve them.</p>
+<h2>Gemini-only property — thought-signature persistence</h2>
+<p>One more Gemini-only fact worth naming. <strong>Thought signatures persist across multi-turn tool calls</strong> within a conversation.</p>
+<p>What that means practically: if the model reasoned through a problem in turn one, and turn two involves a follow-up that depends on the same reasoning, Gemini preserves the reasoning context without re-thinking from scratch. The thinking budget isn&rsquo;t consumed again; the prior reasoning carries through.</p>
+<p>No other frontier model ships this as of April 2026. OpenAI&rsquo;s <code>reasoning_effort</code> starts fresh each turn. Claude&rsquo;s extended thinking resets. Gemini carries forward.</p>
+<p>For agents that have multi-turn tool-heavy conversations on hard problems — coding assistants, research agents, debugging bots — this is meaningful. You pay the reasoning cost once per session, not per turn.</p>
+<h2>LiteLLM parity — partial</h2>
+<p>Other providers ship similar knobs. None are as clean as Gemini&rsquo;s <code>ThinkingConfig</code>:</p>
+<table>
+<thead>
+<tr>
+<th>Provider</th>
+<th>Equivalent</th>
+<th>Works through LiteLLM?</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>OpenAI</strong> (GPT-5, o3)</td>
+<td><code>reasoning_effort=low/medium/high</code></td>
+<td>✅ Passes through</td>
+</tr>
+<tr>
+<td><strong>Anthropic</strong> (Claude 4.5+)</td>
+<td><code>thinking={"type": "enabled", "budget_tokens": N}</code></td>
+<td>⚠️ Works basic; breaks on tool calls</td>
+</tr>
+<tr>
+<td><strong>Qwen / DeepSeek</strong></td>
+<td>Reasoning-variant models; some accept <code>reasoning.effort</code></td>
+<td>⚠️ Varies by variant</td>
+</tr>
+</tbody>
+</table>
+<p>If reasoning budgets are a first-class requirement for your agent architecture, native Gemini is where you get the most reliable API. For everything else, LiteLLM&rsquo;s partial parity is fine.</p>
+<h2>What to carry forward</h2>
+<ul>
+<li><strong>Thinking is a knob, not a default.</strong> Crank it for hard problems; leave it at 0 for easy ones.</li>
+<li><strong><code>thinking_budget</code></strong> (int) is Gemini 2.5&rsquo;s control; <strong><code>thinking_level</code></strong> (enum) is Gemini 3+&rsquo;s coarser preset.</li>
+<li><strong>Cost</strong>: thought tokens billed at the output-token rate. Modest per-invocation cost.</li>
+<li><strong><code>BuiltInPlanner</code></strong> plumbs <code>ThinkingConfig</code> through to an <code>LlmAgent</code> via the <code>planner=</code> argument.</li>
+<li><strong>Production pattern</strong>: router with thinking=0 delegates to specialists (thinking-heavy or fast) per query type.</li>
+<li><strong>Gemini-only property</strong>: thought signatures persist across multi-turn tool calls. No other frontier model does this.</li>
+<li><strong>LiteLLM parity is partial.</strong> OpenAI&rsquo;s <code>reasoning_effort</code> works cleanly; Claude&rsquo;s thinking breaks on tool calls.</li>
+</ul>
+<h2>Your turn</h2>
+<ol>
+<li><strong>A problem where thinking matters.</strong> Pose a 4-step logic puzzle to both <code>fast_agent</code> and <code>thinking_agent</code>. Does the fast one miss steps?</li>
+<li><strong>Scale the budget.</strong> Agents at budgets 0, 512, 2048, 8192. Hard math problem. At what budget does quality stop improving?</li>
+<li><strong>Include thoughts.</strong> Set <code>include_thoughts=True</code> in a <code>ThinkingConfig</code> and inspect the response. What does the model&rsquo;s internal reasoning look like?</li>
+</ol>
+<p>Module 13 — the last of the three Gemini unlocks — covers the <strong>Live API</strong>: bidirectional voice streaming with voice activity detection and interruption. It&rsquo;s the single most differentiated Gemini-only capability on the market as of April 2026. Fair warning: the Live API is genuinely fragile in some environments. If the notebook demo doesn&rsquo;t run end-to-end on your machine, the course&rsquo;s <code>DEMOS_BROKEN.md</code> logs the fallback path.</p>
         </section>
         </main>
     </div>


### PR DESCRIPTION
Module 12. Gemini 2.5+ ThinkingConfig — the knob that trades latency for reasoning quality. A/B demo shows thinking=0 getting a WRONG answer (255 for sum of primes 20-50) while thinking=2048 gets the correct 251. BuiltInPlanner wires it into an ADK agent. Production pattern: router on thinking=0 delegates to thinking-heavy or fast specialists per query type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)