### PR TITLE
course(M14): A2A protocol — course finale

### DIFF
--- a/index.html
+++ b/index.html
@@ -350,14 +350,14 @@
   <h2>Module 14</h2>
   <div class="modules">
 
-    <div class="module soon">
+    <a class="module" href="slides/module-14-a2a/index.html">
       <div class="num">M14</div>
       <div>
         <div class="title">A2A protocol</div>
         <div class="desc">Agent-to-agent communication: Agent Cards, Tasks, <code>RemoteA2aAgent</code>.</div>
       </div>
-      <div class="status soon">Soon</div>
-    </div>
+      <div class="status ready">Ready</div>
+    </a>
 
   </div>
 </section>

--- a/notebooks/14_a2a_protocol.ipynb
+++ b/notebooks/14_a2a_protocol.ipynb
@@ -1,0 +1,428 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a6f70cc3",
+   "metadata": {},
+   "source": [
+    "# Module 14 — A2A Protocol (the Side Step)\n",
+    "\n",
+    "The course finale. Thirty minutes on something that isn't strictly ADK at all — the **A2A protocol**, the industry standard for agent-to-agent communication.\n",
+    "\n",
+    "You've seen agents talk to tools (M02 — MCP is the protocol for that). This module is about agents talking to **other agents** — across processes, across organizations, possibly written in completely different frameworks.\n",
+    "\n",
+    "Google launched A2A at Cloud Next 2025, donated it to the Linux Foundation in June 2025, IBM's competing ACP merged in under A2A in August 2025, and v1.0 of the spec landed in early 2026. It's now the de facto standard: ~150 founding-member organizations, five language SDKs, governance under the Linux Foundation's Technical Steering Committee.\n",
+    "\n",
+    "This is the single most durable thing in this course. MCP and A2A together will outlast any specific model, any specific framework, any specific vendor.\n",
+    "\n",
+    "**What you'll build:**\n",
+    "- An ADK agent exposed over A2A via `to_a2a()` — a Starlette+uvicorn service.\n",
+    "- An Agent Card inspected at `/.well-known/agent-card.json`.\n",
+    "- A `RemoteA2aAgent` in another process that consumes the first agent as if it were local.\n",
+    "\n",
+    "**What you'll leave with:**\n",
+    "- The four A2A nouns (Agent Card, Task, Message, Artifact).\n",
+    "- The A2A-vs-MCP mental model.\n",
+    "- The `use_legacy=False` fix that matters in production.\n",
+    "- A honest read on A2A's maturity (v1.0 spec; ADK integration still `@a2a_experimental`).\n",
+    "\n",
+    "**Running cost:** under $0.01 (one OpenRouter call via the remote agent)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e50d77c",
+   "metadata": {},
+   "source": [
+    "# Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b4c3b769",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -q google-adk==1.28.0 litellm==1.83.4 a2a-sdk uvicorn python-dotenv==1.0.1 nest-asyncio==1.6.0 deprecated==1.2.18 2>/dev/null\n",
+    "print(\"✅ Packages installed.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f90c877b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os, sys, warnings\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "try: sys.stderr.fileno()\n",
+    "except Exception: sys.stderr = open(os.devnull, \"w\")\n",
+    "\n",
+    "OPENROUTER_API_KEY = None\n",
+    "try:\n",
+    "    from google.colab import userdata\n",
+    "    OPENROUTER_API_KEY = userdata.get(\"OPENROUTER_API_KEY\")\n",
+    "except Exception:\n",
+    "    try:\n",
+    "        from dotenv import load_dotenv; load_dotenv()\n",
+    "        OPENROUTER_API_KEY = os.getenv(\"OPENROUTER_API_KEY\")\n",
+    "    except ImportError: pass\n",
+    "if not OPENROUTER_API_KEY:\n",
+    "    from getpass import getpass\n",
+    "    OPENROUTER_API_KEY = getpass(\"Enter your OpenRouter API key: \")\n",
+    "os.environ[\"OPENROUTER_API_KEY\"] = OPENROUTER_API_KEY\n",
+    "print(\"✅ Environment ready.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15914200",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import subprocess, time, tempfile, shutil, signal, json, urllib.request, asyncio, uuid\n",
+    "import nest_asyncio; nest_asyncio.apply()\n",
+    "\n",
+    "# ADK A2A pieces\n",
+    "from google.adk.agents.remote_a2a_agent import RemoteA2aAgent, AGENT_CARD_WELL_KNOWN_PATH\n",
+    "from google.adk.runners import Runner\n",
+    "from google.adk.sessions import InMemorySessionService\n",
+    "from google.genai import types\n",
+    "\n",
+    "print(\"✅ Imports successful.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3984310",
+   "metadata": {},
+   "source": [
+    "# The Four A2A Nouns\n",
+    "\n",
+    "A2A reduces agent-to-agent communication to four concepts. Memorize these and the rest of the protocol is commentary.\n",
+    "\n",
+    "| Noun | What it is | Analogue |\n",
+    "|---|---|---|\n",
+    "| **Agent Card** | JSON descriptor served at `/.well-known/agent-card.json` — identity, capabilities, skills, auth | OpenAPI spec for an agent |\n",
+    "| **Task** | Stateful, server-owned unit of work. Has an ID, status, history, artifacts | A GitHub Issue, roughly |\n",
+    "| **Message** | One turn in a task — user or agent, with typed parts (text/file/data) | A chat message |\n",
+    "| **Artifact** | Durable output of a task (reports, images, structured JSON) | An Issue's attachments |\n",
+    "\n",
+    "**Skills** are the semantic menu a discovering agent sees — `translate_spanish`, `find_flights`, each with id/name/description/examples. **Capabilities** are protocol feature-flags — whether the agent supports streaming, push notifications, state history.\n",
+    "\n",
+    "One teaching line worth remembering: *\"skills are the restaurant's menu; capabilities are whether it does delivery.\"*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b6f1951f",
+   "metadata": {},
+   "source": [
+    "# A2A vs MCP\n",
+    "\n",
+    "The dominant framing — and it's the right one:\n",
+    "\n",
+    "> **MCP is agent↔tool. A2A is agent↔agent.**\n",
+    "\n",
+    "A2A's role is the agent-to-agent thing MCP isn't for. Specifically:\n",
+    "\n",
+    "- **Stateful long-running tasks** — task lifecycle with `working / input-required / completed`, not just synchronous request/response.\n",
+    "- **Streaming + push notifications** — agents can resume after disconnection.\n",
+    "- **Typed artifacts** — structured outputs distinct from chat messages.\n",
+    "- **Peer symmetry** — every A2A agent is both client and server; no hierarchy.\n",
+    "- **Cross-framework interop** — an ADK agent calling a LangGraph agent calling a CrewAI agent all speaking A2A.\n",
+    "\n",
+    "Where the boundary blurs: an A2A agent with a single synchronous skill is functionally indistinguishable from an MCP tool call. The distinction is **interaction model**, not what's being called.\n",
+    "\n",
+    "**The layered pattern to leave this module with:** an orchestrator uses **A2A** to reach specialist agents; each specialist internally uses **MCP** to call tools. Same pattern you've built in M02+M06, with A2A as the network transport."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1749aa64",
+   "metadata": {},
+   "source": [
+    "# Demo Part 1 — Expose an ADK Agent as A2A\n",
+    "\n",
+    "`to_a2a()` wraps any ADK agent in a Starlette app that speaks A2A. Spin it up with `uvicorn`; you have an agent-as-HTTP-service that any A2A client can call.\n",
+    "\n",
+    "We'll write a small specialist agent to a temp directory, then launch it as a subprocess on `localhost:8123`. The agent does one thing: convert Celsius to Fahrenheit via a tool call."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3502280e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Write the specialist agent + server script to a temp dir\n",
+    "SRV_DIR = tempfile.mkdtemp(prefix=\"adk_m14_a2a_\")\n",
+    "SRV_SCRIPT = os.path.join(SRV_DIR, \"server.py\")\n",
+    "\n",
+    "SERVER_CODE = (\n",
+    "    \"import os\\n\"\n",
+    "    \"from dotenv import load_dotenv\\n\"\n",
+    "    \"load_dotenv()\\n\\n\"\n",
+    "    \"from google.adk.agents import LlmAgent\\n\"\n",
+    "    \"from google.adk.models.lite_llm import LiteLlm\\n\"\n",
+    "    \"from google.adk.a2a.utils.agent_to_a2a import to_a2a\\n\"\n",
+    "    \"import uvicorn\\n\\n\"\n",
+    "    \"def convert_c_to_f(celsius: float) -> dict:\\n\"\n",
+    "    \"    'Convert Celsius to Fahrenheit.'\\n\"\n",
+    "    \"    return {'celsius': celsius, 'fahrenheit': round(celsius * 9/5 + 32, 2)}\\n\\n\"\n",
+    "    \"root_agent = LlmAgent(\\n\"\n",
+    "    \"    name='temperature_specialist',\\n\"\n",
+    "    \"    model=LiteLlm(model='openrouter/google/gemini-2.5-flash-lite'),\\n\"\n",
+    "    \"    description='Converts Celsius to Fahrenheit via convert_c_to_f tool.',\\n\"\n",
+    "    \"    instruction='Convert temperatures using the tool. Return only the number.',\\n\"\n",
+    "    \"    tools=[convert_c_to_f],\\n\"\n",
+    "    \")\\n\\n\"\n",
+    "    \"app = to_a2a(root_agent, host='localhost', port=8123)\\n\"\n",
+    "    \"uvicorn.run(app, host='localhost', port=8123, log_level='error')\\n\"\n",
+    ")\n",
+    "\n",
+    "with open(SRV_SCRIPT, \"w\") as f:\n",
+    "    f.write(SERVER_CODE)\n",
+    "\n",
+    "# Launch server as subprocess\n",
+    "env = {**os.environ}\n",
+    "proc = subprocess.Popen(\n",
+    "    [sys.executable, SRV_SCRIPT],\n",
+    "    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,\n",
+    "    env=env,\n",
+    ")\n",
+    "time.sleep(7)  # give it time to start uvicorn + ADK\n",
+    "print(f\"✅ A2A server running (PID {proc.pid}) on http://localhost:8123\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e6b0a7d8",
+   "metadata": {},
+   "source": [
+    "## Fetch the Agent Card\n",
+    "\n",
+    "The Agent Card is the A2A discovery mechanism. Served at `/.well-known/agent-card.json` (this path was renamed from `/.well-known/agent.json` in A2A v0.3.0 — a trap for anyone reading older blogs). A2A clients fetch it to learn:\n",
+    "\n",
+    "- The agent's name, description, skills.\n",
+    "- The transport preference (JSON-RPC, gRPC, or REST).\n",
+    "- The protocol version, capabilities, supported modalities.\n",
+    "- Security schemes (OAuth, API key, mTLS, etc.)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6569ffde",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with urllib.request.urlopen(f\"http://localhost:8123{AGENT_CARD_WELL_KNOWN_PATH}\") as r:\n",
+    "    card = json.loads(r.read().decode())\n",
+    "\n",
+    "print(json.dumps(card, indent=2)[:2000])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7157b70c",
+   "metadata": {},
+   "source": [
+    "The card is auto-generated from the agent's `name` + `description` + tools. `preferredTransport` is JSON-RPC by default (works over HTTPS; widely supported). `protocolVersion` is 0.3.0 — that's what ADK 1.28's `a2a-sdk 0.3.24` speaks.\n",
+    "\n",
+    "In production you'd author the card more carefully — populate `skills[]` with specific examples, declare `capabilities.streaming: true` if your agent supports it, add signed identity (`AgentCardSignature`). For a course demo, the auto-generated version is enough."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "76ad5687",
+   "metadata": {},
+   "source": [
+    "# Demo Part 2 — Consume the Agent as a `RemoteA2aAgent`\n",
+    "\n",
+    "`RemoteA2aAgent` takes an Agent Card URL, fetches it, and exposes the remote agent as a local ADK agent. Drop it into any runner's agent argument, or into another agent's `sub_agents=` list — from the consuming side, it looks identical to a local agent.\n",
+    "\n",
+    "**Critical**: pass `use_legacy=False`. The legacy streaming path has three known bugs (user-message duplication, remote outputs mis-classified as thoughts, sub-agent output loss). The new path replaces the executor with one that fixes these. `False` is the correct choice for new code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1bf29bbe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "remote = RemoteA2aAgent(\n",
+    "    name=\"remote_temp_agent\",\n",
+    "    agent_card=f\"http://localhost:8123{AGENT_CARD_WELL_KNOWN_PATH}\",\n",
+    "    description=\"Remote temperature conversion specialist.\",\n",
+    "    use_legacy=False,   # critical; skips the three known streaming bugs\n",
+    ")\n",
+    "\n",
+    "print(\"✅ RemoteA2aAgent ready.\")\n",
+    "print(f\"   Pointing at: http://localhost:8123{AGENT_CARD_WELL_KNOWN_PATH}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d76462e8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Call the remote agent locally via Runner — same API as any other LlmAgent\n",
+    "session_service = InMemorySessionService()\n",
+    "await session_service.create_session(app_name=\"m14\", user_id=\"student\", session_id=\"s1\")\n",
+    "runner = Runner(agent=remote, app_name=\"m14\", session_service=session_service)\n",
+    "\n",
+    "msg = types.Content(role=\"user\", parts=[types.Part(text=\"Convert 20 degrees Celsius to Fahrenheit.\")])\n",
+    "print(\"USER: Convert 20 degrees Celsius to Fahrenheit.\\n\")\n",
+    "\n",
+    "async for ev in runner.run_async(user_id=\"student\", session_id=\"s1\", new_message=msg):\n",
+    "    if ev.content and ev.content.parts:\n",
+    "        for p in ev.content.parts:\n",
+    "            if p.text and p.text.strip():\n",
+    "                print(f\"[{ev.author}] {p.text.strip()[:200]}\")\n",
+    "            if p.function_call:\n",
+    "                print(f\"[tool_call] {p.function_call.name}\")\n",
+    "            if p.function_response:\n",
+    "                print(f\"[tool_resp] {p.function_response.response}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1c4baa9",
+   "metadata": {},
+   "source": [
+    "Read the event stream carefully. **The tool call (`convert_c_to_f`) executed on the remote server's side of the WebSocket.** Your side sees it as a regular event — tool call, tool response, final text — just like if the agent were local.\n",
+    "\n",
+    "This is the A2A payoff. From your agent's perspective, the specialist might as well be local. From the network's perspective, you just made an HTTP call to a separate process (or a separate machine, or a separate organization). The A2A protocol handles the translation.\n",
+    "\n",
+    "**Remember the M06 pattern?** `sub_agents` for transfer, `AgentTool` for consultant calls. `RemoteA2aAgent` plugs into either — it works as a child in `sub_agents=[RemoteA2aAgent(...)]`, or as the `agent=` argument of an `AgentTool`. Same composition patterns, A2A as the transport underneath."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1579a84",
+   "metadata": {},
+   "source": [
+    "# Cleanup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a5a8a3f5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "proc.terminate()\n",
+    "try:\n",
+    "    proc.wait(timeout=3)\n",
+    "except subprocess.TimeoutExpired:\n",
+    "    proc.kill()\n",
+    "shutil.rmtree(SRV_DIR, ignore_errors=True)\n",
+    "print(\"✅ Server stopped, temp dir cleaned.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2e5d07ba",
+   "metadata": {},
+   "source": [
+    "# A2A Maturity — An Honest Read\n",
+    "\n",
+    "Worth naming. A2A's trajectory:\n",
+    "\n",
+    "- **April 2025** — Google launches at Cloud Next. Spec v0.1.\n",
+    "- **June 2025** — Donated to the Linux Foundation. Technical Steering Committee forms.\n",
+    "- **August 2025** — IBM's competing ACP merged in.\n",
+    "- **December 2025** — MCP donated to the new Agentic AI Foundation; A2A and MCP under cross-vendor governance.\n",
+    "- **Early 2026** — A2A v1.0 spec landed. Five official language SDKs (Python, JavaScript, Java, Go, .NET).\n",
+    "- **Now** — ~150 founding-member organizations. ~23K GitHub stars. ADK integration still marked `@a2a_experimental`.\n",
+    "\n",
+    "What this means in practice:\n",
+    "\n",
+    "- **The spec is real.** You can read A2A v1.0 and build against it knowing the shape will be stable.\n",
+    "- **The ecosystem is thin.** Most of those 150 orgs are signatories, not shipping production integrations. Named customer references exist (Adobe, Tyson Foods, S&P Global) but no deep post-mortems.\n",
+    "- **The ADK integration is experimental.** You'll see `@a2a_experimental` warnings. `use_legacy=False` exists because the legacy path has bugs. Version-pin carefully: ADK 1.28 uses `a2a-sdk 0.3.24`; newer a2a-sdk versions break.\n",
+    "\n",
+    "The honest framing: **A2A is architecture worth understanding, not infrastructure you'd bet production on yet.** Build against it for new work; don't migrate existing production workloads yet. By late 2026 this should invert as the ecosystem matures."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2173ee9f",
+   "metadata": {},
+   "source": [
+    "# Gotchas Worth Knowing\n",
+    "\n",
+    "Six sharp edges to pre-empt:\n",
+    "\n",
+    "1. **The `.well-known` path rename.** `/.well-known/agent.json` in v0.2 became `/.well-known/agent-card.json` in v0.3. Code copied from older blog posts WILL be wrong.\n",
+    "2. **Legacy executor bugs.** `RemoteA2aAgent(..., use_legacy=True)` (the default) has three issues: user-message duplication, remote outputs mis-classified as thoughts, sub-agent output loss. **Pass `use_legacy=False`.**\n",
+    "3. **Version-pin ADK and a2a-sdk together.** ADK 1.28–1.31 uses `a2a-sdk 0.3.24`; A2A v1.0 requires `a2a-sdk ≥ 1.0.0a1` which ADK doesn't yet speak. Don't mix.\n",
+    "4. **Discovery is underspecified.** The spec defines `.well-known` as one mechanism; registries are explicitly \"future exploration.\" Don't build on registry features.\n",
+    "5. **Agent Engine is non-spec-default.** Google's Agent Engine serves the Agent Card behind authentication at `/v1/card`, not at `/.well-known/`. Third-party A2A clients expecting the standard path will fail against Agent Engine.\n",
+    "6. **Cross-org trust is unsolved.** Signed Agent Cards are in v1.0 as SHOULD, not MUST. There's no central root-of-trust CA. Treat every cross-org A2A response as untrusted input to your planner — **the lethal trifecta from Simon Willison's framing applies fully to A2A**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5e40472",
+   "metadata": {},
+   "source": [
+    "# Your Turn\n",
+    "\n",
+    "1. **Modify the agent card.** Author it by hand before passing to `to_a2a(agent_card=...)`. Add `examples` to `skills`. Declare `capabilities.streaming`. Does the notebook demo still work?\n",
+    "2. **Cross-framework A2A.** Clone the [`a2aproject/a2a-samples`](https://github.com/a2aproject/a2a-samples) repo. Run the LangGraph currency-converter sample on port 8124. Build a `RemoteA2aAgent` in this notebook that consumes it. Does ADK talk to LangGraph cleanly?\n",
+    "3. **Two-agent orchestrator.** Keep the temperature specialist running. Build a second remote specialist for string reversal. Create a local orchestrator ADK agent with BOTH as `sub_agents=`. Does the coordinator route correctly?\n",
+    "4. **Inspect the JSON-RPC calls.** Use `mitmproxy` or `Wireshark` on port 8123 to capture the JSON-RPC messages. See the A2A wire format. What does a `message/stream` call look like?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2f5aaf0",
+   "metadata": {},
+   "source": [
+    "# Key Takeaways — M14\n",
+    "\n",
+    "- **Four A2A nouns**: Agent Card, Task, Message, Artifact. Memorize these.\n",
+    "- **A2A is agent↔agent; MCP is agent↔tool.** The layered pattern: orchestrator uses A2A; specialists use MCP.\n",
+    "- **`to_a2a(agent)`** exposes any ADK agent as a Starlette A2A server. **`RemoteA2aAgent(agent_card=...)`** consumes one from any process.\n",
+    "- **`use_legacy=False`** is non-negotiable for new `RemoteA2aAgent` code — the legacy executor has three known bugs.\n",
+    "- **Agent Cards** are served at `/.well-known/agent-card.json` — auto-generated by ADK, but hand-authorable for production.\n",
+    "- **Version-pin** `google-adk` and `a2a-sdk` together. ADK 1.28-1.31 speaks 0.3.x protocol.\n",
+    "- **Maturity check**: A2A is architecture worth understanding, not production infrastructure yet.\n",
+    "- **Cross-org trust is unsolved**; every A2A response from outside your org is untrusted input.\n",
+    "\n",
+    "# Course finale\n",
+    "\n",
+    "Fourteen modules. From \"what is an agent?\" to \"here's how agents talk to each other across organizations.\"\n",
+    "\n",
+    "## Part 1 — Vendor-agnostic spine (M01-M10)\n",
+    "The four primitives; four tool flavors; state with scope prefixes; one-line model swaps; workflow agents (Sequential / Parallel / Loop); multi-agent via sub_agents and AgentTool; callbacks as middleware; memory with persistence and long-term recall; automated eval; deployment.\n",
+    "\n",
+    "## Part 2 — Gemini unlocks (M11-M13)\n",
+    "Google Search grounding with real citations; long context + 90%-discount caching; thinking budgets; Live API voice.\n",
+    "\n",
+    "## Side step (M14)\n",
+    "A2A protocol for cross-framework agent-to-agent communication.\n",
+    "\n",
+    "**What to do next:**\n",
+    "- Build something. A voice-first customer-support bot. A research orchestrator. A personal assistant that survives restarts. The course taught the mechanics; building teaches the rest.\n",
+    "- Follow the spec. A2A v1.0 and MCP are both under Linux Foundation governance now. The protocols will outlast ADK-as-a-framework; invest in understanding them as durable.\n",
+    "- Watch the course repo. `DEMOS_BROKEN.md` will be updated as preview APIs stabilize and fragile demos start working.\n",
+    "\n",
+    "Thanks for taking the course. Go build something."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/slides/module-14-a2a/index.html
+++ b/slides/module-14-a2a/index.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ADK Course — M14: A2A Protocol</title>
+  <link rel="stylesheet" href="../shared/shared.css">
+  <link rel="stylesheet" href="../shared/slides.css">
+</head>
+<body>
+  <nav class="progress-strip">
+    <a href="../../index.html" class="progress-home">Course</a>
+    <div class="progress-title">M14 — A2A Protocol</div>
+    <div class="progress-meta">
+      <span class="slide-counter">1 / 1</span>
+      <button class="theme-toggle">Theme</button>
+    </div>
+  </nav>
+
+  <main class="slide-viewport">
+
+  <div class="slide active" data-module="14" data-type="section-title">
+    <div class="topic-badge">Module 14 &middot; Side step &middot; Course finale</div>
+    <h1>A2A protocol</h1>
+    <h3>Agents talking to agents across frameworks and organizations</h3>
+    <p class="highlight-text">The thing that outlasts ADK-as-a-framework.</p>
+  </div>
+
+  <div class="slide" data-module="14" data-type="keyfact">
+    <h2 class="text-muted" style="border-bottom:none;font-size:1em;text-transform:uppercase;letter-spacing:0.08em;">The framing</h2>
+    <p><strong>MCP</strong> is agent↔tool.<br><strong>A2A</strong> is agent↔agent.</p>
+    <p style="font-size:0.7em;color:var(--text-muted);margin-top:var(--space-4);">Both now under Linux Foundation governance.</p>
+  </div>
+
+  <div class="slide" data-module="14">
+    <h2>The journey — fast</h2>
+    <ul>
+      <li><strong>April 2025</strong> — Google launches A2A at Cloud Next</li>
+      <li><strong>June 2025</strong> — Donated to the Linux Foundation</li>
+      <li><strong>August 2025</strong> — IBM's ACP merged in</li>
+      <li><strong>December 2025</strong> — MCP also donated; both under Agentic AI Foundation</li>
+      <li><strong>Early 2026</strong> — A2A v1.0 spec landed; 5 official SDKs (Py/JS/Java/Go/.NET)</li>
+      <li><strong>Now</strong> — ~150 founding-member orgs; ADK integration still <code>@a2a_experimental</code></li>
+    </ul>
+  </div>
+
+  <div class="slide" data-module="14" data-type="section-title" style="background:linear-gradient(135deg,var(--navy-dark) 0%,var(--navy) 100%);">
+    <div class="topic-badge">Four nouns</div>
+    <h1>Agent Card &middot; Task &middot; Message &middot; Artifact</h1>
+    <p class="highlight-text">Memorize these. Rest is commentary.</p>
+  </div>
+
+  <div class="slide" data-module="14">
+    <h2>The four nouns</h2>
+    <table>
+      <thead><tr><th>Noun</th><th>What</th><th>Analogue</th></tr></thead>
+      <tbody>
+        <tr><td><strong>Agent Card</strong></td><td>JSON descriptor at <code>/.well-known/agent-card.json</code> — identity, skills, auth</td><td>OpenAPI spec for an agent</td></tr>
+        <tr><td><strong>Task</strong></td><td>Stateful, server-owned unit of work; has ID, status, history, artifacts</td><td>A GitHub Issue</td></tr>
+        <tr><td><strong>Message</strong></td><td>One turn — user or agent — with typed parts</td><td>A chat message</td></tr>
+        <tr><td><strong>Artifact</strong></td><td>Durable output (reports, images, JSON)</td><td>An Issue's attachment</td></tr>
+      </tbody>
+    </table>
+    <p style="color:var(--text-muted);font-size:0.9em;"><strong>Skills</strong> are the restaurant's menu; <strong>capabilities</strong> are whether it does delivery.</p>
+  </div>
+
+  <div class="slide" data-module="14">
+    <h2>Where A2A fits</h2>
+<pre class="diagram">Orchestrator  ─────A2A─────▶  Remote specialist
+  (ADK)                         (LangGraph, CrewAI,
+    │                            or another ADK)
+    │                              │
+    │                              ├──MCP──▶ Tool server
+    │                              │        (any language)
+    │                              │
+    │                              └──MCP──▶ Tool server
+    │
+    └──MCP──▶ Local tools</pre>
+    <p><strong>Layered pattern:</strong> A2A for agent-to-agent. MCP for agent-to-tool.</p>
+  </div>
+
+  <div class="slide" data-module="14" data-type="section-title" style="background:linear-gradient(135deg,var(--amber-dark) 0%,var(--amber) 100%);">
+    <h1>Live</h1>
+    <h3>Expose an ADK agent as A2A; consume it remotely</h3>
+    <p class="highlight-text" style="color:white;">Notebook cells 8-14</p>
+  </div>
+
+  <div class="slide" data-module="14" data-type="code">
+    <h2>Expose — <code>to_a2a()</code></h2>
+<pre><code>from google.adk.a2a.utils.agent_to_a2a import to_a2a
+import uvicorn
+
+root_agent = LlmAgent(
+    name="temperature_specialist",
+    model=...,
+    tools=[convert_c_to_f],
+)
+
+app = to_a2a(root_agent, host="localhost", port=8123)
+uvicorn.run(app, host="localhost", port=8123)</code></pre>
+    <p class="code-caption">Any ADK agent → Starlette app → A2A-compliant HTTP service.</p>
+  </div>
+
+  <div class="slide" data-module="14" data-type="code">
+    <h2>Consume — <code>RemoteA2aAgent</code></h2>
+<pre><code>remote = RemoteA2aAgent(
+    name="remote_temp_agent",
+    agent_card="http://localhost:8123/.well-known/agent-card.json",
+    description="Remote temperature conversion specialist.",
+    use_legacy=False,   # ← critical; skips 3 known bugs
+)
+
+# Use it anywhere a regular agent fits — Runner, sub_agents, AgentTool
+runner = Runner(agent=remote, ...)</code></pre>
+    <p class="code-caption">From your side, the remote agent looks local. Under the hood: HTTP, A2A JSON-RPC.</p>
+  </div>
+
+  <div class="slide" data-module="14">
+    <h2>The event stream</h2>
+<pre class="diagram">USER: Convert 20 degrees Celsius to Fahrenheit.
+
+[tool_call] convert_c_to_f                   ← executed on REMOTE server
+[tool_resp] {'celsius': 20, 'fahrenheit': 68.0}
+[remote_temp_agent] 68</pre>
+    <p>The tool call ran on the remote server's side of the network. Your side sees a regular event — <strong>same shape as a local agent's call</strong>.</p>
+  </div>
+
+  <div class="slide" data-module="14" data-type="keyfact">
+    <h2 class="text-muted" style="border-bottom:none;font-size:1em;text-transform:uppercase;letter-spacing:0.08em;">The critical detail</h2>
+    <p><code>use_legacy=False</code></p>
+    <p style="font-size:0.7em;color:var(--text-muted);margin-top:var(--space-4);">The default is <code>True</code>. Legacy executor has three known bugs: user-message duplication, remote outputs mis-classified as thoughts, sub-agent output loss.</p>
+  </div>
+
+  <div class="slide" data-module="14">
+    <h2>Agent Card structure</h2>
+<pre class="diagram">{
+  "name": "temperature_specialist",
+  "description": "Converts Celsius to Fahrenheit...",
+  "protocolVersion": "0.3.0",
+  "preferredTransport": "JSONRPC",
+  "capabilities": { "streaming": false, ... },
+  "defaultInputModes": ["text/plain"],
+  "defaultOutputModes": ["text/plain"],
+  "skills": [
+    {
+      "id": "temperature_specialist-convert_c_to_f",
+      "description": "Convert Celsius to Fahrenheit.",
+      "examples": [],
+      "tags": ["llm"]
+    }
+  ]
+}</pre>
+    <p>ADK auto-generates this from the agent's name, description, and tools. Production agents author it by hand — populate examples, declare capabilities, sign with <code>AgentCardSignature</code>.</p>
+  </div>
+
+  <div class="slide" data-module="14">
+    <h2>Maturity — honest read</h2>
+    <div class="callout callout-tip">
+      <div class="callout-title">What's real</div>
+      <p style="margin:0;">A2A v1.0 spec is stable. Linux Foundation governance. Five official SDKs. Cross-vendor protocol body.</p>
+    </div>
+    <div class="callout callout-gotcha">
+      <div class="callout-title">What's thin</div>
+      <p style="margin:0;">Ecosystem. Most of the ~150 orgs are signatories, not shipping production. ADK integration marked <code>@a2a_experimental</code>. Cross-org trust fabric unfinished.</p>
+    </div>
+    <p><strong>The framing:</strong> A2A is <em>architecture</em> worth understanding, <em>not infrastructure</em> you'd bet production on yet.</p>
+  </div>
+
+  <div class="slide" data-module="14">
+    <h2>Gotchas — six sharp edges</h2>
+    <ol>
+      <li><strong>Path rename</strong>: <code>/.well-known/agent.json</code> (v0.2) → <code>/.well-known/agent-card.json</code> (v0.3). Older blogs have the wrong path.</li>
+      <li><strong>Legacy executor</strong>: pass <code>use_legacy=False</code> for new code.</li>
+      <li><strong>Version-pin</strong> <code>google-adk</code> + <code>a2a-sdk</code> together. ADK 1.28-1.31 = a2a-sdk 0.3.24.</li>
+      <li><strong>Discovery is underspecified</strong> — <code>.well-known</code> is stable; registries are future work.</li>
+      <li><strong>Agent Engine is non-spec-default</strong>: serves card at <code>/v1/card</code> behind auth, not at <code>.well-known</code>.</li>
+      <li><strong>Cross-org trust is unsolved.</strong> Every cross-org A2A response = untrusted input. Lethal trifecta applies fully.</li>
+    </ol>
+  </div>
+
+  <div class="slide" data-module="14" data-type="keyfact">
+    <h2 class="text-muted" style="border-bottom:none;font-size:1em;text-transform:uppercase;letter-spacing:0.08em;">What to carry forward</h2>
+    <p><strong>Four nouns. Two patterns. Six gotchas.</strong></p>
+    <p style="font-size:0.7em;color:var(--text-muted);margin-top:var(--space-4);">The protocols outlast the frameworks. Invest accordingly.</p>
+  </div>
+
+  <div class="slide" data-module="14" data-type="section-title" style="background:linear-gradient(135deg,var(--navy-dark) 0%,var(--navy) 50%,var(--amber-dark) 100%);">
+    <div class="topic-badge">Course finale</div>
+    <h1>Fourteen modules.</h1>
+    <p class="highlight-text" style="color:white;">From "what is an agent" to "agents talking to agents."</p>
+  </div>
+
+  <div class="slide" data-module="14">
+    <h2>What you can build now</h2>
+    <div class="two-col">
+      <div class="col">
+        <h3>Part 1 — vendor-agnostic</h3>
+        <ul>
+          <li>Four primitives: Agent, Runner, Event, Session</li>
+          <li>Tools — four flavors</li>
+          <li>State with scope prefixes</li>
+          <li>One-line model swaps</li>
+          <li>Workflow agents (Seq, Par, Loop)</li>
+          <li>sub_agents vs AgentTool</li>
+          <li>Callbacks as middleware</li>
+          <li>Memory: persistent + long-term recall</li>
+          <li>Automated eval</li>
+          <li>Deployed HTTP service</li>
+        </ul>
+      </div>
+      <div class="col">
+        <h3>Part 2 — Gemini unlocks</h3>
+        <ul>
+          <li>Search grounding with real citations</li>
+          <li>Long context + caching (90% discount)</li>
+          <li>Thinking budgets</li>
+          <li>Live API voice agents</li>
+        </ul>
+        <h3 style="margin-top:var(--space-4);">Side step</h3>
+        <ul>
+          <li>A2A protocol for cross-framework agent-to-agent</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <div class="slide" data-module="14" data-type="section-title" style="background:linear-gradient(135deg,var(--amber-dark) 0%,var(--amber) 100%);">
+    <h1>Thanks.</h1>
+    <p style="font-size:1.2em;color:white;">Go build something.</p>
+  </div>
+
+  </main>
+
+  <script src="../shared/slides.js"></script>
+</body>
+</html>

--- a/slides/module-14-a2a/speaker_notes.md
+++ b/slides/module-14-a2a/speaker_notes.md
@@ -1,0 +1,159 @@
+# M14 — Speaker notes
+
+Spoken delivery. One section per slide.
+
+---
+
+## Slide 1 — Title
+
+Module fourteen. The course finale. The side step. Thirty minutes on something that isn't strictly ADK at all — the A2A protocol, the industry standard for agent-to-agent communication. You've spent thirteen modules building ADK agents that talk to tools. This module is about those agents talking to other agents, across processes, across organizations, possibly written in completely different frameworks. This is the thing that outlasts ADK-as-a-framework. MCP and A2A together will survive any specific model, any specific framework, any specific vendor.
+
+---
+
+## Slide 2 — MCP vs A2A framing
+
+The dominant framing — and it's the right one. MCP is the protocol for agents-calling-tools. A2A is the protocol for agents-calling-agents. Both now under Linux Foundation governance. Both stable-ish specs with official SDKs. If you learn only one thing from this module, learn this split.
+
+---
+
+## Slide 3 — The journey
+
+The trajectory, fast. Google launched A2A at Cloud Next in April 2025. Donated it to the Linux Foundation in June. IBM's competing ACP protocol merged in in August. In December, MCP was also donated to the new Agentic AI Foundation, so A2A and MCP are now under cross-vendor governance together. Early 2026, A2A v1.0 landed with five official language SDKs. As of now, there are about 150 founding-member organizations — though the ADK integration is still marked experimental.
+
+That's the short version. The protocol is real; the ecosystem is still catching up.
+
+---
+
+## Slide 4 — Four nouns header
+
+Four nouns. Memorize these. Everything else about A2A is commentary on these four.
+
+---
+
+## Slide 5 — The four nouns
+
+Agent Card — a JSON descriptor served at a well-known URL. It's the agent's identity, capabilities, skills, and authentication schemes. OpenAPI spec but for an agent.
+
+Task — a stateful, server-owned unit of work. It has an ID, a status that moves through working / input-required / completed, a history of messages, and artifacts. Like a GitHub Issue, roughly — persistent, trackable, long-running.
+
+Message — one turn in a task. User or agent. Typed parts — text, file, data. A chat message.
+
+Artifact — the durable output of a task. Reports, images, structured JSON. Distinct from messages; it's the deliverable, not the conversation.
+
+One more distinction worth getting right. Skills are the restaurant's menu — the semantic list of things the agent can do. Capabilities are whether the restaurant does delivery — the protocol feature flags for streaming, push notifications, history replay.
+
+---
+
+## Slide 6 — Where A2A fits
+
+The architectural picture. An orchestrator agent, built in ADK, uses A2A to reach specialist agents — which might be LangGraph, CrewAI, or just another ADK agent in a different process or organization. Each specialist, in turn, uses MCP to call tools — which might be written in Go, Rust, TypeScript, anything.
+
+Layered pattern. A2A for agent-to-agent across frameworks. MCP for agent-to-tool across languages. This is the shape of a modern multi-agent deployment.
+
+---
+
+## Slide 7 — Live demo
+
+Switch to the notebook. Cells eight through fourteen. We expose an ADK agent as an A2A service, fetch its Agent Card, create a RemoteA2aAgent that consumes it, and call the remote agent as if it were local.
+
+---
+
+## Slide 8 — to_a2a
+
+The expose side. `to_a2a(agent)` takes any ADK agent and wraps it in a Starlette app. Starlette speaks A2A. You hand the app to uvicorn, run it on a port, and you have an agent-as-HTTP-service.
+
+That's the whole server-side integration. Three lines of code. The Agent Card, the JSON-RPC endpoint, the task lifecycle — all auto-wired by `to_a2a`.
+
+---
+
+## Slide 9 — RemoteA2aAgent
+
+The consume side. `RemoteA2aAgent` takes an Agent Card URL, fetches it, and exposes the remote agent as if it were a local ADK agent. You drop it into a Runner or into another agent's sub_agents list. From the consuming side, same shape as a local agent.
+
+Two arguments matter. `name` — how the local side refers to it. `agent_card` — the URL where the card lives. Plus `use_legacy=False` which I'll get to in a moment.
+
+---
+
+## Slide 10 — Event stream
+
+The event stream when you call the remote agent. User message. Tool call — but executed on the remote server, not locally. Tool response. Final text.
+
+From your code's perspective, this is the same event shape as a local agent doing the same work. From the network's perspective, an HTTP call happened. A2A bridges the two.
+
+---
+
+## Slide 11 — use_legacy=False
+
+The single most important practical detail in this module. `RemoteA2aAgent(use_legacy=False)`.
+
+The default is True. The legacy executor has three known bugs — user-message duplication, remote outputs mis-classified as thoughts, and sub-agent output loss on nested remote agents. The new path, controlled by `use_legacy=False`, replaces the executor with one that fixes these.
+
+You almost certainly want `False` for new code. The default will presumably flip eventually; until it does, type the argument explicitly every time.
+
+---
+
+## Slide 12 — Agent Card structure
+
+The Agent Card's structure, condensed from the notebook output. Name. Description. Protocol version — 0.3.0 for ADK 1.28. Transport preference — JSON-RPC by default. Capabilities — what protocol features the agent supports. Default input and output modes. Skills — a list of things the agent can do, with descriptions and examples.
+
+ADK auto-generates all of this from your agent's name, description, and tools. For production agents, you'd author it by hand — populate realistic examples in each skill, declare capabilities explicitly, sign the card with `AgentCardSignature` for cryptographic identity. For a course demo, the auto-generated version is enough.
+
+---
+
+## Slide 13 — Maturity honest read
+
+An honest read on A2A's maturity.
+
+What's real. A2A v1.0 is a stable specification. Linux Foundation governance is in place. Five official language SDKs. Cross-vendor protocol body with representatives from AWS, Cisco, Google, IBM, Microsoft, Salesforce, SAP, ServiceNow.
+
+What's thin. The ecosystem. Most of the 150 founding-member organizations are signatories; not many are shipping production integrations. ADK's A2A integration is still marked `@a2a_experimental`. Cross-org trust fabric — signed cards, registries, federated identity — is explicitly "future exploration" in the spec.
+
+The framing to carry. A2A is architecture worth understanding. It is not infrastructure you'd bet production on this year. Build against it for new work; don't migrate existing production workloads yet. By late 2026 this should invert as the ecosystem matures.
+
+---
+
+## Slide 14 — Six gotchas
+
+Six sharp edges worth naming.
+
+Path rename. In v0.2 the Agent Card was at `/.well-known/agent.json`. In v0.3 — which is what ADK speaks — it moved to `/.well-known/agent-card.json`. Code from older blog posts has the wrong path.
+
+Legacy executor. Already covered. `use_legacy=False`, always.
+
+Version pin. ADK 1.28 through 1.31 uses a2a-sdk 0.3.24. A2A v1.0 requires a2a-sdk 1.0 alpha, which ADK doesn't yet speak. Don't mix versions.
+
+Discovery is underspecified. The `.well-known` path is stable; registries are future work. Don't depend on registry features.
+
+Agent Engine is non-spec-default. Google's own Agent Engine serves the Agent Card at `/v1/card` behind authentication, not at `.well-known`. Third-party A2A clients expecting the standard path fail against Agent Engine. Flag this if you deploy there.
+
+Cross-org trust is unsolved. Signed cards are in v1.0 as SHOULD, not MUST. There is no central root-of-trust CA for agents. Every cross-org A2A response is untrusted input to your planner. Simon Willison's lethal trifecta — private data plus untrusted content plus external communication — applies fully. Treat every remote agent's output as if a malicious user wrote it.
+
+---
+
+## Slide 15 — Carry forward
+
+What to carry forward. Four nouns. Two patterns — A2A for agent-to-agent, MCP for agent-to-tool. Six gotchas. The protocols outlast the frameworks. Invest in understanding them as durable.
+
+---
+
+## Slide 16 — Course finale header
+
+The course finale. Fourteen modules. From "what is an agent" to "agents talking to agents across organizations."
+
+---
+
+## Slide 17 — What you can build
+
+The summary. Part 1 — ten modules of vendor-agnostic ADK. The four primitives. Four tool flavors. State with scope prefixes. One-line model swaps across five providers. Workflow agents — Sequential, Parallel, Loop. Multi-agent composition — sub_agents for transfer, AgentTool for consultant. Callbacks as middleware. Memory that persists across restarts and recalls across sessions. Automated evaluation with trajectory testing. Deployed HTTP service.
+
+Part 2 — three Gemini unlocks. Google Search grounding with real citations. Long context plus caching for ninety-percent cost reduction. Thinking budgets that trade latency for reasoning quality. Live API voice agents.
+
+And the side step — A2A protocol for cross-framework agent-to-agent.
+
+After fourteen modules, you can build real agent software. Stateful. Memory-aware. Composable across frameworks. Deployable. Evaluable. Multi-modal. Production-shaped.
+
+---
+
+## Slide 18 — Thanks
+
+Thanks for taking the course. Go build something. That's the only way to actually learn this stuff. A voice-first customer support bot. A research orchestrator. A personal assistant that survives restarts and remembers you across weeks. The course taught the mechanics; building teaches the rest.

--- a/textbook/_sources/chapters/14-a2a-protocol.md
+++ b/textbook/_sources/chapters/14-a2a-protocol.md
@@ -1,0 +1,218 @@
+# A2A protocol — the side step
+
+The course finale. Thirty minutes on something that isn't strictly ADK at all — the **A2A protocol**, the industry standard for agent-to-agent communication.
+
+You've spent thirteen chapters building ADK agents that talk to tools. This chapter is about those agents talking to **other agents** — across processes, across organizations, possibly written in completely different frameworks. This is the single most durable thing in this course. **MCP and A2A together will outlast any specific model, any specific framework, any specific vendor.**
+
+## The framing
+
+One sentence that captures everything. **MCP is agent↔tool. A2A is agent↔agent.**
+
+You saw MCP in Module 02 — connecting an agent to a separate tool-server process. A2A is the protocol for the next layer up: one agent calling another agent across a network boundary. They're both under Linux Foundation governance now (A2A since June 2025, MCP since December 2025), so they evolve together as the standard for the agentic-AI infrastructure layer.
+
+## The journey — fast
+
+- **April 2025** — Google launches A2A at Cloud Next.
+- **June 2025** — Donated to the Linux Foundation. Technical Steering Committee forms.
+- **August 2025** — IBM's competing Agent Communication Protocol (ACP) merged in.
+- **December 2025** — MCP also donated to the Linux Foundation's Agentic AI Foundation; A2A and MCP under cross-vendor governance together.
+- **Early 2026** — A2A v1.0 spec landed. Five official language SDKs (Python, JavaScript, Java, Go, .NET).
+- **Now** — ~150 founding-member organizations. ~23K GitHub stars. ADK's A2A integration still marked `@a2a_experimental`.
+
+The spec is real and stable. The ecosystem is real but thin.
+
+## The four nouns
+
+Memorize these. Everything else about A2A is commentary on these four.
+
+| Noun | What it is | Analogue |
+|---|---|---|
+| **Agent Card** | JSON descriptor at `/.well-known/agent-card.json` — identity, skills, capabilities, auth | OpenAPI spec, but for an agent |
+| **Task** | Stateful, server-owned unit of work. ID, status, history, artifacts | A GitHub Issue |
+| **Message** | One turn — user or agent — with typed parts (text/file/data) | A chat message |
+| **Artifact** | Durable output of a task (reports, images, structured data) | An Issue's attachments |
+
+Two more distinctions worth getting right:
+
+- **Skills** are the semantic menu a discovering agent reads to decide whether to call — `translate_spanish`, `find_flights`, each with description and examples.
+- **Capabilities** are protocol feature-flags — whether the agent supports streaming, push notifications, state-history replay.
+
+Pithy version: *"skills are the restaurant's menu; capabilities are whether it does delivery."*
+
+## Where A2A fits architecturally
+
+The layered pattern A2A enables:
+
+```
+Orchestrator  ─────A2A─────▶  Remote specialist
+  (ADK)                         (LangGraph, CrewAI,
+    │                            or another ADK)
+    │                              │
+    │                              ├──MCP──▶ Tool server
+    │                              │        (any language)
+    │                              │
+    │                              └──MCP──▶ Tool server
+    │
+    └──MCP──▶ Local tools
+```
+
+An orchestrator agent (say, ADK) uses **A2A** to reach specialist agents — which might be written in LangGraph or CrewAI or just another ADK process owned by a different team. Each specialist, in turn, uses **MCP** to call tools — which might be written in Go, Rust, TypeScript, whatever.
+
+This is the shape of a modern multi-agent deployment. A2A for agent-to-agent across frameworks. MCP for agent-to-tool across languages. Your code is an orchestrator layer over both.
+
+## Exposing an ADK agent as A2A — `to_a2a()`
+
+```python
+from google.adk.agents import LlmAgent
+from google.adk.a2a.utils.agent_to_a2a import to_a2a
+import uvicorn
+
+root_agent = LlmAgent(
+    name="temperature_specialist",
+    model=LiteLlm(model="openrouter/google/gemini-2.5-flash-lite"),
+    description="Converts Celsius to Fahrenheit via convert_c_to_f tool.",
+    instruction="Convert temperatures. Return only the number.",
+    tools=[convert_c_to_f],
+)
+
+app = to_a2a(root_agent, host="localhost", port=8123)
+uvicorn.run(app, host="localhost", port=8123)
+```
+
+Three lines do the server side. `to_a2a` returns a Starlette app. Starlette speaks A2A — it auto-generates the Agent Card, exposes the JSON-RPC endpoint, handles task lifecycle. You run it under uvicorn and you have an agent-as-HTTP-service any A2A client can call.
+
+## Consuming an A2A agent — `RemoteA2aAgent`
+
+```python
+from google.adk.agents.remote_a2a_agent import RemoteA2aAgent, AGENT_CARD_WELL_KNOWN_PATH
+
+remote = RemoteA2aAgent(
+    name="remote_temp_agent",
+    agent_card=f"http://localhost:8123{AGENT_CARD_WELL_KNOWN_PATH}",
+    description="Remote temperature conversion specialist.",
+    use_legacy=False,   # critical; see below
+)
+
+# Use it anywhere a regular agent fits
+runner = Runner(agent=remote, ...)
+```
+
+`RemoteA2aAgent` takes an Agent Card URL, fetches it on first use, and exposes the remote agent as a local ADK agent. Drop it into a `Runner`, into another agent's `sub_agents=` list, or wrap it in an `AgentTool`. The composition patterns from Module 06 apply unchanged — A2A is just the transport underneath.
+
+**The single most practical detail in this chapter: `use_legacy=False`.** The default is `True`, and the legacy executor has three known bugs:
+
+1. User messages can be duplicated across the wire.
+2. Remote agent outputs are mis-classified as "thoughts" in the event stream.
+3. Nested remote agents can lose sub-agent output entirely.
+
+The new path (`use_legacy=False`) replaces the executor with one that fixes these. For new code, always `False`. Type it explicitly every time until the default flips.
+
+## The event stream — what a remote call looks like
+
+When you run the remote agent:
+
+```
+USER: Convert 20 degrees Celsius to Fahrenheit.
+
+[tool_call] convert_c_to_f                   ← ran on the REMOTE server
+[tool_resp] {'celsius': 20, 'fahrenheit': 68.0}
+[remote_temp_agent] 68
+```
+
+The `convert_c_to_f` tool call executed **on the remote server's side of the network**, not locally. Your side sees a regular event — tool call, tool response, final text — same shape as a local agent's work. A2A bridges the gap seamlessly.
+
+This is the A2A payoff. From your agent's perspective, the specialist might as well be local. From the network's perspective, you made an HTTP call to a separate process. From the architectural perspective, you've just crossed a framework or organization boundary. The event stream doesn't care which.
+
+## The Agent Card, up close
+
+ADK auto-generates the Agent Card from your agent's name, description, and tools. Here's what the course's demo agent produces:
+
+```json
+{
+  "name": "temperature_specialist",
+  "description": "Converts Celsius to Fahrenheit via convert_c_to_f tool.",
+  "protocolVersion": "0.3.0",
+  "preferredTransport": "JSONRPC",
+  "capabilities": {},
+  "defaultInputModes": ["text/plain"],
+  "defaultOutputModes": ["text/plain"],
+  "skills": [
+    {
+      "id": "temperature_specialist",
+      "name": "model",
+      "description": "Converts Celsius to Fahrenheit... Convert temperatures using the tool. Return only the number.",
+      "tags": ["llm"],
+      "examples": []
+    },
+    {
+      "id": "temperature_specialist-convert_c_to_f",
+      "description": "Convert Celsius to Fahrenheit.",
+      "tags": ["tool"],
+      "examples": []
+    }
+  ]
+}
+```
+
+For production, you'd author this by hand:
+
+- Populate `examples` on each skill with realistic invocations.
+- Declare `capabilities.streaming: true` if your agent supports incremental output.
+- Add `securitySchemes` and `security` blocks for authenticated endpoints.
+- Sign the card with an `AgentCardSignature` (JWS over canonicalized JSON) so consumers can verify identity.
+
+The auto-generated version is fine for internal and demo use; the carefully-authored version is what you ship to external consumers.
+
+## Maturity — an honest read
+
+What's real:
+
+- **A2A v1.0** is a stable, published specification.
+- **Linux Foundation governance** is in place with a cross-vendor Technical Steering Committee.
+- **Five official SDKs** — Python, JavaScript, Java, Go, .NET.
+- **150+ founding-member organizations** have signed on.
+
+What's thin:
+
+- Most of those 150 orgs are signatories, not shippers. Named customer references (Adobe, Tyson Foods, S&P Global Market Intelligence) exist, but no deep production post-mortems are public yet.
+- ADK's A2A integration is still marked `@a2a_experimental`. Tool-call shapes can drift between ADK and a2a-sdk versions; `use_legacy=False` exists because the legacy path has bugs.
+- The cross-org **trust fabric is unfinished**. Signed Agent Cards are in v1.0 as SHOULD, not MUST. There's no central root-of-trust CA for agents. Registries — how you discover an agent you haven't hard-coded a URL for — are explicitly marked "future exploration" in the spec.
+
+The framing to carry: **A2A is architecture worth understanding, not infrastructure you'd bet production on this year.** Build against it for new work; don't migrate existing production workloads yet. By late 2026 this should invert as the ecosystem matures.
+
+## Six gotchas
+
+1. **The `.well-known` path rename.** `/.well-known/agent.json` (v0.2) became `/.well-known/agent-card.json` (v0.3). Code copied from older blogs has the wrong path.
+2. **Legacy executor bugs.** `RemoteA2aAgent(..., use_legacy=True)` (the default) has three issues: user-message duplication, remote outputs mis-classified as thoughts, sub-agent output loss. Pass `use_legacy=False` always.
+3. **Version-pin ADK and a2a-sdk together.** ADK 1.28-1.31 uses `a2a-sdk 0.3.24`; A2A v1.0 requires `a2a-sdk ≥ 1.0.0a1` which ADK doesn't yet speak. Don't mix.
+4. **Discovery is underspecified.** The `.well-known` path is stable; registries are explicitly future work. Don't build on registry features.
+5. **Agent Engine is non-spec-default.** Google's Agent Engine serves the Agent Card at `/v1/card` behind authentication, not at `/.well-known/`. Third-party A2A clients expecting the standard path will fail against Agent Engine.
+6. **Cross-org trust is unsolved.** Every cross-org A2A response is **untrusted input** to your planner. Simon Willison's lethal trifecta — private data + untrusted content + external communications — applies fully. Treat every remote agent's output as if a malicious user wrote it; run it through the same guardrails you'd apply to user input.
+
+## What to carry forward — M14
+
+- **Four A2A nouns**: Agent Card, Task, Message, Artifact.
+- **Two patterns**: A2A for agent↔agent; MCP for agent↔tool.
+- **`to_a2a(agent)`** exposes any ADK agent as A2A; **`RemoteA2aAgent(agent_card=...)`** consumes one.
+- **`use_legacy=False`** is non-negotiable for new code.
+- **Version-pin** `google-adk` + `a2a-sdk` together.
+- **Maturity check**: spec is real, ecosystem is thin. Architecture worth understanding; not yet production-grade infrastructure.
+- **Cross-org trust is unsolved**; every remote agent's output is untrusted.
+
+## Course finale
+
+Fourteen chapters. From "what is an agent" to "agents talking to agents across organizations."
+
+**Part 1 — Vendor-agnostic spine** (M01-M10). The four primitives; four tool flavors; state with scope prefixes; one-line model swaps; workflow agents (Sequential / Parallel / Loop); multi-agent via `sub_agents` and `AgentTool`; callbacks as middleware; memory with persistence and long-term recall; automated eval; deployment as HTTP service.
+
+**Part 2 — Gemini unlocks** (M11-M13). Google Search grounding with real citations; long context + 90%-discount caching; thinking budgets; Live API voice agents.
+
+**Side step** (M14). A2A protocol for cross-framework agent-to-agent communication.
+
+### What to do next
+
+- **Build something.** A voice-first customer-support bot. A research orchestrator. A personal assistant that survives restarts. The course taught mechanics; building teaches the rest.
+- **Follow the protocols.** A2A and MCP are both under Linux Foundation governance. The protocols outlast frameworks; invest in understanding them as durable.
+- **Watch the course repo.** `DEMOS_BROKEN.md` tracks what's broken at preview-tier; entries will be cleared as the APIs stabilize.
+
+Thanks for taking the course. Go build something.

--- a/textbook/index.html
+++ b/textbook/index.html
@@ -325,6 +325,7 @@ hr {
 <li><a href="#gemini-unlocks-grounding-and-context-caching">11. Gemini unlocks — grounding and context caching</a></li>
 <li><a href="#thinking-budgets">12. Thinking budgets</a></li>
 <li><a href="#live-api-voice-agent">13. Live API voice agent</a></li>
+<li><a href="#a2a-protocol-the-side-step">14. A2A protocol — the side step</a></li>
             </ul>
         </nav>
     </aside>
@@ -2681,6 +2682,209 @@ Audio out   ◀──WebSocket──   stream response audio
 <li><strong>Rate-limit exploration.</strong> Run multiple concurrent Live sessions. What rate limits appear on your key&rsquo;s tier?</li>
 </ol>
 <p>Module 14 — the course finale — steps sideways into the <strong>A2A protocol</strong>. Agent-to-agent communication — the protocol Google donated to the Linux Foundation in June 2025 that&rsquo;s now the industry standard for agents talking to agents across vendors. 30-minute block: four nouns, one demo, the gotchas that make A2A worth understanding as architecture before infrastructure.</p>
+        </section>
+
+        <section class="chapter" id="a2a-protocol-the-side-step">
+            <div class="chapter-number">Chapter 14</div>
+            <h1>A2A protocol — the side step</h1>
+<p>The course finale. Thirty minutes on something that isn&rsquo;t strictly ADK at all — the <strong>A2A protocol</strong>, the industry standard for agent-to-agent communication.</p>
+<p>You&rsquo;ve spent thirteen chapters building ADK agents that talk to tools. This chapter is about those agents talking to <strong>other agents</strong> — across processes, across organizations, possibly written in completely different frameworks. This is the single most durable thing in this course. <strong>MCP and A2A together will outlast any specific model, any specific framework, any specific vendor.</strong></p>
+<h2>The framing</h2>
+<p>One sentence that captures everything. <strong>MCP is agent↔tool. A2A is agent↔agent.</strong></p>
+<p>You saw MCP in Module 02 — connecting an agent to a separate tool-server process. A2A is the protocol for the next layer up: one agent calling another agent across a network boundary. They&rsquo;re both under Linux Foundation governance now (A2A since June 2025, MCP since December 2025), so they evolve together as the standard for the agentic-AI infrastructure layer.</p>
+<h2>The journey — fast</h2>
+<ul>
+<li><strong>April 2025</strong> — Google launches A2A at Cloud Next.</li>
+<li><strong>June 2025</strong> — Donated to the Linux Foundation. Technical Steering Committee forms.</li>
+<li><strong>August 2025</strong> — IBM&rsquo;s competing Agent Communication Protocol (ACP) merged in.</li>
+<li><strong>December 2025</strong> — MCP also donated to the Linux Foundation&rsquo;s Agentic AI Foundation; A2A and MCP under cross-vendor governance together.</li>
+<li><strong>Early 2026</strong> — A2A v1.0 spec landed. Five official language SDKs (Python, JavaScript, Java, Go, .NET).</li>
+<li><strong>Now</strong> — ~150 founding-member organizations. ~23K GitHub stars. ADK&rsquo;s A2A integration still marked <code>@a2a_experimental</code>.</li>
+</ul>
+<p>The spec is real and stable. The ecosystem is real but thin.</p>
+<h2>The four nouns</h2>
+<p>Memorize these. Everything else about A2A is commentary on these four.</p>
+<table>
+<thead>
+<tr>
+<th>Noun</th>
+<th>What it is</th>
+<th>Analogue</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Agent Card</strong></td>
+<td>JSON descriptor at <code>/.well-known/agent-card.json</code> — identity, skills, capabilities, auth</td>
+<td>OpenAPI spec, but for an agent</td>
+</tr>
+<tr>
+<td><strong>Task</strong></td>
+<td>Stateful, server-owned unit of work. ID, status, history, artifacts</td>
+<td>A GitHub Issue</td>
+</tr>
+<tr>
+<td><strong>Message</strong></td>
+<td>One turn — user or agent — with typed parts (text/file/data)</td>
+<td>A chat message</td>
+</tr>
+<tr>
+<td><strong>Artifact</strong></td>
+<td>Durable output of a task (reports, images, structured data)</td>
+<td>An Issue&rsquo;s attachments</td>
+</tr>
+</tbody>
+</table>
+<p>Two more distinctions worth getting right:</p>
+<ul>
+<li><strong>Skills</strong> are the semantic menu a discovering agent reads to decide whether to call — <code>translate_spanish</code>, <code>find_flights</code>, each with description and examples.</li>
+<li><strong>Capabilities</strong> are protocol feature-flags — whether the agent supports streaming, push notifications, state-history replay.</li>
+</ul>
+<p>Pithy version: <em>&ldquo;skills are the restaurant&rsquo;s menu; capabilities are whether it does delivery.&rdquo;</em></p>
+<h2>Where A2A fits architecturally</h2>
+<p>The layered pattern A2A enables:</p>
+<pre><code>Orchestrator  ─────A2A─────▶  Remote specialist
+  (ADK)                         (LangGraph, CrewAI,
+    │                            or another ADK)
+    │                              │
+    │                              ├──MCP──▶ Tool server
+    │                              │        (any language)
+    │                              │
+    │                              └──MCP──▶ Tool server
+    │
+    └──MCP──▶ Local tools
+</code></pre>
+<p>An orchestrator agent (say, ADK) uses <strong>A2A</strong> to reach specialist agents — which might be written in LangGraph or CrewAI or just another ADK process owned by a different team. Each specialist, in turn, uses <strong>MCP</strong> to call tools — which might be written in Go, Rust, TypeScript, whatever.</p>
+<p>This is the shape of a modern multi-agent deployment. A2A for agent-to-agent across frameworks. MCP for agent-to-tool across languages. Your code is an orchestrator layer over both.</p>
+<h2>Exposing an ADK agent as A2A — <code>to_a2a()</code></h2>
+<pre><code class="language-python">from google.adk.agents import LlmAgent
+from google.adk.a2a.utils.agent_to_a2a import to_a2a
+import uvicorn
+
+root_agent = LlmAgent(
+    name=&quot;temperature_specialist&quot;,
+    model=LiteLlm(model=&quot;openrouter/google/gemini-2.5-flash-lite&quot;),
+    description=&quot;Converts Celsius to Fahrenheit via convert_c_to_f tool.&quot;,
+    instruction=&quot;Convert temperatures. Return only the number.&quot;,
+    tools=[convert_c_to_f],
+)
+
+app = to_a2a(root_agent, host=&quot;localhost&quot;, port=8123)
+uvicorn.run(app, host=&quot;localhost&quot;, port=8123)
+</code></pre>
+<p>Three lines do the server side. <code>to_a2a</code> returns a Starlette app. Starlette speaks A2A — it auto-generates the Agent Card, exposes the JSON-RPC endpoint, handles task lifecycle. You run it under uvicorn and you have an agent-as-HTTP-service any A2A client can call.</p>
+<h2>Consuming an A2A agent — <code>RemoteA2aAgent</code></h2>
+<pre><code class="language-python">from google.adk.agents.remote_a2a_agent import RemoteA2aAgent, AGENT_CARD_WELL_KNOWN_PATH
+
+remote = RemoteA2aAgent(
+    name=&quot;remote_temp_agent&quot;,
+    agent_card=f&quot;http://localhost:8123{AGENT_CARD_WELL_KNOWN_PATH}&quot;,
+    description=&quot;Remote temperature conversion specialist.&quot;,
+    use_legacy=False,   # critical; see below
+)
+
+# Use it anywhere a regular agent fits
+runner = Runner(agent=remote, ...)
+</code></pre>
+<p><code>RemoteA2aAgent</code> takes an Agent Card URL, fetches it on first use, and exposes the remote agent as a local ADK agent. Drop it into a <code>Runner</code>, into another agent&rsquo;s <code>sub_agents=</code> list, or wrap it in an <code>AgentTool</code>. The composition patterns from Module 06 apply unchanged — A2A is just the transport underneath.</p>
+<p><strong>The single most practical detail in this chapter: <code>use_legacy=False</code>.</strong> The default is <code>True</code>, and the legacy executor has three known bugs:</p>
+<ol>
+<li>User messages can be duplicated across the wire.</li>
+<li>Remote agent outputs are mis-classified as &ldquo;thoughts&rdquo; in the event stream.</li>
+<li>Nested remote agents can lose sub-agent output entirely.</li>
+</ol>
+<p>The new path (<code>use_legacy=False</code>) replaces the executor with one that fixes these. For new code, always <code>False</code>. Type it explicitly every time until the default flips.</p>
+<h2>The event stream — what a remote call looks like</h2>
+<p>When you run the remote agent:</p>
+<pre><code>USER: Convert 20 degrees Celsius to Fahrenheit.
+
+[tool_call] convert_c_to_f                   ← ran on the REMOTE server
+[tool_resp] {'celsius': 20, 'fahrenheit': 68.0}
+[remote_temp_agent] 68
+</code></pre>
+<p>The <code>convert_c_to_f</code> tool call executed <strong>on the remote server&rsquo;s side of the network</strong>, not locally. Your side sees a regular event — tool call, tool response, final text — same shape as a local agent&rsquo;s work. A2A bridges the gap seamlessly.</p>
+<p>This is the A2A payoff. From your agent&rsquo;s perspective, the specialist might as well be local. From the network&rsquo;s perspective, you made an HTTP call to a separate process. From the architectural perspective, you&rsquo;ve just crossed a framework or organization boundary. The event stream doesn&rsquo;t care which.</p>
+<h2>The Agent Card, up close</h2>
+<p>ADK auto-generates the Agent Card from your agent&rsquo;s name, description, and tools. Here&rsquo;s what the course&rsquo;s demo agent produces:</p>
+<pre><code class="language-json">{
+  &quot;name&quot;: &quot;temperature_specialist&quot;,
+  &quot;description&quot;: &quot;Converts Celsius to Fahrenheit via convert_c_to_f tool.&quot;,
+  &quot;protocolVersion&quot;: &quot;0.3.0&quot;,
+  &quot;preferredTransport&quot;: &quot;JSONRPC&quot;,
+  &quot;capabilities&quot;: {},
+  &quot;defaultInputModes&quot;: [&quot;text/plain&quot;],
+  &quot;defaultOutputModes&quot;: [&quot;text/plain&quot;],
+  &quot;skills&quot;: [
+    {
+      &quot;id&quot;: &quot;temperature_specialist&quot;,
+      &quot;name&quot;: &quot;model&quot;,
+      &quot;description&quot;: &quot;Converts Celsius to Fahrenheit... Convert temperatures using the tool. Return only the number.&quot;,
+      &quot;tags&quot;: [&quot;llm&quot;],
+      &quot;examples&quot;: []
+    },
+    {
+      &quot;id&quot;: &quot;temperature_specialist-convert_c_to_f&quot;,
+      &quot;description&quot;: &quot;Convert Celsius to Fahrenheit.&quot;,
+      &quot;tags&quot;: [&quot;tool&quot;],
+      &quot;examples&quot;: []
+    }
+  ]
+}
+</code></pre>
+<p>For production, you&rsquo;d author this by hand:</p>
+<ul>
+<li>Populate <code>examples</code> on each skill with realistic invocations.</li>
+<li>Declare <code>capabilities.streaming: true</code> if your agent supports incremental output.</li>
+<li>Add <code>securitySchemes</code> and <code>security</code> blocks for authenticated endpoints.</li>
+<li>Sign the card with an <code>AgentCardSignature</code> (JWS over canonicalized JSON) so consumers can verify identity.</li>
+</ul>
+<p>The auto-generated version is fine for internal and demo use; the carefully-authored version is what you ship to external consumers.</p>
+<h2>Maturity — an honest read</h2>
+<p>What&rsquo;s real:</p>
+<ul>
+<li><strong>A2A v1.0</strong> is a stable, published specification.</li>
+<li><strong>Linux Foundation governance</strong> is in place with a cross-vendor Technical Steering Committee.</li>
+<li><strong>Five official SDKs</strong> — Python, JavaScript, Java, Go, .NET.</li>
+<li><strong>150+ founding-member organizations</strong> have signed on.</li>
+</ul>
+<p>What&rsquo;s thin:</p>
+<ul>
+<li>Most of those 150 orgs are signatories, not shippers. Named customer references (Adobe, Tyson Foods, S&amp;P Global Market Intelligence) exist, but no deep production post-mortems are public yet.</li>
+<li>ADK&rsquo;s A2A integration is still marked <code>@a2a_experimental</code>. Tool-call shapes can drift between ADK and a2a-sdk versions; <code>use_legacy=False</code> exists because the legacy path has bugs.</li>
+<li>The cross-org <strong>trust fabric is unfinished</strong>. Signed Agent Cards are in v1.0 as SHOULD, not MUST. There&rsquo;s no central root-of-trust CA for agents. Registries — how you discover an agent you haven&rsquo;t hard-coded a URL for — are explicitly marked &ldquo;future exploration&rdquo; in the spec.</li>
+</ul>
+<p>The framing to carry: <strong>A2A is architecture worth understanding, not infrastructure you&rsquo;d bet production on this year.</strong> Build against it for new work; don&rsquo;t migrate existing production workloads yet. By late 2026 this should invert as the ecosystem matures.</p>
+<h2>Six gotchas</h2>
+<ol>
+<li><strong>The <code>.well-known</code> path rename.</strong> <code>/.well-known/agent.json</code> (v0.2) became <code>/.well-known/agent-card.json</code> (v0.3). Code copied from older blogs has the wrong path.</li>
+<li><strong>Legacy executor bugs.</strong> <code>RemoteA2aAgent(..., use_legacy=True)</code> (the default) has three issues: user-message duplication, remote outputs mis-classified as thoughts, sub-agent output loss. Pass <code>use_legacy=False</code> always.</li>
+<li><strong>Version-pin ADK and a2a-sdk together.</strong> ADK 1.28-1.31 uses <code>a2a-sdk 0.3.24</code>; A2A v1.0 requires <code>a2a-sdk ≥ 1.0.0a1</code> which ADK doesn&rsquo;t yet speak. Don&rsquo;t mix.</li>
+<li><strong>Discovery is underspecified.</strong> The <code>.well-known</code> path is stable; registries are explicitly future work. Don&rsquo;t build on registry features.</li>
+<li><strong>Agent Engine is non-spec-default.</strong> Google&rsquo;s Agent Engine serves the Agent Card at <code>/v1/card</code> behind authentication, not at <code>/.well-known/</code>. Third-party A2A clients expecting the standard path will fail against Agent Engine.</li>
+<li><strong>Cross-org trust is unsolved.</strong> Every cross-org A2A response is <strong>untrusted input</strong> to your planner. Simon Willison&rsquo;s lethal trifecta — private data + untrusted content + external communications — applies fully. Treat every remote agent&rsquo;s output as if a malicious user wrote it; run it through the same guardrails you&rsquo;d apply to user input.</li>
+</ol>
+<h2>What to carry forward — M14</h2>
+<ul>
+<li><strong>Four A2A nouns</strong>: Agent Card, Task, Message, Artifact.</li>
+<li><strong>Two patterns</strong>: A2A for agent↔agent; MCP for agent↔tool.</li>
+<li><strong><code>to_a2a(agent)</code></strong> exposes any ADK agent as A2A; <strong><code>RemoteA2aAgent(agent_card=...)</code></strong> consumes one.</li>
+<li><strong><code>use_legacy=False</code></strong> is non-negotiable for new code.</li>
+<li><strong>Version-pin</strong> <code>google-adk</code> + <code>a2a-sdk</code> together.</li>
+<li><strong>Maturity check</strong>: spec is real, ecosystem is thin. Architecture worth understanding; not yet production-grade infrastructure.</li>
+<li><strong>Cross-org trust is unsolved</strong>; every remote agent&rsquo;s output is untrusted.</li>
+</ul>
+<h2>Course finale</h2>
+<p>Fourteen chapters. From &ldquo;what is an agent&rdquo; to &ldquo;agents talking to agents across organizations.&rdquo;</p>
+<p><strong>Part 1 — Vendor-agnostic spine</strong> (M01-M10). The four primitives; four tool flavors; state with scope prefixes; one-line model swaps; workflow agents (Sequential / Parallel / Loop); multi-agent via <code>sub_agents</code> and <code>AgentTool</code>; callbacks as middleware; memory with persistence and long-term recall; automated eval; deployment as HTTP service.</p>
+<p><strong>Part 2 — Gemini unlocks</strong> (M11-M13). Google Search grounding with real citations; long context + 90%-discount caching; thinking budgets; Live API voice agents.</p>
+<p><strong>Side step</strong> (M14). A2A protocol for cross-framework agent-to-agent communication.</p>
+<h3>What to do next</h3>
+<ul>
+<li><strong>Build something.</strong> A voice-first customer-support bot. A research orchestrator. A personal assistant that survives restarts. The course taught mechanics; building teaches the rest.</li>
+<li><strong>Follow the protocols.</strong> A2A and MCP are both under Linux Foundation governance. The protocols outlast frameworks; invest in understanding them as durable.</li>
+<li><strong>Watch the course repo.</strong> <code>DEMOS_BROKEN.md</code> tracks what&rsquo;s broken at preview-tier; entries will be cleared as the APIs stabilize.</li>
+</ul>
+<p>Thanks for taking the course. Go build something.</p>
         </section>
         </main>
     </div>


### PR DESCRIPTION
Module 14 — the course finale. Full A2A end-to-end: `to_a2a()` spawns an ADK agent as a Starlette+uvicorn A2A server; `RemoteA2aAgent` consumes it from another process. 20°C → 68°F conversion runs on the remote server; event stream shows the remote tool call + response + final text. Covers the four nouns, use_legacy=False, Agent Card structure, honest maturity read, six gotchas, and the course wrap.

All 14 modules are now Ready. Full course shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)