### PR TITLE
course: Nunito typography + Quick-path (1-hour track)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,24 +4,58 @@ A vendor-agnostic course on Google's Agent Development Kit. Fourteen modules, fo
 
 Part 1 teaches the portable spine of ADK — the agent mental model, tools, state, workflow agents, multi-agent hierarchies, callbacks, memory, evaluation, deployment — running against any model via LiteLLM (OpenRouter by default). Part 2 covers what only unlocks with Gemini: search grounding, long context with caching, thinking budgets, and the Live voice API. A short side step on the A2A agent-to-agent protocol closes the course.
 
-## Course map
+---
 
-| # | Module | API key needed |
+## Two ways to take the course
+
+Pick the path that matches what you have time for.
+
+### ⚡ Quick path — ~1 hour
+
+For the impatient, or for a course preview before committing. Four modules, in order, give you the core ADK mental model plus the most-demonstrated wow capabilities.
+
+| # | Module | Why it's on the quick path |
 |---|---|---|
-| M01 | Why agents, why ADK — the Agent + Runner + Event model | OpenRouter |
-| M02 | Tools as verbs — FunctionTool, OpenAPI, MCP, AgentTool | OpenRouter |
+| **M01** | Why agents, why ADK | The four primitives (Agent, Runner, Event, Session). Non-negotiable foundation. |
+| **M02** | Tools as verbs | Tools are what make an agent useful. Four flavors in 20 minutes. |
+| **M05** | Workflow agents | The canonical Generator+Critic refinement loop — the "oh, this is what ADK is good at" moment. |
+| **M11** | Gemini grounding + caching | A taste of what Part 2 adds on top of vendor-agnostic ADK. Real citations, 90% caching discount. |
+
+Each quick-path module is marked with **⚡** on the portal, in slide-deck headers, and in the textbook sidebar. Everything else in the course is there for when you want to deepen a specific area.
+
+**Suggested reading order for Quick path:**
+1. Slides M01 + speaker notes — 15 min
+2. Notebook M01 — skim the code, no need to run it fully — 5 min
+3. Slides M02 — 20 min
+4. Textbook chapter 5 (Workflow agents) — 15 min
+5. Slides M11 — 10 min
+
+That's ~65 minutes; you'll be able to explain what ADK is, what agent software looks like, and why Gemini is the vendor with the most to offer.
+
+### Full path — 6–8 hours
+
+The deep track. All 14 modules; all four artifacts per module. Build, test, deploy. This is the course as authored.
+
+| # | Module | API key |
+|---|---|---|
+| **M01** ⚡ | Why agents, why ADK — the Agent + Runner + Event model | OpenRouter |
+| **M02** ⚡ | Tools as verbs — FunctionTool, OpenAPI, MCP, AgentTool | OpenRouter |
 | M03 | Sessions, State, Events, Artifacts | OpenRouter |
 | M04 | The one-line model swap (LiteLLM) | OpenRouter |
-| M05 | Workflow agents — Sequential, Parallel, Loop | OpenRouter |
+| **M05** ⚡ | Workflow agents — Sequential, Parallel, Loop | OpenRouter |
 | M06 | Multi-agent hierarchies — `sub_agents` vs `AgentTool` | OpenRouter |
 | M07 | Callbacks as middleware | OpenRouter |
 | M08 | Memory — sessions, long-term recall, `load_memory` | OpenRouter |
 | M09 | Evaluation — trajectories, EvalSets | OpenRouter |
 | M10 | Deployment — Cloud Run and vanilla Docker | OpenRouter |
-| M11 | Google Search grounding, long context, context caching | Google AI Studio |
+| **M11** ⚡ | Google Search grounding, long context, context caching | Google AI Studio |
 | M12 | Thinking budgets | Google AI Studio |
 | M13 | Live API — voice agent with interruption | Google AI Studio |
 | M14 | A2A protocol — agent-to-agent | OpenRouter |
+
+Rows marked **⚡** are the quick-path modules. If you're on the full path, the marker is just a cue that those four carry the highest-density content — pay special attention.
+
+---
 
 ## Getting started
 
@@ -40,28 +74,46 @@ cp .env.example .env
 jupyter notebook notebooks/
 ```
 
-Each module's slide deck opens directly in a browser:
+### Open the slides portal
+
+The course front page — a compact grid of all 14 decks plus the Quick-path callout — lives at the repo root:
+
+```bash
+open index.html
+```
+
+Each module's slide deck is self-contained and opens standalone too:
 
 ```bash
 open slides/module-01-mental-model/index.html
 ```
 
-To build the textbook as a single-page HTML booklet:
+### Open the textbook
+
+Single-page HTML booklet, 15 chapters (introduction plus one per module):
 
 ```bash
+# Generate if not already built
 python3 textbook/_sources/tools/build_html.py
+
 open textbook/index.html
 ```
+
+Quick-path chapters are marked with **⚡** in the sidebar and chapter headers.
+
+---
 
 ## Repository layout
 
 ```
-slides/shared/              shared CSS/JS used by every deck
-slides/module-NN-slug/      per-module deck + speaker_notes.md
+index.html                  slides portal / course front page (deployable to S3)
+slides/shared/              canonical CSS/JS — edit here
+slides/build_slides.py      inlines shared/*.{css,js} into each deck (run after edits)
+slides/module-NN-slug/      per-module deck (self-contained) + speaker_notes.md
 textbook/_sources/chapters/ chapter markdown (canonical)
 textbook/_sources/tools/    build_html.py
 textbook/index.html         generated booklet (do not hand-edit)
-notebooks/                  runnable exercises, one per module
+notebooks/                  14 runnable exercises, one per module
 notebooks/legacy/           earlier notebooks, kept for reference during transition
 mcp_servers/                reusable MCP servers used in M02 and M14
 scripts/                    python helpers for notebooks
@@ -72,6 +124,8 @@ CLAUDE.md                   project conventions for AI collaborators
 ## Cost notes
 
 All exercises are designed to run on cheap models. Default to `openrouter/google/gemini-2.5-flash-lite` or `openrouter/openai/gpt-4o-mini` on OpenRouter (typical module cost: under $0.05 when running all cells). On Google AI Studio, default to `gemini-2.5-flash`; the Live API demo in M13 uses `gemini-live-2.5-flash-native-audio` for short smoke tests only.
+
+A full Quick path costs under **$0.10** total on OpenRouter + Google AI Studio free tier combined.
 
 ## License
 

--- a/index.html
+++ b/index.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Google ADK — A Practical Course</title>
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;500;600;700;800&display=swap');
+
     :root {
       --navy: #1E3A5F;
       --navy-light: #2A5280;
@@ -27,7 +29,7 @@
     * { margin: 0; padding: 0; box-sizing: border-box; }
     html { scroll-behavior: smooth; }
     body {
-      font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+      font-family: 'Nunito', 'Segoe UI', system-ui, -apple-system, sans-serif;
       color: var(--text);
       background: var(--bg);
       line-height: 1.55;
@@ -213,6 +215,40 @@
     .module .status.soon { background: var(--soon-bg); color: var(--soon); }
     .module.soon { opacity: 0.6; }
 
+    /* Quick-path markers on selected modules (1-hour survey). */
+    .qn.quick-path {
+      border-left: 3px solid var(--amber);
+    }
+    .qn.quick-path .num::after {
+      content: '  ⚡';
+      color: var(--amber-dark);
+    }
+    .module.quick-path {
+      border-left: 3px solid var(--amber);
+    }
+    .module.quick-path .num::after {
+      content: ' ⚡';
+      color: var(--amber-dark);
+    }
+    .quick-path-callout {
+      background: #fffbeb;
+      border: 1px solid #fde68a;
+      border-left: 4px solid var(--amber);
+      border-radius: 8px;
+      padding: 1rem 1.3rem;
+      margin-bottom: 1.2rem;
+    }
+    .quick-path-callout strong {
+      color: var(--amber-dark);
+      display: block;
+      margin-bottom: 0.3rem;
+      font-size: 0.95rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+    .quick-path-callout span { font-size: 0.9rem; color: var(--text); line-height: 1.5; }
+    .quick-path-callout .modules-list { color: var(--navy); font-weight: 700; }
+
     /* ── Resources ────────────────────────────────────────────── */
     .resources {
       display: grid;
@@ -278,13 +314,17 @@
 <!-- Quick-nav grid — all 14 decks in one glance, above the fold.    -->
 <!-- ═══════════════════════════════════════════════════════════════ -->
 <section>
+  <div class="quick-path-callout">
+    <strong>⚡ Just want a 1-hour intro?</strong>
+    <span>Follow the four <span class="modules-list">⚡</span>-marked modules below — <span class="modules-list">M01 → M02 → M05 → M11</span>. You'll leave with the core ADK mental model, the four tool flavors, the canonical composition wow demo, and a taste of what Gemini unlocks. The rest deepens each area.</span>
+  </div>
   <h2>Slide decks</h2>
   <div class="quick-nav">
-    <a class="qn" href="slides/module-01-mental-model/index.html">
+    <a class="qn quick-path" href="slides/module-01-mental-model/index.html">
       <div class="num">M01</div>
       <div class="title">Why agents, why ADK</div>
     </a>
-    <a class="qn" href="slides/module-02-tools/index.html">
+    <a class="qn quick-path" href="slides/module-02-tools/index.html">
       <div class="num">M02</div>
       <div class="title">Tools as verbs</div>
     </a>
@@ -296,7 +336,7 @@
       <div class="num">M04</div>
       <div class="title">One-line model swap</div>
     </a>
-    <a class="qn" href="slides/module-05-workflow-agents/index.html">
+    <a class="qn quick-path" href="slides/module-05-workflow-agents/index.html">
       <div class="num">M05</div>
       <div class="title">Workflow agents</div>
     </a>
@@ -320,7 +360,7 @@
       <div class="num">M10</div>
       <div class="title">Deployment</div>
     </a>
-    <a class="qn" href="slides/module-11-gemini-grounding/index.html">
+    <a class="qn quick-path" href="slides/module-11-gemini-grounding/index.html">
       <div class="num">M11 &middot; Part 2</div>
       <div class="title">Gemini grounding + caching</div>
     </a>
@@ -349,7 +389,7 @@
   <div class="section-label">Part 1 — Vendor-agnostic spine (OpenRouter)</div>
   <div class="modules">
 
-    <a class="module" href="slides/module-01-mental-model/index.html">
+    <a class="module quick-path" href="slides/module-01-mental-model/index.html">
       <div class="num">M01</div>
       <div>
         <div class="title">Why agents, why ADK</div>
@@ -362,7 +402,7 @@
       <div class="status ready">Ready</div>
     </a>
 
-    <a class="module" href="slides/module-02-tools/index.html">
+    <a class="module quick-path" href="slides/module-02-tools/index.html">
       <div class="num">M02</div>
       <div>
         <div class="title">Tools as verbs</div>
@@ -401,7 +441,7 @@
       <div class="status ready">Ready</div>
     </a>
 
-    <a class="module" href="slides/module-05-workflow-agents/index.html">
+    <a class="module quick-path" href="slides/module-05-workflow-agents/index.html">
       <div class="num">M05</div>
       <div>
         <div class="title">Workflow agents</div>
@@ -484,7 +524,7 @@
   <div class="section-label">Part 2 — Gemini unlocks (Google AI Studio)</div>
   <div class="modules">
 
-    <a class="module" href="slides/module-11-gemini-grounding/index.html">
+    <a class="module quick-path" href="slides/module-11-gemini-grounding/index.html">
       <div class="num">M11</div>
       <div>
         <div class="title">Grounding, long context, caching</div>

--- a/notebooks/01_mental_model.ipynb
+++ b/notebooks/01_mental_model.ipynb
@@ -5,14 +5,18 @@
    "id": "fc80aae5",
    "metadata": {},
    "source": [
-    "# Module 01 — Why agents, why ADK\n",
+    "# Module 01 \u2014 Why agents, why ADK\n",
     "\n",
-    "In this notebook you'll build two versions of the world's simplest agent — one without tools, one with a tool — and watch the **event stream** that connects the LLM, the tool, and you.\n",
+    "> **\u26a1 Quick path** \u2014 this is one of four modules on the 1-hour course preview.\n",
+    "> See the [README's Quick path section](../README.md#-quick-path---1-hour) for the sequence.\n",
+    "\n",
+    "In this notebook you'll build two versions of the world's simplest agent \u2014 one without tools, one with a tool \u2014 and watch the **event stream** that connects the LLM, the tool, and you.\n",
     "\n",
     "**What you'll leave with:** a mental model for the four primitives ADK gives you (`Agent`, `Runner`, `Event`, `Session`). Every later module unpacks one of those four.\n",
     "\n",
     "**Runs in:** Google Colab or a local Python 3.10+ environment.\n",
-    "**Running cost:** well under $0.01 on OpenRouter's cheap models.\n"
+    "**Running cost:** well under $0.01 on OpenRouter's cheap models.\n",
+    ""
    ]
   },
   {
@@ -38,7 +42,7 @@
    "source": [
     "!pip install -q google-adk==1.28.0 litellm==1.83.4 python-dotenv==1.0.1 nest-asyncio==1.6.0 deprecated==1.2.18 2>/dev/null\n",
     "\n",
-    "print(\"✅ Packages installed.\")"
+    "print(\"\u2705 Packages installed.\")"
    ]
   },
   {
@@ -48,11 +52,11 @@
    "source": [
     "## API Key Configuration\n",
     "\n",
-    "Part 1 of this course (M01–M10) uses **OpenRouter** so every demo works against Claude, GPT, Gemini, Qwen, or Gemma with a one-line swap. You need an `OPENROUTER_API_KEY`. Get one at [openrouter.ai/keys](https://openrouter.ai/keys) — pay-as-you-go, this notebook costs under a cent.\n",
+    "Part 1 of this course (M01\u2013M10) uses **OpenRouter** so every demo works against Claude, GPT, Gemini, Qwen, or Gemma with a one-line swap. You need an `OPENROUTER_API_KEY`. Get one at [openrouter.ai/keys](https://openrouter.ai/keys) \u2014 pay-as-you-go, this notebook costs under a cent.\n",
     "\n",
     "Two ways to provide it:\n",
     "\n",
-    "**Method 1 (Colab, recommended):** Click the 🔑 icon in the left sidebar → Add new secret → Name: `OPENROUTER_API_KEY` → Value: your key → enable notebook access.\n",
+    "**Method 1 (Colab, recommended):** Click the \ud83d\udd11 icon in the left sidebar \u2192 Add new secret \u2192 Name: `OPENROUTER_API_KEY` \u2192 Value: your key \u2192 enable notebook access.\n",
     "\n",
     "**Method 2 (local or fallback):** Put it in a `.env` file next to the notebook, or paste it when prompted."
    ]
@@ -72,28 +76,28 @@
     "try:\n",
     "    from google.colab import userdata\n",
     "    OPENROUTER_API_KEY = userdata.get(\"OPENROUTER_API_KEY\")\n",
-    "    print(\"✅ API key loaded from Colab secrets.\")\n",
+    "    print(\"\u2705 API key loaded from Colab secrets.\")\n",
     "except Exception:\n",
     "    try:\n",
     "        from dotenv import load_dotenv\n",
     "        load_dotenv()\n",
     "        OPENROUTER_API_KEY = os.getenv(\"OPENROUTER_API_KEY\")\n",
     "        if OPENROUTER_API_KEY:\n",
-    "            print(\"✅ API key loaded from .env file.\")\n",
+    "            print(\"\u2705 API key loaded from .env file.\")\n",
     "    except ImportError:\n",
     "        pass\n",
     "\n",
     "if not OPENROUTER_API_KEY:\n",
     "    from getpass import getpass\n",
-    "    print(\"💡 Tip for Colab users: Go to 🔑 (left sidebar) → Add new secret → Name: OPENROUTER_API_KEY\")\n",
+    "    print(\"\ud83d\udca1 Tip for Colab users: Go to \ud83d\udd11 (left sidebar) \u2192 Add new secret \u2192 Name: OPENROUTER_API_KEY\")\n",
     "    OPENROUTER_API_KEY = getpass(\"Enter your OpenRouter API key: \")\n",
     "\n",
-    "assert OPENROUTER_API_KEY and OPENROUTER_API_KEY.strip(), \"❌ No API key provided.\"\n",
+    "assert OPENROUTER_API_KEY and OPENROUTER_API_KEY.strip(), \"\u274c No API key provided.\"\n",
     "os.environ[\"OPENROUTER_API_KEY\"] = OPENROUTER_API_KEY\n",
     "\n",
     "# Cheap + fast model for all vendor-agnostic demos. Swap it to try another provider.\n",
     "MODEL_STRING = \"openrouter/google/gemini-2.5-flash-lite\"\n",
-    "print(f\"✅ Model: {MODEL_STRING}\")"
+    "print(f\"\u2705 Model: {MODEL_STRING}\")"
    ]
   },
   {
@@ -103,7 +107,7 @@
    "source": [
     "## Import Libraries\n",
     "\n",
-    "ADK is Google's framework, so it natively speaks Gemini. To use it with any other model, we go through **LiteLLM** — a translation layer that turns one API format into many providers' formats. The `LiteLlm` wrapper you'll see below is the single line that makes ADK vendor-neutral."
+    "ADK is Google's framework, so it natively speaks Gemini. To use it with any other model, we go through **LiteLLM** \u2014 a translation layer that turns one API format into many providers' formats. The `LiteLlm` wrapper you'll see below is the single line that makes ADK vendor-neutral."
    ]
   },
   {
@@ -133,7 +137,7 @@
     "import asyncio\n",
     "import uuid\n",
     "\n",
-    "print(\"✅ Imports successful.\")"
+    "print(\"\u2705 Imports successful.\")"
    ]
   },
   {
@@ -150,9 +154,9 @@
     "| `LlmAgent` | An LLM wired to instructions, a model, and (optionally) tools | You define one |\n",
     "| `Runner` | The event loop that drives a conversation | You call `.run_async()` |\n",
     "| `Event` | Every message, tool call, tool response, and state change | You read them to see what's happening |\n",
-    "| `Session` | The conversation's memory — event history plus a state dict | You create one per conversation |\n",
+    "| `Session` | The conversation's memory \u2014 event history plus a state dict | You create one per conversation |\n",
     "\n",
-    "Everything else — workflow agents, multi-agent hierarchies, callbacks, memory services, evaluation — composes on top of these four. Keep them in mind; they'll come back every module."
+    "Everything else \u2014 workflow agents, multi-agent hierarchies, callbacks, memory services, evaluation \u2014 composes on top of these four. Keep them in mind; they'll come back every module."
    ]
   },
   {
@@ -162,7 +166,7 @@
    "source": [
     "# The World's Simplest Agent\n",
     "\n",
-    "Four required arguments: a name, a model, a description, and an instruction. No tools yet — this is just an LLM with a system prompt, wrapped in ADK's plumbing."
+    "Four required arguments: a name, a model, a description, and an instruction. No tools yet \u2014 this is just an LLM with a system prompt, wrapped in ADK's plumbing."
    ]
   },
   {
@@ -179,7 +183,7 @@
     "    instruction=\"You are a friendly greeter. Respond in one short sentence.\",\n",
     ")\n",
     "\n",
-    "print(f\"✅ Agent '{greeter.name}' built.\")"
+    "print(f\"\u2705 Agent '{greeter.name}' built.\")"
    ]
   },
   {
@@ -189,7 +193,7 @@
    "source": [
     "## Running the Agent\n",
     "\n",
-    "An `LlmAgent` on its own doesn't do anything. It needs a `Runner` to drive it, and a `Session` to hold the conversation. `runner.run_async(...)` returns an **event stream** — one yielded event per step. Watch the stream carefully; this is how ADK makes agent behavior visible."
+    "An `LlmAgent` on its own doesn't do anything. It needs a `Runner` to drive it, and a `Session` to hold the conversation. `runner.run_async(...)` returns an **event stream** \u2014 one yielded event per step. Watch the stream carefully; this is how ADK makes agent behavior visible."
    ]
   },
   {
@@ -233,7 +237,7 @@
    "id": "9ce70dee",
    "metadata": {},
    "source": [
-    "One event came back, containing the final text response. That's the minimum a conversation can produce — a user turn goes in, one model turn comes out, the stream ends. **Events are the unit of observability in ADK:** every message, tool call, tool response, state change, or agent hand-off is one. Later modules add tools, delegation, and state mutations; you'll see the event stream grow."
+    "One event came back, containing the final text response. That's the minimum a conversation can produce \u2014 a user turn goes in, one model turn comes out, the stream ends. **Events are the unit of observability in ADK:** every message, tool call, tool response, state change, or agent hand-off is one. Later modules add tools, delegation, and state mutations; you'll see the event stream grow."
    ]
   },
   {
@@ -241,14 +245,14 @@
    "id": "8fb29e49",
    "metadata": {},
    "source": [
-    "# Add a Tool — And Watch the Events Multiply\n",
+    "# Add a Tool \u2014 And Watch the Events Multiply\n",
     "\n",
     "Tools are Python functions with a **docstring** and **type hints**. ADK reads those to build a JSON schema the model can see. The model decides to call the tool; ADK executes it; the result comes back as a tool-response event; the model produces a final answer.\n",
     "\n",
     "You'll see three events instead of one:\n",
     "\n",
     "```\n",
-    "user turn → [tool_call] → [tool_resp] → [FINAL] text response\n",
+    "user turn \u2192 [tool_call] \u2192 [tool_resp] \u2192 [FINAL] text response\n",
     "```"
    ]
   },
@@ -266,9 +270,9 @@
     "    as a string; the output is a dict with 'city' and 'report' keys.\n",
     "    \"\"\"\n",
     "    fake_db = {\n",
-    "        \"Bratislava\": \"Sunny, 18°C\",\n",
-    "        \"Prague\": \"Cloudy, 14°C\",\n",
-    "        \"Munich\": \"Rainy, 11°C\",\n",
+    "        \"Bratislava\": \"Sunny, 18\u00b0C\",\n",
+    "        \"Prague\": \"Cloudy, 14\u00b0C\",\n",
+    "        \"Munich\": \"Rainy, 11\u00b0C\",\n",
     "    }\n",
     "    return {\n",
     "        \"city\": city,\n",
@@ -298,11 +302,11 @@
     "\n",
     "The output above is the smallest complete picture of an agent run:\n",
     "\n",
-    "1. **`[tool_call] get_weather({'city': 'Prague'})`** — the model decided a tool was needed and emitted a structured call. ADK caught it before it left the agent.\n",
-    "2. **`[tool_resp] {'city': 'Prague', 'report': 'Cloudy, 14°C'}`** — ADK executed the Python function and fed the return value back to the model as a tool-response event.\n",
-    "3. **`[FINAL] weather_agent: ...`** — the model wrote a natural-language answer using the tool's output.\n",
+    "1. **`[tool_call] get_weather({'city': 'Prague'})`** \u2014 the model decided a tool was needed and emitted a structured call. ADK caught it before it left the agent.\n",
+    "2. **`[tool_resp] {'city': 'Prague', 'report': 'Cloudy, 14\u00b0C'}`** \u2014 ADK executed the Python function and fed the return value back to the model as a tool-response event.\n",
+    "3. **`[FINAL] weather_agent: ...`** \u2014 the model wrote a natural-language answer using the tool's output.\n",
     "\n",
-    "Three events, all visible, all inspectable. If the model had called the tool wrong, you'd see the error. If it had refused to call the tool, you'd see the refusal. If it had called two tools in sequence, you'd see both. This visibility is ADK's single biggest pedagogical advantage over stringing together raw LLM calls — you can read the agent's reasoning by reading the events."
+    "Three events, all visible, all inspectable. If the model had called the tool wrong, you'd see the error. If it had refused to call the tool, you'd see the refusal. If it had called two tools in sequence, you'd see both. This visibility is ADK's single biggest pedagogical advantage over stringing together raw LLM calls \u2014 you can read the agent's reasoning by reading the events."
    ]
   },
   {
@@ -312,7 +316,7 @@
    "source": [
     "## A Word on `adk web`\n",
     "\n",
-    "Everything you just printed can be browsed visually by running `adk web` from a folder containing your agent. It opens a chat UI with a live event timeline beside the conversation — the same events, clickable, inspectable, with the full JSON payloads. If you're learning ADK, run `adk web` often. We'll rely on the text printouts in this course because they drop into a video recording cleanly, but the web UI is the best debugger you get for free."
+    "Everything you just printed can be browsed visually by running `adk web` from a folder containing your agent. It opens a chat UI with a live event timeline beside the conversation \u2014 the same events, clickable, inspectable, with the full JSON payloads. If you're learning ADK, run `adk web` often. We'll rely on the text printouts in this course because they drop into a video recording cleanly, but the web UI is the best debugger you get for free."
    ]
   },
   {
@@ -325,8 +329,8 @@
     "Three small changes, five minutes each. Run them in a new cell below so you can diff the event streams.\n",
     "\n",
     "1. **Change the model.** Replace `MODEL_STRING` with `openrouter/anthropic/claude-haiku-4-5` or `openrouter/openai/gpt-4o-mini`. Re-run the weather agent. Does the final answer change? Do the events change shape?\n",
-    "2. **Break the tool on purpose.** Ask the weather agent about `\"Reykjavik\"` (not in the fake database). Read the events. How does the model handle the `\"No data for Reykjavik.\"` response — does it pass the report through honestly, or hallucinate?\n",
-    "3. **Add a second tool.** Write a `convert_celsius_to_fahrenheit(celsius: float) -> float` tool, add it to the agent, and ask *\"What's the weather in Munich in Fahrenheit?\"*. Watch the event stream — how many tool calls does the model make? In what order?\n",
+    "2. **Break the tool on purpose.** Ask the weather agent about `\"Reykjavik\"` (not in the fake database). Read the events. How does the model handle the `\"No data for Reykjavik.\"` response \u2014 does it pass the report through honestly, or hallucinate?\n",
+    "3. **Add a second tool.** Write a `convert_celsius_to_fahrenheit(celsius: float) -> float` tool, add it to the agent, and ask *\"What's the weather in Munich in Fahrenheit?\"*. Watch the event stream \u2014 how many tool calls does the model make? In what order?\n",
     "\n",
     "No grading. The goal is to get a feel for what shows up in the event stream and what doesn't."
    ]
@@ -338,15 +342,15 @@
    "source": [
     "# Key Takeaways\n",
     "\n",
-    "- An ADK agent is a configuration object. Four required arguments — name, model, description, instruction — plus an optional list of tools.\n",
+    "- An ADK agent is a configuration object. Four required arguments \u2014 name, model, description, instruction \u2014 plus an optional list of tools.\n",
     "- The **Runner** drives conversations forward; `.run_async()` yields an **Event** per step.\n",
     "- Every meaningful moment in an agent run is an Event: user input, tool calls, tool responses, state changes, final text. Read events to debug.\n",
     "- The **`LiteLlm` wrapper** is the one-line swap that makes ADK vendor-neutral. The same agent runs on Gemini, Claude, GPT, or any OpenRouter-routable model.\n",
-    "- The four primitives to carry forward: **`Agent` · `Runner` · `Event` · `Session`**. Every later module composes on top of them.\n",
+    "- The four primitives to carry forward: **`Agent` \u00b7 `Runner` \u00b7 `Event` \u00b7 `Session`**. Every later module composes on top of them.\n",
     "\n",
-    "# Next up — M02: Tools as verbs\n",
+    "# Next up \u2014 M02: Tools as verbs\n",
     "\n",
-    "You just saw one flavor of tool: a plain Python function. ADK supports three more — an OpenAPI spec, an MCP server, and another agent wrapped as a tool. M02 builds one of each. Before you move on, make sure you can say out loud what each primitive is. If not, re-read the event-stream output once more."
+    "You just saw one flavor of tool: a plain Python function. ADK supports three more \u2014 an OpenAPI spec, an MCP server, and another agent wrapped as a tool. M02 builds one of each. Before you move on, make sure you can say out loud what each primitive is. If not, re-read the event-stream output once more."
    ]
   }
  ],

--- a/notebooks/02_tools.ipynb
+++ b/notebooks/02_tools.ipynb
@@ -5,15 +5,18 @@
    "id": "67eaa179",
    "metadata": {},
    "source": [
-    "# Module 02 — Tools as verbs\n",
+    "# Module 02 \u2014 Tools as verbs\n",
     "\n",
-    "If Module 01 gave you the *mental model* for an agent, Module 02 is where the agent starts *doing things*. Tools are the verbs of agent programming. An agent without tools is a chatbot — it can only emit text. An agent with tools can look up data, call APIs, talk to other agents, run code. Everything interesting.\n",
+    "> **\u26a1 Quick path** \u2014 this is one of four modules on the 1-hour course preview.\n",
+    "> See the [README's Quick path section](../README.md#-quick-path---1-hour) for the sequence.\n",
     "\n",
-    "In this module you'll learn the **four flavors of tools** ADK supports, when to use each, and a short theoretical interlude on **risk-based tool design** — because a tool that reads data and a tool that deletes a database should not be in the same design category.\n",
+    "If Module 01 gave you the *mental model* for an agent, Module 02 is where the agent starts *doing things*. Tools are the verbs of agent programming. An agent without tools is a chatbot \u2014 it can only emit text. An agent with tools can look up data, call APIs, talk to other agents, run code. Everything interesting.\n",
+    "\n",
+    "In this module you'll learn the **four flavors of tools** ADK supports, when to use each, and a short theoretical interlude on **risk-based tool design** \u2014 because a tool that reads data and a tool that deletes a database should not be in the same design category.\n",
     "\n",
     "**What you'll build:** four small agents, one per tool flavor, plus one extra that demonstrates a confirmation gate on a destructive tool.\n",
     "\n",
-    "**Runs in:** Google Colab or local Jupyter. MCP demo needs the `mcp_servers/` folder from this repo — if you're on Colab, clone the repo first.\n",
+    "**Runs in:** Google Colab or local Jupyter. MCP demo needs the `mcp_servers/` folder from this repo \u2014 if you're on Colab, clone the repo first.\n",
     "\n",
     "**Running cost:** under $0.02 on OpenRouter."
    ]
@@ -37,7 +40,7 @@
    "source": [
     "!pip install -q google-adk==1.28.0 litellm==1.83.4 mcp==1.27.0 httpx==0.28.1 python-dotenv==1.0.1 nest-asyncio==1.6.0 deprecated==1.2.18 2>/dev/null\n",
     "\n",
-    "print(\"✅ Packages installed.\")"
+    "print(\"\u2705 Packages installed.\")"
    ]
   },
   {
@@ -47,7 +50,7 @@
    "source": [
     "## Clone the MCP servers folder (Colab only)\n",
     "\n",
-    "If you're running this locally, skip the next cell — you already have `mcp_servers/`. If you're on Colab, run it to pull the repo and `cd` into it."
+    "If you're running this locally, skip the next cell \u2014 you already have `mcp_servers/`. If you're on Colab, run it to pull the repo and `cd` into it."
    ]
   },
   {
@@ -61,10 +64,10 @@
     "if \"COLAB_GPU\" in os.environ or \"COLAB_JUPYTER_IP\" in os.environ:\n",
     "    !git clone --depth=1 -q https://github.com/robertbarcik/ADK-tutorial /content/ADK-tutorial 2>/dev/null || true\n",
     "    os.chdir(\"/content/ADK-tutorial\")\n",
-    "    print(f\"✅ Colab: working in {os.getcwd()}\")\n",
+    "    print(f\"\u2705 Colab: working in {os.getcwd()}\")\n",
     "else:\n",
     "    # Local: you should already be inside the repo.\n",
-    "    print(f\"✅ Local: working in {os.getcwd()}\")"
+    "    print(f\"\u2705 Local: working in {os.getcwd()}\")"
    ]
   },
   {
@@ -90,27 +93,27 @@
     "try:\n",
     "    from google.colab import userdata\n",
     "    OPENROUTER_API_KEY = userdata.get(\"OPENROUTER_API_KEY\")\n",
-    "    print(\"✅ API key loaded from Colab secrets.\")\n",
+    "    print(\"\u2705 API key loaded from Colab secrets.\")\n",
     "except Exception:\n",
     "    try:\n",
     "        from dotenv import load_dotenv\n",
     "        load_dotenv()\n",
     "        OPENROUTER_API_KEY = os.getenv(\"OPENROUTER_API_KEY\")\n",
     "        if OPENROUTER_API_KEY:\n",
-    "            print(\"✅ API key loaded from .env file.\")\n",
+    "            print(\"\u2705 API key loaded from .env file.\")\n",
     "    except ImportError:\n",
     "        pass\n",
     "\n",
     "if not OPENROUTER_API_KEY:\n",
     "    from getpass import getpass\n",
-    "    print(\"💡 Tip: set OPENROUTER_API_KEY in Colab secrets (🔑 icon) or a local .env file.\")\n",
+    "    print(\"\ud83d\udca1 Tip: set OPENROUTER_API_KEY in Colab secrets (\ud83d\udd11 icon) or a local .env file.\")\n",
     "    OPENROUTER_API_KEY = getpass(\"Enter your OpenRouter API key: \")\n",
     "\n",
-    "assert OPENROUTER_API_KEY, \"❌ No API key provided.\"\n",
+    "assert OPENROUTER_API_KEY, \"\u274c No API key provided.\"\n",
     "os.environ[\"OPENROUTER_API_KEY\"] = OPENROUTER_API_KEY\n",
     "\n",
     "MODEL_STRING = \"openrouter/google/gemini-2.5-flash-lite\"\n",
-    "print(f\"✅ Model: {MODEL_STRING}\")"
+    "print(f\"\u2705 Model: {MODEL_STRING}\")"
    ]
   },
   {
@@ -160,7 +163,7 @@
     "from mcp import StdioServerParameters\n",
     "from google.genai import types\n",
     "\n",
-    "print(\"✅ Imports successful.\")"
+    "print(\"\u2705 Imports successful.\")"
    ]
   },
   {
@@ -173,16 +176,16 @@
     "Here's what's happening when your agent calls a tool, regardless of the flavor:\n",
     "\n",
     "```\n",
-    "┌─────────────┐   \"I need to know X\"    ┌─────────────┐\n",
-    "│   LLM       │────────────────────────▶│    ADK      │\n",
-    "│   decides   │                         │  dispatch   │\n",
-    "└─────────────┘                         └──────┬──────┘\n",
-    "       ▲                                       │\n",
-    "       │  \"X is {...}\"                         ▼\n",
-    "       │                                 ┌─────────────┐\n",
-    "       └─────────────────────────────────│  your tool  │\n",
-    "                                         │  (any kind) │\n",
-    "                                         └─────────────┘\n",
+    "\u250c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510   \"I need to know X\"    \u250c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510\n",
+    "\u2502   LLM       \u2502\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u25b6\u2502    ADK      \u2502\n",
+    "\u2502   decides   \u2502                         \u2502  dispatch   \u2502\n",
+    "\u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518                         \u2514\u2500\u2500\u2500\u2500\u2500\u2500\u252c\u2500\u2500\u2500\u2500\u2500\u2500\u2518\n",
+    "       \u25b2                                       \u2502\n",
+    "       \u2502  \"X is {...}\"                         \u25bc\n",
+    "       \u2502                                 \u250c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510\n",
+    "       \u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2502  your tool  \u2502\n",
+    "                                         \u2502  (any kind) \u2502\n",
+    "                                         \u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518\n",
     "```\n",
     "\n",
     "The model sees a **schema** (tool name, description, argument types) and decides when to call the tool and with what arguments. ADK handles the dispatch: it finds the Python code behind the schema, calls it, wraps the return value, and gives it back to the model as a tool-response event.\n",
@@ -241,7 +244,7 @@
     "                    # Truncate long MCP responses\n",
     "                    print(f\"[tool_resp] {resp[:350]}{'...' if len(resp) > 350 else ''}\")\n",
     "\n",
-    "print(\"✅ chat() helper ready.\")"
+    "print(\"\u2705 chat() helper ready.\")"
    ]
   },
   {
@@ -249,7 +252,7 @@
    "id": "ff07efe5",
    "metadata": {},
    "source": [
-    "# Flavor 1 — FunctionTool: Plain Python Functions\n",
+    "# Flavor 1 \u2014 FunctionTool: Plain Python Functions\n",
     "\n",
     "You saw this one in M01. Here's the deep version: **the docstring is the schema the model sees.** ADK reads your function's docstring + type hints and turns them into the JSON schema the LLM provider expects. Three practical consequences:\n",
     "\n",
@@ -257,7 +260,7 @@
     "2. **Type hints are load-bearing.** `city: str` becomes `\"type\": \"string\"`. A missing type hint degrades to `\"string\"` or worse. Always type your tool functions.\n",
     "3. **Return a JSON-serializable dict or string.** Not a custom class, not a NumPy array. The return value is sent verbatim to the model as a tool-response event.\n",
     "\n",
-    "Here's a richer version of the weather tool — two parameters, one optional — that demonstrates what good tool docstrings look like."
+    "Here's a richer version of the weather tool \u2014 two parameters, one optional \u2014 that demonstrates what good tool docstrings look like."
    ]
   },
   {
@@ -295,7 +298,7 @@
     "    model=LiteLlm(model=MODEL_STRING),\n",
     "    description=\"Reports today's weather for a city.\",\n",
     "    instruction=(\n",
-    "        \"You report weather. Always use the get_weather tool. Be brief — \"\n",
+    "        \"You report weather. Always use the get_weather tool. Be brief \u2014 \"\n",
     "        \"a single short sentence.\"\n",
     "    ),\n",
     "    tools=[get_weather],\n",
@@ -312,7 +315,7 @@
     "Two things worth noticing in that event stream:\n",
     "\n",
     "- The model picked `units='fahrenheit'` because you asked for it in English. It did *not* hallucinate a unit the schema doesn't allow; the docstring's explicit mention of \"celsius\" and \"fahrenheit\" narrowed the choice.\n",
-    "- The return value is passed through as a dict. The model read the numeric `temperature` field and composed a natural-language response around it. The tool didn't need to return prose — structured data is enough.\n",
+    "- The return value is passed through as a dict. The model read the numeric `temperature` field and composed a natural-language response around it. The tool didn't need to return prose \u2014 structured data is enough.\n",
     "\n",
     "FunctionTool is the default flavor. Reach for it unless you have a specific reason to use one of the others."
    ]
@@ -322,13 +325,13 @@
    "id": "e1b5983f",
    "metadata": {},
    "source": [
-    "# Flavor 2 — OpenAPIToolset: Consume an Entire API\n",
+    "# Flavor 2 \u2014 OpenAPIToolset: Consume an Entire API\n",
     "\n",
     "When the thing you want to call is a REST API, you probably don't want to hand-write N `FunctionTool`s for every endpoint. `OpenAPIToolset` takes a full OpenAPI spec and turns every operation into a tool, automatically.\n",
     "\n",
-    "The demo below uses [Frankfurter](https://api.frankfurter.dev) — a free, no-auth public currency rates API. The full Frankfurter spec has several endpoints; we'll feed ADK a minimal subset that covers \"convert currency X to Y.\"\n",
+    "The demo below uses [Frankfurter](https://api.frankfurter.dev) \u2014 a free, no-auth public currency rates API. The full Frankfurter spec has several endpoints; we'll feed ADK a minimal subset that covers \"convert currency X to Y.\"\n",
     "\n",
-    "In production, you'd point this at your company's existing API spec — the same spec your web frontend already uses — and get all those endpoints available to your agent in one line."
+    "In production, you'd point this at your company's existing API spec \u2014 the same spec your web frontend already uses \u2014 and get all those endpoints available to your agent in one line."
    ]
   },
   {
@@ -398,7 +401,7 @@
    "source": [
     "Notice the tool name in the event stream: `get_latest_rate`, not `getLatestRate`. ADK snake-cases operation IDs from OpenAPI specs to match typical Python conventions. If you ever wonder why your tool by a specific name isn't being called, check whether ADK renamed it.\n",
     "\n",
-    "The tool-response event shows the raw HTTP JSON body — ADK does not transform the API's output; it just ferries it back to the model, which picks out the rate. This is a feature: you get to debug your API's contract directly in the event stream."
+    "The tool-response event shows the raw HTTP JSON body \u2014 ADK does not transform the API's output; it just ferries it back to the model, which picks out the rate. This is a feature: you get to debug your API's contract directly in the event stream."
    ]
   },
   {
@@ -406,15 +409,15 @@
    "id": "6dea9f4c",
    "metadata": {},
    "source": [
-    "# Flavor 3 — McpToolset: Connect to an MCP Server\n",
+    "# Flavor 3 \u2014 McpToolset: Connect to an MCP Server\n",
     "\n",
     "Model Context Protocol is Anthropic's standard for exposing tools to agents. It was donated to the Linux Foundation in December 2025 and is now the de facto protocol for agent-to-tool communication across the industry. An MCP server is a separate process that exposes a set of tools; your agent connects to it over stdin/stdout (or HTTP) and uses the tools as if they were local.\n",
     "\n",
     "This repo ships three MCP servers under `mcp_servers/`:\n",
     "\n",
-    "- `ticket_mcp_server.py` — an IT support ticket database (5 tools: get, list, create, update, search)\n",
-    "- `knowledge_mcp_server.py` — a help-article knowledge base\n",
-    "- `system_monitoring_mcp_server.py` — server uptime / disk / CPU lookups\n",
+    "- `ticket_mcp_server.py` \u2014 an IT support ticket database (5 tools: get, list, create, update, search)\n",
+    "- `knowledge_mcp_server.py` \u2014 a help-article knowledge base\n",
+    "- `system_monitoring_mcp_server.py` \u2014 server uptime / disk / CPU lookups\n",
     "\n",
     "We'll use the ticket server. The `McpToolset` launches it as a subprocess and discovers its tools automatically."
    ]
@@ -439,7 +442,7 @@
     "    raise FileNotFoundError(f\"Could not locate mcp_servers/{script_name}\")\n",
     "\n",
     "TICKET_SERVER_PATH = _resolve_mcp_server(\"ticket_mcp_server.py\")\n",
-    "print(f\"✅ MCP server script: {TICKET_SERVER_PATH}\")\n",
+    "print(f\"\u2705 MCP server script: {TICKET_SERVER_PATH}\")\n",
     "\n",
     "ticket_toolset = McpToolset(\n",
     "    connection_params=StdioConnectionParams(\n",
@@ -471,9 +474,9 @@
    "id": "dc5dc023",
    "metadata": {},
    "source": [
-    "What just happened under the hood: `McpToolset` started `ticket_mcp_server.py` as a subprocess, spoke the MCP handshake over stdio, and asked it for the list of tools. The server returned a schema for five tools. ADK registered those as if they were local FunctionTools, and from the agent's perspective there's no difference — it just sees `search_tickets` and calls it.\n",
+    "What just happened under the hood: `McpToolset` started `ticket_mcp_server.py` as a subprocess, spoke the MCP handshake over stdio, and asked it for the list of tools. The server returned a schema for five tools. ADK registered those as if they were local FunctionTools, and from the agent's perspective there's no difference \u2014 it just sees `search_tickets` and calls it.\n",
     "\n",
-    "**This is the most valuable part of the flavor.** Your MCP server can be written in any language (TypeScript, Go, Rust), run on any machine, and own any state — database connections, API credentials, caches. The agent doesn't care. It talks the protocol, the tools just work.\n",
+    "**This is the most valuable part of the flavor.** Your MCP server can be written in any language (TypeScript, Go, Rust), run on any machine, and own any state \u2014 database connections, API credentials, caches. The agent doesn't care. It talks the protocol, the tools just work.\n",
     "\n",
     "When you're done with an MCP toolset, close it to shut down the subprocess cleanly. We'll do that at the end of the notebook."
    ]
@@ -483,13 +486,13 @@
    "id": "add81f5e",
    "metadata": {},
    "source": [
-    "# Flavor 4 — AgentTool: Wrap an Agent as a Tool\n",
+    "# Flavor 4 \u2014 AgentTool: Wrap an Agent as a Tool\n",
     "\n",
     "The fourth flavor is the most conceptually interesting, and the one Module 06 will unpack fully. For now, the one-sentence version: **`AgentTool` takes any existing agent and makes it callable as a tool from another agent.**\n",
     "\n",
-    "Why this is useful: sometimes you have a specialist agent — a translator, a data-lookup agent, a math reasoning agent — and you want a parent orchestrator to *call* it rather than hand control over to it. The parent stays in charge; the specialist answers one question and hands control back. If that sounds like a function call, that's the mental model.\n",
+    "Why this is useful: sometimes you have a specialist agent \u2014 a translator, a data-lookup agent, a math reasoning agent \u2014 and you want a parent orchestrator to *call* it rather than hand control over to it. The parent stays in charge; the specialist answers one question and hands control back. If that sounds like a function call, that's the mental model.\n",
     "\n",
-    "The contrast is with `sub_agents` — the parent's LLM can decide to *transfer* to a child agent, which takes over the conversation until it decides to transfer back. That's delegation, not a function call. We'll compare the two in M06. For now, focus on the `AgentTool` pattern:"
+    "The contrast is with `sub_agents` \u2014 the parent's LLM can decide to *transfer* to a child agent, which takes over the conversation until it decides to transfer back. That's delegation, not a function call. We'll compare the two in M06. For now, focus on the `AgentTool` pattern:"
    ]
   },
   {
@@ -506,7 +509,7 @@
     "    description=\"Translates a short English phrase into Slovak. Input: the phrase. Output: the Slovak translation.\",\n",
     "    instruction=(\n",
     "        \"You are a translation tool. Input is an English phrase. Output is the \"\n",
-    "        \"Slovak translation only — no commentary, no prefix, no quotes. Respond \"\n",
+    "        \"Slovak translation only \u2014 no commentary, no prefix, no quotes. Respond \"\n",
     "        \"with the translation and nothing else.\"\n",
     "    ),\n",
     ")\n",
@@ -537,7 +540,7 @@
     "`AgentTool` is the right answer when:\n",
     "- The child agent has a clean input/output contract (like a function).\n",
     "- You want the parent to stay in charge of the conversation.\n",
-    "- You want the child's work to be visible in the parent's event stream (it is — you can see the call and the response).\n",
+    "- You want the child's work to be visible in the parent's event stream (it is \u2014 you can see the call and the response).\n",
     "\n",
     "Use `sub_agents` instead when the child should own the conversation for a stretch of turns. M06 will make the distinction crisp with a side-by-side demo."
    ]
@@ -547,11 +550,11 @@
    "id": "abfa622c",
    "metadata": {},
    "source": [
-    "# Interlude — Risk-based Tool Design\n",
+    "# Interlude \u2014 Risk-based Tool Design\n",
     "\n",
     "> *From the \"Agentic Design Patterns\" publication, Pattern 4. This 2-minute interlude is theory; the code below is the minimal demonstration.*\n",
     "\n",
-    "Not all tools are equal. A tool that reads a ticket database is not the same category as a tool that deletes the database. The difference is **blast radius** — the scope of damage a misfiring tool call can do before anyone notices.\n",
+    "Not all tools are equal. A tool that reads a ticket database is not the same category as a tool that deletes the database. The difference is **blast radius** \u2014 the scope of damage a misfiring tool call can do before anyone notices.\n",
     "\n",
     "A practical taxonomy:\n",
     "\n",
@@ -562,7 +565,7 @@
     "| **Mutating, irreversible** | Writes that can't be easily rolled back | `charge_credit_card`, `post_to_slack`, `execute_sql` | **Explicit confirmation** |\n",
     "| **Catastrophic** | Destructive, multi-user, loud | `drop_database`, `delete_user`, `publish_press_release` | **Human in the loop.** Do not let the agent call these directly.\n",
     "\n",
-    "The temptation is to treat every tool the same because the agent framework treats them the same. Don't. Put the guards in the *tool implementation*, not in the instruction — an instruction is a polite request the model can ignore. A code-level guard is a wall.\n",
+    "The temptation is to treat every tool the same because the agent framework treats them the same. Don't. Put the guards in the *tool implementation*, not in the instruction \u2014 an instruction is a polite request the model can ignore. A code-level guard is a wall.\n",
     "\n",
     "Here's the minimal pattern: a `delete_ticket` tool that refuses to execute without a confirmation token."
    ]
@@ -623,7 +626,7 @@
    "id": "8fdae6ec",
    "metadata": {},
    "source": [
-    "Read the event stream. The agent called `delete_ticket` without a confirmation token, got back a **preview** response, and surfaced it to the user — rather than silently destroying the ticket. The actual delete only happens if a second user turn provides the confirmation.\n",
+    "Read the event stream. The agent called `delete_ticket` without a confirmation token, got back a **preview** response, and surfaced it to the user \u2014 rather than silently destroying the ticket. The actual delete only happens if a second user turn provides the confirmation.\n",
     "\n",
     "The key design move: **the guard is in the tool's code**, enforced by a string-equality check. The instruction tells the model how to behave politely, but the tool *cannot be tricked* into executing without the token, no matter what the model does. This is the pattern to carry forward for any tool with irreversible consequences."
    ]
@@ -646,7 +649,7 @@
    "outputs": [],
    "source": [
     "await ticket_toolset.close()\n",
-    "print(\"✅ MCP subprocess closed.\")"
+    "print(\"\u2705 MCP subprocess closed.\")"
    ]
   },
   {
@@ -659,9 +662,9 @@
     "Four small tasks, one per flavor plus the interlude. Each should take about five minutes in its own new cell below.\n",
     "\n",
     "1. **FunctionTool.** Extend `get_weather` to take a third optional argument `days_ahead: int = 0` and have the function return a different (fake) forecast for each day. Ask the agent for tomorrow's weather in Prague. Does the model call the tool with `days_ahead=1`?\n",
-    "2. **OpenAPIToolset.** Add a second path to `FRANKFURTER_SPEC` — `/currencies` (which returns a JSON dict of all supported currency codes). Ask the agent *\"What currencies do you support?\"* — does it call the new operation?\n",
+    "2. **OpenAPIToolset.** Add a second path to `FRANKFURTER_SPEC` \u2014 `/currencies` (which returns a JSON dict of all supported currency codes). Ask the agent *\"What currencies do you support?\"* \u2014 does it call the new operation?\n",
     "3. **McpToolset.** Swap `ticket_mcp_server.py` for `knowledge_mcp_server.py` in `McpToolset`. Build a new agent that searches the knowledge base. What tools does it expose?\n",
-    "4. **AgentTool.** Wrap the `fx_agent` (from flavor 2) as an `AgentTool` and add it to the `orchestrator`. Ask the orchestrator *\"Translate 'Today 1 USD is X EUR' into Slovak, with X filled from the live rate.\"* — does it call both tools in one turn?\n",
+    "4. **AgentTool.** Wrap the `fx_agent` (from flavor 2) as an `AgentTool` and add it to the `orchestrator`. Ask the orchestrator *\"Translate 'Today 1 USD is X EUR' into Slovak, with X filled from the live rate.\"* \u2014 does it call both tools in one turn?\n",
     "5. **Risk-based.** Add a second destructive tool, `wipe_all_tickets()`, that returns a preview with a counter like \"this would delete 17 tickets\" and requires the token `\"CONFIRM_WIPE_ALL\"`. Verify the preview comes back correctly."
    ]
   },
@@ -679,7 +682,7 @@
     "- **AgentTool**: wrap a specialist agent so its parent can call it like a function. Keeps the parent in charge.\n",
     "- **Risk-based tool design**: blast radius matters. Put confirmation gates *in the tool code*, not only the instruction. An instruction is a request; code is a wall.\n",
     "\n",
-    "# Next up — M03: Sessions, State, Events, Artifacts\n",
+    "# Next up \u2014 M03: Sessions, State, Events, Artifacts\n",
     "\n",
     "Every tool call you just saw went into the session's event history. M03 makes sessions the subject: how to persist them, how to put state in them, how to scope state with prefixes (`user:`, `app:`, `temp:`), and why the boundary between *session state* and *long-term memory* matters for production agents. See you there."
    ]

--- a/notebooks/05_workflow_agents.ipynb
+++ b/notebooks/05_workflow_agents.ipynb
@@ -5,15 +5,18 @@
    "id": "c45406a5",
    "metadata": {},
    "source": [
-    "# Module 05 — Workflow Agents\n",
+    "# Module 05 \u2014 Workflow Agents\n",
+    "\n",
+    "> **\u26a1 Quick path** \u2014 this is one of four modules on the 1-hour course preview.\n",
+    "> See the [README's Quick path section](../README.md#-quick-path---1-hour) for the sequence.\n",
     "\n",
     "Four modules in, every demo has had **one agent** doing the work. That's enough for toy problems. Real work needs composition.\n",
     "\n",
-    "ADK ships **three first-class workflow primitives** that let you compose agents into pipelines, fan-outs, and refinement loops — without writing orchestration code yourself:\n",
+    "ADK ships **three first-class workflow primitives** that let you compose agents into pipelines, fan-outs, and refinement loops \u2014 without writing orchestration code yourself:\n",
     "\n",
-    "- **`SequentialAgent`** — run children in order, passing state between them. A shell pipeline.\n",
-    "- **`ParallelAgent`** — run children concurrently, each writing to its own state key. An `asyncio.gather()`.\n",
-    "- **`LoopAgent`** — run children in a cycle until one of them calls `exit_loop` or the iteration limit is reached. A `while` loop with an escape hatch.\n",
+    "- **`SequentialAgent`** \u2014 run children in order, passing state between them. A shell pipeline.\n",
+    "- **`ParallelAgent`** \u2014 run children concurrently, each writing to its own state key. An `asyncio.gather()`.\n",
+    "- **`LoopAgent`** \u2014 run children in a cycle until one of them calls `exit_loop` or the iteration limit is reached. A `while` loop with an escape hatch.\n",
     "\n",
     "This is the single strongest pedagogical differentiator ADK has over LangGraph and CrewAI. LangGraph makes you draw your control flow as a node-and-edge graph; CrewAI hides it behind a role-playing DSL. ADK lets you name the control flow directly: *Sequential*, *Parallel*, *Loop*. Three Python classes, no graph diagrams needed.\n",
     "\n",
@@ -42,7 +45,7 @@
    "source": [
     "!pip install -q google-adk==1.28.0 litellm==1.83.4 python-dotenv==1.0.1 nest-asyncio==1.6.0 deprecated==1.2.18 2>/dev/null\n",
     "\n",
-    "print(\"✅ Packages installed.\")"
+    "print(\"\u2705 Packages installed.\")"
    ]
   },
   {
@@ -65,22 +68,22 @@
     "try:\n",
     "    from google.colab import userdata\n",
     "    OPENROUTER_API_KEY = userdata.get(\"OPENROUTER_API_KEY\")\n",
-    "    print(\"✅ API key loaded from Colab secrets.\")\n",
+    "    print(\"\u2705 API key loaded from Colab secrets.\")\n",
     "except Exception:\n",
     "    try:\n",
     "        from dotenv import load_dotenv; load_dotenv()\n",
     "        OPENROUTER_API_KEY = os.getenv(\"OPENROUTER_API_KEY\")\n",
     "        if OPENROUTER_API_KEY:\n",
-    "            print(\"✅ API key loaded from .env file.\")\n",
+    "            print(\"\u2705 API key loaded from .env file.\")\n",
     "    except ImportError:\n",
     "        pass\n",
     "if not OPENROUTER_API_KEY:\n",
     "    from getpass import getpass\n",
     "    OPENROUTER_API_KEY = getpass(\"Enter your OpenRouter API key: \")\n",
-    "assert OPENROUTER_API_KEY, \"❌ No API key provided.\"\n",
+    "assert OPENROUTER_API_KEY, \"\u274c No API key provided.\"\n",
     "os.environ[\"OPENROUTER_API_KEY\"] = OPENROUTER_API_KEY\n",
     "MODEL_STRING = \"openrouter/google/gemini-2.5-flash-lite\"\n",
-    "print(f\"✅ Model: {MODEL_STRING}\")"
+    "print(f\"\u2705 Model: {MODEL_STRING}\")"
    ]
   },
   {
@@ -115,7 +118,7 @@
     "from google.adk.tools import exit_loop\n",
     "from google.genai import types\n",
     "\n",
-    "print(\"✅ Imports successful.\")"
+    "print(\"\u2705 Imports successful.\")"
    ]
   },
   {
@@ -123,25 +126,25 @@
    "id": "2e11f343",
    "metadata": {},
    "source": [
-    "# The Three Workflow Types — A Picture\n",
+    "# The Three Workflow Types \u2014 A Picture\n",
     "\n",
     "```\n",
     "SequentialAgent           ParallelAgent             LoopAgent\n",
-    "─────────────────         ─────────────────         ─────────────────\n",
-    "                                                    ┌────────────────┐\n",
-    "    child 1                   child 1               │   child 1      │\n",
-    "       │                         │                  │      │         │\n",
-    "       ▼                         ▼                  │      ▼         │\n",
-    "    child 2           ──>    child 2      <──       │   child 2      │\n",
-    "       │                         │                  │      │         │\n",
-    "       ▼                         ▼                  │      ▼ (loop)  │\n",
-    "    child 3                   child 3               │   child 1 ...  │\n",
-    "                                                    └────────────────┘\n",
+    "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500         \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500         \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
+    "                                                    \u250c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510\n",
+    "    child 1                   child 1               \u2502   child 1      \u2502\n",
+    "       \u2502                         \u2502                  \u2502      \u2502         \u2502\n",
+    "       \u25bc                         \u25bc                  \u2502      \u25bc         \u2502\n",
+    "    child 2           \u2500\u2500>    child 2      <\u2500\u2500       \u2502   child 2      \u2502\n",
+    "       \u2502                         \u2502                  \u2502      \u2502         \u2502\n",
+    "       \u25bc                         \u25bc                  \u2502      \u25bc (loop)  \u2502\n",
+    "    child 3                   child 3               \u2502   child 1 ...  \u2502\n",
+    "                                                    \u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518\n",
     "    ordered                 concurrent              until exit_loop\n",
     "    pipeline                fan-out                 or max_iterations\n",
     "```\n",
     "\n",
-    "Same `Runner`, same event stream, same state dict — only the composition class changes. State flows through the same mechanism: `output_key=` on each child writes its result to the session state, and subsequent children read it via the `{key}` template syntax in their instruction."
+    "Same `Runner`, same event stream, same state dict \u2014 only the composition class changes. State flows through the same mechanism: `output_key=` on each child writes its result to the session state, and subsequent children read it via the `{key}` template syntax in their instruction."
    ]
   },
   {
@@ -149,7 +152,7 @@
    "id": "d9e837c3",
    "metadata": {},
    "source": [
-    "# SequentialAgent — A Two-Step Pipeline\n",
+    "# SequentialAgent \u2014 A Two-Step Pipeline\n",
     "\n",
     "Runs children one after another. The first child writes to state; the next child reads it; and so on. Think of it as a shell pipeline where state keys are the pipe.\n",
     "\n",
@@ -208,7 +211,7 @@
     "    return dict(s.state)\n",
     "\n",
     "state = await run(pipeline, \"The cat sat on the mat. It was hungry. It meowed loudly until fed.\", \"seq\")\n",
-    "print(\"\\n── Final state ──\")\n",
+    "print(\"\\n\u2500\u2500 Final state \u2500\u2500\")\n",
     "for k, v in state.items():\n",
     "    print(f\"  {k!r}: {v!r}\")"
    ]
@@ -218,7 +221,7 @@
    "id": "6bb0decc",
    "metadata": {},
    "source": [
-    "Two agents ran in order. The summarizer wrote to `state[\"summary\"]`. The translator's instruction contained `{summary}` — ADK substituted the value from state before the model saw the prompt, so the translator worked on the summary, not the original.\n",
+    "Two agents ran in order. The summarizer wrote to `state[\"summary\"]`. The translator's instruction contained `{summary}` \u2014 ADK substituted the value from state before the model saw the prompt, so the translator worked on the summary, not the original.\n",
     "\n",
     "The `{key}` template is the glue that makes workflow agents composable. Write to state with `output_key=`, read from state with `{key}` in a later agent's instruction. No orchestration code."
    ]
@@ -228,9 +231,9 @@
    "id": "5735a576",
    "metadata": {},
    "source": [
-    "# ParallelAgent — Fan-Out, Concurrent\n",
+    "# ParallelAgent \u2014 Fan-Out, Concurrent\n",
     "\n",
-    "Runs all children concurrently (via `asyncio`), each writing to its own state key. Total wall time ≈ slowest child, not sum of children.\n",
+    "Runs all children concurrently (via `asyncio`), each writing to its own state key. Total wall time \u2248 slowest child, not sum of children.\n",
     "\n",
     "Below: three researchers report one fact each about three different countries. All three run at once."
    ]
@@ -266,8 +269,8 @@
     "# Time the parallel run\n",
     "t0 = time.time()\n",
     "state = await run(trio, \"Give me three country facts.\", \"par\")\n",
-    "print(f\"\\n⏱  Total wall time: {time.time() - t0:.2f}s\")\n",
-    "print(\"\\n── Final state ──\")\n",
+    "print(f\"\\n\u23f1  Total wall time: {time.time() - t0:.2f}s\")\n",
+    "print(\"\\n\u2500\u2500 Final state \u2500\u2500\")\n",
     "for k, v in state.items():\n",
     "    if k.endswith(\"_fact\"):\n",
     "        print(f\"  {k!r}: {v}\")"
@@ -278,7 +281,7 @@
    "id": "8069336f",
    "metadata": {},
    "source": [
-    "Notice the authors in the event stream — `de_researcher`, `sk_researcher`, `cz_researcher` interleave in whatever order they finish, not the order you declared them. That's concurrency.\n",
+    "Notice the authors in the event stream \u2014 `de_researcher`, `sk_researcher`, `cz_researcher` interleave in whatever order they finish, not the order you declared them. That's concurrency.\n",
     "\n",
     "And the wall time is roughly one child's duration, not three. If each LLM call is ~1s, a sequential run would take ~3s; a parallel run takes ~1.1s. The savings scale with the width of the fan-out.\n",
     "\n",
@@ -290,11 +293,11 @@
    "id": "b5343a45",
    "metadata": {},
    "source": [
-    "# LoopAgent — The Generator+Critic Wow Demo\n",
+    "# LoopAgent \u2014 The Generator+Critic Wow Demo\n",
     "\n",
-    "The canonical ADK composition. Two agents cycle: a **generator** produces a draft, a **critic** evaluates it. If the critic is not satisfied, it writes a critique back to state and the loop continues — the generator reads the critique on the next iteration and revises. When the critic is satisfied, it calls the `exit_loop` tool and the loop terminates.\n",
+    "The canonical ADK composition. Two agents cycle: a **generator** produces a draft, a **critic** evaluates it. If the critic is not satisfied, it writes a critique back to state and the loop continues \u2014 the generator reads the critique on the next iteration and revises. When the critic is satisfied, it calls the `exit_loop` tool and the loop terminates.\n",
     "\n",
-    "This pattern goes by many names — *critic-driven refinement*, *self-correction*, *reflexion*. In plain agent frameworks you'd write it yourself with a `while` loop. In ADK, it's a `LoopAgent` with two children and a `max_iterations=` guard."
+    "This pattern goes by many names \u2014 *critic-driven refinement*, *self-correction*, *reflexion*. In plain agent frameworks you'd write it yourself with a `while` loop. In ADK, it's a `LoopAgent` with two children and a `max_iterations=` guard."
    ]
   },
   {
@@ -349,7 +352,7 @@
     ")\n",
     "\n",
     "state = await run(refiner, \"Write a tagline.\", \"loop\")\n",
-    "print(\"\\n── Final draft ──\")\n",
+    "print(\"\\n\u2500\u2500 Final draft \u2500\u2500\")\n",
     "print(state.get(\"draft\", \"(none)\"))"
    ]
   },
@@ -368,7 +371,7 @@
     "\n",
     "Two things to notice in the code:\n",
     "\n",
-    "- `{draft?}` and `{critique?}` use the `?` suffix — \"optional state key, do not error if missing.\" The generator runs before the critic on iteration 1 when neither key exists yet.\n",
+    "- `{draft?}` and `{critique?}` use the `?` suffix \u2014 \"optional state key, do not error if missing.\" The generator runs before the critic on iteration 1 when neither key exists yet.\n",
     "- `max_iterations=5` is the safety net. If the critic is impossible to satisfy, the loop stops after 5 cycles. Always set this; never rely on the critic to always exit.\n",
     "\n",
     "This is the pattern you'd otherwise implement as:\n",
@@ -424,15 +427,15 @@
     "pipeline2 = SequentialAgent(\n",
     "    name=\"research_pipeline\",\n",
     "    sub_agents=[\n",
-    "        trio,           # ← the ParallelAgent from earlier\n",
+    "        trio,           # \u2190 the ParallelAgent from earlier\n",
     "        synthesizer,\n",
     "    ],\n",
     ")\n",
     "\n",
     "t0 = time.time()\n",
     "state = await run(pipeline2, \"Research and synthesize.\", \"compose\")\n",
-    "print(f\"\\n⏱  Total wall time: {time.time() - t0:.2f}s\")\n",
-    "print(\"\\n── Final report ──\")\n",
+    "print(f\"\\n\u23f1  Total wall time: {time.time() - t0:.2f}s\")\n",
+    "print(\"\\n\u2500\u2500 Final report \u2500\u2500\")\n",
     "print(state.get(\"report\", \"\"))"
    ]
   },
@@ -441,7 +444,7 @@
    "id": "a107adda",
    "metadata": {},
    "source": [
-    "Five LLM calls — three researchers in parallel, then a synthesizer — and the wall time is close to two calls' worth, not five. Production agents are built out of compositions like this."
+    "Five LLM calls \u2014 three researchers in parallel, then a synthesizer \u2014 and the wall time is close to two calls' worth, not five. Production agents are built out of compositions like this."
    ]
   },
   {
@@ -466,14 +469,14 @@
     "\n",
     "| Use a **workflow agent** when... | Use **LLM-driven** when... |\n",
     "|---|---|\n",
-    "| The control flow is fixed — always summarize, then translate | The control flow depends on user input |\n",
+    "| The control flow is fixed \u2014 always summarize, then translate | The control flow depends on user input |\n",
     "| You need determinism (tests, evals) | You need flexibility |\n",
-    "| Latency matters — Parallel fans out without an LLM turn of deliberation | The model's judgment is the point |\n",
+    "| Latency matters \u2014 Parallel fans out without an LLM turn of deliberation | The model's judgment is the point |\n",
     "| You want the workflow to be auditable from a diagram | Conversations can go anywhere |\n",
     "\n",
     "Rule of thumb: **if you can name the workflow, use a workflow agent. If you can't, let the LLM decide.**\n",
     "\n",
-    "Sequential, Parallel, Loop cover the named-workflow cases cleanly. Anything more complex, you start composing them. And if the composition gets unwieldy, that's a sign the workflow shouldn't be named after all — let the LLM drive."
+    "Sequential, Parallel, Loop cover the named-workflow cases cleanly. Anything more complex, you start composing them. And if the composition gets unwieldy, that's a sign the workflow shouldn't be named after all \u2014 let the LLM drive."
    ]
   },
   {
@@ -483,10 +486,10 @@
    "source": [
     "# Your Turn\n",
     "\n",
-    "1. **A three-step pipeline.** Add a third step after `summarizer → translator` that takes the translation and writes a haiku about it (`output_key=\"haiku\"`). Run the pipeline. Do all three results appear in state?\n",
-    "2. **Parallel then sequential.** Build a sequential pipeline whose first step is the `trio` parallel agent and whose second step writes a headline summarizing all three facts. (Hint: you already have `synthesizer` — swap its instruction for a headline.)\n",
+    "1. **A three-step pipeline.** Add a third step after `summarizer \u2192 translator` that takes the translation and writes a haiku about it (`output_key=\"haiku\"`). Run the pipeline. Do all three results appear in state?\n",
+    "2. **Parallel then sequential.** Build a sequential pipeline whose first step is the `trio` parallel agent and whose second step writes a headline summarizing all three facts. (Hint: you already have `synthesizer` \u2014 swap its instruction for a headline.)\n",
     "3. **A stricter critic.** In the generator+critic loop, modify the critic to also reject taglines over 20 words. Run the loop. Does it ever converge, or does it max out at `max_iterations`?\n",
-    "4. **A loop with one child.** LoopAgent works with a single child too. Build a `LoopAgent(name=\"persistent_greeter\", sub_agents=[greeter], max_iterations=3)` and see what happens — does the same greeter run three times?"
+    "4. **A loop with one child.** LoopAgent works with a single child too. Build a `LoopAgent(name=\"persistent_greeter\", sub_agents=[greeter], max_iterations=3)` and see what happens \u2014 does the same greeter run three times?"
    ]
   },
   {
@@ -503,9 +506,9 @@
     "- **Compose workflows:** Parallel inside Sequential is the classic \"fan out research, then synthesize\" pattern. Production agents are built out of compositions.\n",
     "- **Rule:** if you can name the workflow, use a workflow agent. If you can't, let the LLM decide.\n",
     "\n",
-    "# Next up — M06: Multi-agent hierarchies\n",
+    "# Next up \u2014 M06: Multi-agent hierarchies\n",
     "\n",
-    "Workflow agents give you control flow by declaration. M06 gives you the other half — **LLM-driven routing** between agents. `sub_agents` for transfer, `AgentTool` for consultant-style calls (we saw a glimpse of `AgentTool` in M02). Same agent, two coordination patterns, different trade-offs. See you there."
+    "Workflow agents give you control flow by declaration. M06 gives you the other half \u2014 **LLM-driven routing** between agents. `sub_agents` for transfer, `AgentTool` for consultant-style calls (we saw a glimpse of `AgentTool` in M02). Same agent, two coordination patterns, different trade-offs. See you there."
    ]
   }
  ],

--- a/notebooks/11_gemini_grounding_caching.ipynb
+++ b/notebooks/11_gemini_grounding_caching.ipynb
@@ -5,21 +5,24 @@
    "id": "c9203734",
    "metadata": {},
    "source": [
-    "# Module 11 — Gemini Unlocks: Search Grounding and Context Caching\n",
+    "# Module 11 \u2014 Gemini Unlocks: Search Grounding and Context Caching\n",
+    "\n",
+    "> **\u26a1 Quick path** \u2014 this is one of four modules on the 1-hour course preview.\n",
+    "> See the [README's Quick path section](../README.md#-quick-path---1-hour) for the sequence.\n",
     "\n",
     "**Part 2 of the course begins here.**\n",
     "\n",
-    "Ten modules of vendor-neutral ADK — everything running on whichever model you chose. Part 2 is honest about what you give up by staying vendor-neutral. Three Gemini-specific capabilities earn their own modules because nothing in LiteLLM-land can replicate them.\n",
+    "Ten modules of vendor-neutral ADK \u2014 everything running on whichever model you chose. Part 2 is honest about what you give up by staying vendor-neutral. Three Gemini-specific capabilities earn their own modules because nothing in LiteLLM-land can replicate them.\n",
     "\n",
     "This module covers two of them:\n",
     "\n",
-    "- **Google Search grounding** — Gemini can call Google Search as a built-in tool, return answers with real citations to real URLs, and surface grounding metadata showing exactly which source backs each claim. No external search-API wrangling, no hallucinated URLs. Billed separately: ~$35 per 1,000 grounded requests.\n",
-    "- **Long context + context caching** — Gemini 2.5+ handles 1M-token input windows. For repeat queries over the same large document, you can **cache** the document once and get a 75-90% discount on all subsequent input tokens. This is the economics trick that makes long-context agents affordable in production.\n",
+    "- **Google Search grounding** \u2014 Gemini can call Google Search as a built-in tool, return answers with real citations to real URLs, and surface grounding metadata showing exactly which source backs each claim. No external search-API wrangling, no hallucinated URLs. Billed separately: ~$35 per 1,000 grounded requests.\n",
+    "- **Long context + context caching** \u2014 Gemini 2.5+ handles 1M-token input windows. For repeat queries over the same large document, you can **cache** the document once and get a 75-90% discount on all subsequent input tokens. This is the economics trick that makes long-context agents affordable in production.\n",
     "\n",
-    "The switch from Part 1 is mechanical: we stop using the `LiteLlm(model=...)` wrapper and pass Gemini model names directly. `model=\"gemini-2.5-flash\"` — done. Everything else about the agent (tools, sessions, workflow agents, callbacks) stays identical.\n",
+    "The switch from Part 1 is mechanical: we stop using the `LiteLlm(model=...)` wrapper and pass Gemini model names directly. `model=\"gemini-2.5-flash\"` \u2014 done. Everything else about the agent (tools, sessions, workflow agents, callbacks) stays identical.\n",
     "\n",
     "**What you'll leave with:**\n",
-    "- A grounded Gemini agent that cites its sources — which you then verify in the `grounding_metadata`.\n",
+    "- A grounded Gemini agent that cites its sources \u2014 which you then verify in the `grounding_metadata`.\n",
     "- A long-context Gemini query over a manual, with token-count reporting.\n",
     "- A practical understanding of when caching pays off, and why the free tier blocks the demo.\n",
     "\n",
@@ -42,7 +45,7 @@
    "outputs": [],
    "source": [
     "!pip install -q google-adk==1.28.0 google-genai litellm==1.83.4 python-dotenv==1.0.1 nest-asyncio==1.6.0 deprecated==1.2.18 2>/dev/null\n",
-    "print(\"✅ Packages installed.\")"
+    "print(\"\u2705 Packages installed.\")"
    ]
   },
   {
@@ -50,9 +53,9 @@
    "id": "a3c2102d",
    "metadata": {},
    "source": [
-    "## API Key — Switching to Google AI Studio\n",
+    "## API Key \u2014 Switching to Google AI Studio\n",
     "\n",
-    "Part 1 used `OPENROUTER_API_KEY`. Part 2 uses `GOOGLE_API_KEY` from [aistudio.google.com/apikey](https://aistudio.google.com/apikey). Free tier is enough for M11–M13; paid tier unlocks context caching and higher rate limits.\n",
+    "Part 1 used `OPENROUTER_API_KEY`. Part 2 uses `GOOGLE_API_KEY` from [aistudio.google.com/apikey](https://aistudio.google.com/apikey). Free tier is enough for M11\u2013M13; paid tier unlocks context caching and higher rate limits.\n",
     "\n",
     "Set `GOOGLE_GENAI_USE_VERTEXAI=FALSE` (default) to use Google AI Studio; `TRUE` to use Vertex AI (requires GCP billing)."
    ]
@@ -73,21 +76,21 @@
     "try:\n",
     "    from google.colab import userdata\n",
     "    GOOGLE_API_KEY = userdata.get(\"GOOGLE_API_KEY\")\n",
-    "    print(\"✅ API key loaded from Colab secrets.\")\n",
+    "    print(\"\u2705 API key loaded from Colab secrets.\")\n",
     "except Exception:\n",
     "    try:\n",
     "        from dotenv import load_dotenv; load_dotenv()\n",
     "        GOOGLE_API_KEY = os.getenv(\"GOOGLE_API_KEY\")\n",
-    "        if GOOGLE_API_KEY: print(\"✅ API key loaded from .env file.\")\n",
+    "        if GOOGLE_API_KEY: print(\"\u2705 API key loaded from .env file.\")\n",
     "    except ImportError: pass\n",
     "if not GOOGLE_API_KEY:\n",
     "    from getpass import getpass\n",
-    "    print(\"💡 Get one at aistudio.google.com/apikey (free tier works).\")\n",
+    "    print(\"\ud83d\udca1 Get one at aistudio.google.com/apikey (free tier works).\")\n",
     "    GOOGLE_API_KEY = getpass(\"Enter your Google AI Studio API key: \")\n",
-    "assert GOOGLE_API_KEY, \"❌ No API key.\"\n",
+    "assert GOOGLE_API_KEY, \"\u274c No API key.\"\n",
     "os.environ[\"GOOGLE_API_KEY\"] = GOOGLE_API_KEY\n",
     "os.environ[\"GOOGLE_GENAI_USE_VERTEXAI\"] = \"FALSE\"\n",
-    "print(\"✅ Environment ready for Gemini.\")"
+    "print(\"\u2705 Environment ready for Gemini.\")"
    ]
   },
   {
@@ -109,17 +112,17 @@
     "import nest_asyncio; nest_asyncio.apply()\n",
     "logging.getLogger(\"LiteLLM\").setLevel(logging.WARNING)\n",
     "\n",
-    "# ADK — same as Part 1\n",
+    "# ADK \u2014 same as Part 1\n",
     "from google.adk.agents import LlmAgent\n",
     "from google.adk.runners import Runner\n",
     "from google.adk.sessions import InMemorySessionService\n",
-    "from google.adk.tools import google_search   # ← new: the Gemini-only built-in\n",
+    "from google.adk.tools import google_search   # \u2190 new: the Gemini-only built-in\n",
     "from google.genai import types\n",
     "\n",
     "# Direct google-genai SDK for caching and raw long-context calls\n",
     "from google import genai\n",
     "\n",
-    "print(\"✅ Imports successful.\")"
+    "print(\"\u2705 Imports successful.\")"
    ]
   },
   {
@@ -127,9 +130,9 @@
    "id": "491d06f6",
    "metadata": {},
    "source": [
-    "# Part 1 — Google Search Grounding\n",
+    "# Part 1 \u2014 Google Search Grounding\n",
     "\n",
-    "In Part 1, every agent we built had a knowledge cutoff. Ask it about today's news and you got a refusal or a hallucinated answer. The workaround was to write your own search tool — call an external API, pass results back.\n",
+    "In Part 1, every agent we built had a knowledge cutoff. Ask it about today's news and you got a refusal or a hallucinated answer. The workaround was to write your own search tool \u2014 call an external API, pass results back.\n",
     "\n",
     "Gemini ships this differently. `google_search` is a **built-in tool**. You import it from `google.adk.tools`, add it to your agent's `tools=` list, and every query triggers a real Google Search, returns cited results, and ADK populates a `grounding_metadata` field on the event with the source URLs.\n",
     "\n",
@@ -155,7 +158,7 @@
     "    tools=[google_search],\n",
     ")\n",
     "\n",
-    "print(\"✅ grounded_agent ready.\")"
+    "print(\"\u2705 grounded_agent ready.\")"
    ]
   },
   {
@@ -185,7 +188,7 @@
     "        if ev.grounding_metadata:\n",
     "            chunks = getattr(ev.grounding_metadata, \"grounding_chunks\", None) or []\n",
     "            if chunks:\n",
-    "                print(f\"\\n── Grounding metadata: {len(chunks)} source(s) ──\")\n",
+    "                print(f\"\\n\u2500\u2500 Grounding metadata: {len(chunks)} source(s) \u2500\u2500\")\n",
     "                for i, chunk in enumerate(chunks[:3], 1):\n",
     "                    web = getattr(chunk, \"web\", None)\n",
     "                    if web:\n",
@@ -202,8 +205,8 @@
    "source": [
     "Two things to notice.\n",
     "\n",
-    "1. **The agent did not call `google_search` as a regular tool.** There's no `[tool_call]` line in the event stream. `google_search` is handled internally by Gemini's grounding infrastructure — it's a *built-in* tool, not a Python function ADK dispatches. You see the *result* of grounding in the final response, not the call sequence.\n",
-    "2. **The `grounding_metadata` block** lists the actual web sources Gemini used. These are real URLs, not hallucinations. In a production agent, you'd surface these to your users — \"Source: bratislava.sk (official)\" — as citations under each answer.\n",
+    "1. **The agent did not call `google_search` as a regular tool.** There's no `[tool_call]` line in the event stream. `google_search` is handled internally by Gemini's grounding infrastructure \u2014 it's a *built-in* tool, not a Python function ADK dispatches. You see the *result* of grounding in the final response, not the call sequence.\n",
+    "2. **The `grounding_metadata` block** lists the actual web sources Gemini used. These are real URLs, not hallucinations. In a production agent, you'd surface these to your users \u2014 \"Source: bratislava.sk (official)\" \u2014 as citations under each answer.\n",
     "\n",
     "This is the single biggest pedagogical gap between Part 1 and Part 2. In Part 1 you'd write `async def web_search(query): ...`, call a paid search API, parse JSON, feed it back. Here, you add one import to the tools list. Gemini does the rest."
    ]
@@ -213,7 +216,7 @@
    "id": "ed3f5b36",
    "metadata": {},
    "source": [
-    "# The Mixing Gotcha — Built-in Tools Don't Combine\n",
+    "# The Mixing Gotcha \u2014 Built-in Tools Don't Combine\n",
     "\n",
     "One sharp edge worth naming before you build on this. **Gemini's built-in tools (google_search, code_execution, Vertex AI Search) cannot coexist with other tools in the same agent.** If you mix them, the Gemini API rejects the request.\n",
     "\n",
@@ -221,13 +224,13 @@
     "# This fails: google_search is a built-in; get_weather is a regular function tool\n",
     "BAD = LlmAgent(\n",
     "    model=\"gemini-2.5-flash\",\n",
-    "    tools=[google_search, get_weather],   # ← mixing built-in + regular\n",
+    "    tools=[google_search, get_weather],   # \u2190 mixing built-in + regular\n",
     ")\n",
     "```\n",
     "\n",
-    "The usual workaround is to wrap each built-in tool as a sub-agent via `AgentTool` (from M02/M06). The coordinator calls `AgentTool(agent=grounded_agent)` for search questions and `AgentTool(agent=weather_agent)` for weather — each sub-agent has a focused tool set, and the coordinator composes their outputs.\n",
+    "The usual workaround is to wrap each built-in tool as a sub-agent via `AgentTool` (from M02/M06). The coordinator calls `AgentTool(agent=grounded_agent)` for search questions and `AgentTool(agent=weather_agent)` for weather \u2014 each sub-agent has a focused tool set, and the coordinator composes their outputs.\n",
     "\n",
-    "An ADK-1.16+ alternative for Search specifically: `google_search` accepts `bypass_multi_tools_limit=True` on Search in ADK ≥ 1.16, which lets Search coexist with other tools. Check your ADK version before you depend on this."
+    "An ADK-1.16+ alternative for Search specifically: `google_search` accepts `bypass_multi_tools_limit=True` on Search in ADK \u2265 1.16, which lets Search coexist with other tools. Check your ADK version before you depend on this."
    ]
   },
   {
@@ -235,19 +238,19 @@
    "id": "bb77d762",
    "metadata": {},
    "source": [
-    "# Part 2 — Long Context + Context Caching\n",
+    "# Part 2 \u2014 Long Context + Context Caching\n",
     "\n",
     "Gemini 2.5+ models handle up to **1M input tokens** (2M on the Pro variants). You can paste a 500-page technical manual, an entire codebase, or several months of email history into a single request.\n",
     "\n",
-    "The obvious problem: 500,000 input tokens at the standard rate is expensive. Ask ten questions against the same manual → 5M input tokens → ~$10 on Flash, ~$50 on Pro.\n",
+    "The obvious problem: 500,000 input tokens at the standard rate is expensive. Ask ten questions against the same manual \u2192 5M input tokens \u2192 ~$10 on Flash, ~$50 on Pro.\n",
     "\n",
-    "**Context caching** fixes this. You cache the large content once; subsequent queries against the cache are billed at a 75–90% discount on the cached portion. Ten queries → one full-price insertion + nine discounted.\n",
+    "**Context caching** fixes this. You cache the large content once; subsequent queries against the cache are billed at a 75\u201390% discount on the cached portion. Ten queries \u2192 one full-price insertion + nine discounted.\n",
     "\n",
     "Two caching flavors:\n",
-    "- **Implicit caching** — Gemini 2.5+ auto-caches repeated prefixes. Zero code changes; 75% discount.\n",
-    "- **Explicit caching** — `client.caches.create(...)` with a fixed TTL. You control what's cached; 90% discount.\n",
+    "- **Implicit caching** \u2014 Gemini 2.5+ auto-caches repeated prefixes. Zero code changes; 75% discount.\n",
+    "- **Explicit caching** \u2014 `client.caches.create(...)` with a fixed TTL. You control what's cached; 90% discount.\n",
     "\n",
-    "Below: a long-context query (no caching) to demonstrate the mechanics and token counts. Then the explicit-caching pattern shown in code — without running it, because **explicit caching requires a paid tier**. The free tier has zero storage quota."
+    "Below: a long-context query (no caching) to demonstrate the mechanics and token counts. Then the explicit-caching pattern shown in code \u2014 without running it, because **explicit caching requires a paid tier**. The free tier has zero storage quota."
    ]
   },
   {
@@ -269,39 +272,39 @@
     "\n",
     "# A small manual. In production this could be 100KB+.\n",
     "MANUAL = '''\\\n",
-    "RaspiKitchen v2.3 — Technical Manual.\n",
+    "RaspiKitchen v2.3 \u2014 Technical Manual.\n",
     "\n",
-    "CHAPTER 1 — Overview.\n",
+    "CHAPTER 1 \u2014 Overview.\n",
     "The device is a voice-controlled kitchen assistant running on a Raspberry\n",
     "Pi 5 with 8GB RAM and an ESP32-S3 microphone array.\n",
     "\n",
-    "CHAPTER 2 — Installation.\n",
+    "CHAPTER 2 \u2014 Installation.\n",
     "Power: USB-C PD, 45W minimum. Network: WiFi 6 or Ethernet. Mount the\n",
     "microphone array at eye level, 1-2m from the workspace.\n",
     "\n",
-    "CHAPTER 3 — Voice wake word.\n",
+    "CHAPTER 3 \u2014 Voice wake word.\n",
     "Default wake word is \"Chef\". To change, edit /etc/raspikitchen/wake.conf\n",
     "and restart the raspikitchen.service.\n",
     "\n",
-    "CHAPTER 4 — Tool list.\n",
+    "CHAPTER 4 \u2014 Tool list.\n",
     "Supported tools: timer, recipe lookup, conversion, substitution, shopping\n",
     "list, thermometer polling (via BLE).\n",
     "\n",
-    "CHAPTER 5 — Privacy.\n",
+    "CHAPTER 5 \u2014 Privacy.\n",
     "Audio is processed locally by default. Cloud fallback can be enabled via\n",
     "/etc/raspikitchen/cloud.conf but is OFF by default.\n",
     "\n",
-    "CHAPTER 6 — Troubleshooting.\n",
+    "CHAPTER 6 \u2014 Troubleshooting.\n",
     "If the device does not respond to wake word, check microphone array\n",
     "connection on GPIO pins 22-27. If voice recognition is slow, verify the\n",
     "local Whisper model is loaded (ps aux | grep whisper).\n",
     "\n",
-    "CHAPTER 7 — Updating.\n",
+    "CHAPTER 7 \u2014 Updating.\n",
     "Run: sudo raspikitchen-update. Will pull the latest image and restart on\n",
     "completion. Takes 2-5 minutes.\n",
     "'''\n",
     "\n",
-    "# A single direct call — no ADK, just google-genai — so we see raw token counts.\n",
+    "# A single direct call \u2014 no ADK, just google-genai \u2014 so we see raw token counts.\n",
     "resp = client.models.generate_content(\n",
     "    model=\"gemini-2.5-flash\",\n",
     "    contents=f\"Based on this manual, what is the default wake word and how do I change it?\\n\\nMANUAL:\\n{MANUAL}\",\n",
@@ -320,7 +323,7 @@
    "source": [
     "Two things worth noting.\n",
     "\n",
-    "1. **The `usage_metadata` reports `prompt_token_count`** — what you paid for on the input side. For a real 100KB manual, that could be 25,000+ tokens per question. Asking ten questions = 250,000 input tokens.\n",
+    "1. **The `usage_metadata` reports `prompt_token_count`** \u2014 what you paid for on the input side. For a real 100KB manual, that could be 25,000+ tokens per question. Asking ten questions = 250,000 input tokens.\n",
     "2. **No caching yet.** If you ran the same query twice, you'd be billed twice for the manual. Caching is how you fix that."
    ]
   },
@@ -331,7 +334,7 @@
    "source": [
     "## Explicit Context Caching\n",
     "\n",
-    "The API. This cell **will likely fail on the free tier** — explicit caching has a zero-quota limit. Treat it as a reference for the paid tier."
+    "The API. This cell **will likely fail on the free tier** \u2014 explicit caching has a zero-quota limit. Treat it as a reference for the paid tier."
    ]
   },
   {
@@ -341,7 +344,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Make the cache payload larger — caches have a ~32K-token minimum.\n",
+    "# Make the cache payload larger \u2014 caches have a ~32K-token minimum.\n",
     "big_manual = MANUAL * 50   # repeat the manual 50 times to hit the cache threshold\n",
     "approx_tokens = len(big_manual.split()) * 1.3\n",
     "print(f\"Cache payload: ~{int(approx_tokens)} tokens (minimum is ~32,768)\")\n",
@@ -356,7 +359,7 @@
     "            ttl=\"300s\",   # 5 minutes; charged by the second\n",
     "        ),\n",
     "    )\n",
-    "    print(f\"✅ Cache created: {cache.name}\")\n",
+    "    print(f\"\u2705 Cache created: {cache.name}\")\n",
     "    print(f\"   cached_content_token_count: {cache.usage_metadata.total_token_count}\")\n",
     "\n",
     "    # Now query against the cache. The 32K+ cached tokens are billed at ~10% of normal rate.\n",
@@ -366,16 +369,16 @@
     "        config=types.GenerateContentConfig(cached_content=cache.name),\n",
     "    )\n",
     "    print(f\"\\nResponse: {resp.text[:200]}\")\n",
-    "    print(f\"Tokens — cached: {resp.usage_metadata.cached_content_token_count}, \"\n",
+    "    print(f\"Tokens \u2014 cached: {resp.usage_metadata.cached_content_token_count}, \"\n",
     "          f\"prompt: {resp.usage_metadata.prompt_token_count}, \"\n",
     "          f\"output: {resp.usage_metadata.candidates_token_count}\")\n",
     "\n",
-    "    # Clean up — caches have a TTL but you can delete explicitly\n",
+    "    # Clean up \u2014 caches have a TTL but you can delete explicitly\n",
     "    client.caches.delete(name=cache.name)\n",
-    "    print(f\"✅ Cache deleted.\")\n",
+    "    print(f\"\u2705 Cache deleted.\")\n",
     "\n",
     "except Exception as e:\n",
-    "    print(f\"❌ Caching unavailable on this tier.\")\n",
+    "    print(f\"\u274c Caching unavailable on this tier.\")\n",
     "    print(f\"   Error: {str(e)[:200]}\")\n",
     "    print()\n",
     "    print(\"   The free tier has TotalCachedContentStorageTokensPerModelFreeTier = 0.\")\n",
@@ -402,8 +405,8 @@
     "\n",
     "**Worked example.** A 100-page PDF is roughly 50K tokens. Your agent gets asked 20 questions per hour against this PDF.\n",
     "\n",
-    "- **No caching:** 20 × 50K input = 1M input tokens/hour → $0.075/hour.\n",
-    "- **Explicit caching:** 50K input once ($0.004) + 20 × 50K cached input ($0.008) + 1 hour × 50K storage ($0.0005) = **$0.013/hour**.\n",
+    "- **No caching:** 20 \u00d7 50K input = 1M input tokens/hour \u2192 $0.075/hour.\n",
+    "- **Explicit caching:** 50K input once ($0.004) + 20 \u00d7 50K cached input ($0.008) + 1 hour \u00d7 50K storage ($0.0005) = **$0.013/hour**.\n",
     "\n",
     "**~6x cost reduction** at 20 questions/hour. Scales better the more questions you ask.\n",
     "\n",
@@ -421,17 +424,17 @@
     "\n",
     "| Feature | Native (`model=\"gemini-...\"`) | LiteLLM (`LiteLlm(model=\"openrouter/google/...\")`) |\n",
     "|---|---|---|\n",
-    "| Basic chat / tool calls | ✅ | ✅ |\n",
-    "| `google_search` built-in tool | ✅ | ❌ |\n",
-    "| `BuiltInCodeExecutor` | ✅ | ❌ |\n",
-    "| Context caching | ✅ | ❌ |\n",
-    "| `ThinkingConfig` / budgets (M12) | ✅ | ⚠️ partial via `reasoning` param |\n",
-    "| Live API / voice (M13) | ✅ | ❌ |\n",
-    "| Switch to Claude/GPT/Qwen in one line | ❌ | ✅ |\n",
+    "| Basic chat / tool calls | \u2705 | \u2705 |\n",
+    "| `google_search` built-in tool | \u2705 | \u274c |\n",
+    "| `BuiltInCodeExecutor` | \u2705 | \u274c |\n",
+    "| Context caching | \u2705 | \u274c |\n",
+    "| `ThinkingConfig` / budgets (M12) | \u2705 | \u26a0\ufe0f partial via `reasoning` param |\n",
+    "| Live API / voice (M13) | \u2705 | \u274c |\n",
+    "| Switch to Claude/GPT/Qwen in one line | \u274c | \u2705 |\n",
     "\n",
     "**The practical rule:** use native Gemini when you need a feature that doesn't translate through LiteLLM. For everything else, LiteLLM-wrapped keeps your code portable.\n",
     "\n",
-    "In a production system, it's common to have *both* — a LiteLLM-wrapped agent for routine queries (portable, multi-model for failover) and a native-Gemini agent for tasks that need grounding, long context, or Live API (locked to Gemini, but with capabilities nothing else provides)."
+    "In a production system, it's common to have *both* \u2014 a LiteLLM-wrapped agent for routine queries (portable, multi-model for failover) and a native-Gemini agent for tasks that need grounding, long context, or Live API (locked to Gemini, but with capabilities nothing else provides)."
    ]
   },
   {
@@ -455,16 +458,16 @@
     "# Key Takeaways\n",
     "\n",
     "- **`google_search`** is a Gemini-only built-in tool. Add it to `tools=`; Gemini handles the search internally. Event's `grounding_metadata` exposes real citation URLs. ~$35 per 1,000 grounded requests.\n",
-    "- **Built-in tools don't mix** with regular tools in the same agent — use `AgentTool` sub-agents, or `bypass_multi_tools_limit=True` on Search in ADK ≥ 1.16.\n",
-    "- **Long context** — Gemini 2.5+ handles 1M input tokens (2M on Pro). Plenty of room for large documents.\n",
-    "- **Implicit caching** — automatic, 75% discount on repeated prefixes. Zero code changes.\n",
-    "- **Explicit caching** — `client.caches.create(...)` with TTL. 90% discount, but requires a paid tier (free tier quota is zero).\n",
+    "- **Built-in tools don't mix** with regular tools in the same agent \u2014 use `AgentTool` sub-agents, or `bypass_multi_tools_limit=True` on Search in ADK \u2265 1.16.\n",
+    "- **Long context** \u2014 Gemini 2.5+ handles 1M input tokens (2M on Pro). Plenty of room for large documents.\n",
+    "- **Implicit caching** \u2014 automatic, 75% discount on repeated prefixes. Zero code changes.\n",
+    "- **Explicit caching** \u2014 `client.caches.create(...)` with TTL. 90% discount, but requires a paid tier (free tier quota is zero).\n",
     "- **Native Gemini unlocks** what LiteLLM can't reach: grounding, code execution, caching, thinking budgets (M12), Live API (M13).\n",
     "- **Hybrid production pattern**: LiteLLM-wrapped agents for portable routine tasks; native Gemini agents for tasks that need grounding, long context, or Live API.\n",
     "\n",
-    "# Next up — M12: Thinking Budgets\n",
+    "# Next up \u2014 M12: Thinking Budgets\n",
     "\n",
-    "Gemini 2.5+ supports `ThinkingConfig` — a knob that trades latency for reasoning quality. Set `thinking_budget=0` for instant responses; set it to 8,000+ tokens for deep reasoning on hard math. We'll run the same problem at MIN vs HIGH and watch the answer quality change along with the latency cost."
+    "Gemini 2.5+ supports `ThinkingConfig` \u2014 a knob that trades latency for reasoning quality. Set `thinking_budget=0` for instant responses; set it to 8,000+ tokens for deep reasoning on hard math. We'll run the same problem at MIN vs HIGH and watch the answer quality change along with the latency cost."
    ]
   }
  ],

--- a/slides/build_slides.py
+++ b/slides/build_slides.py
@@ -12,8 +12,10 @@ pointing at ../shared/slides.js with an inlined <script>...</script>.
 Result: each deck becomes a single self-contained HTML file that opens
 cleanly via file:// in any browser, and still deploys cleanly over http://.
 
-Also regenerates the repo-root index.html's module-catalog section with
-the current set of slide decks, so "Ready" status stays in sync.
+The script is idempotent — on repeat runs it strips any previously-inlined
+blocks and re-inlines fresh content from the canonical sources. That means
+editing slides/shared/shared.css (say, to change a font) and re-running the
+script will propagate the change to every deck.
 
 Run from the repo root or the slides/ directory:
     python3 slides/build_slides.py
@@ -26,65 +28,105 @@ from pathlib import Path
 SLIDES_DIR = Path(__file__).resolve().parent
 SHARED_DIR = SLIDES_DIR / "shared"
 
+# Sentinel comments so we can find + replace our own blocks on repeat runs.
+STYLE_SENTINEL_START = "<!-- BEGIN-INLINED-STYLES -->"
+STYLE_SENTINEL_END = "<!-- END-INLINED-STYLES -->"
+SCRIPT_SENTINEL_START = "<!-- BEGIN-INLINED-SCRIPT -->"
+SCRIPT_SENTINEL_END = "<!-- END-INLINED-SCRIPT -->"
+BUILD_BANNER = "<!-- Built by slides/build_slides.py — shared CSS/JS inlined for file:// portability. Edit sources in slides/shared/ and re-run. -->"
+
 
 def read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
-def inline_deck(html_path: Path, shared_css: str, slides_css: str, slides_js: str) -> bool:
+def build_style_block(shared_css: str, slides_css: str) -> str:
+    return (
+        f"{STYLE_SENTINEL_START}\n"
+        "  <style>\n"
+        "  /* shared.css — generated; edit slides/shared/shared.css */\n"
+        f"{shared_css.strip()}\n"
+        "  /* slides.css — generated; edit slides/shared/slides.css */\n"
+        f"{slides_css.strip()}\n"
+        "  </style>\n"
+        f"  {STYLE_SENTINEL_END}"
+    )
+
+
+def build_script_block(slides_js: str) -> str:
+    return (
+        f"{SCRIPT_SENTINEL_START}\n"
+        "<script>\n"
+        f"{slides_js.strip()}\n"
+        "</script>\n"
+        f"{SCRIPT_SENTINEL_END}"
+    )
+
+
+def inline_deck(html_path: Path, style_block: str, script_block: str) -> bool:
     """Inline shared assets into one deck's index.html. Return True if changed."""
-    original = read(html_path)
+    original = html_path.read_text(encoding="utf-8")
+    modified = original
 
-    # Replace both <link> tags with a single combined <style> block.
-    # Match both shared.css and slides.css regardless of order.
-    link_pattern = re.compile(
+    # 1) Strip any previously-inlined style block.
+    modified = re.sub(
+        re.escape(STYLE_SENTINEL_START) + r".*?" + re.escape(STYLE_SENTINEL_END),
+        "",
+        modified,
+        flags=re.DOTALL,
+    )
+    # 2) Strip any previously-inlined script block.
+    modified = re.sub(
+        re.escape(SCRIPT_SENTINEL_START) + r".*?" + re.escape(SCRIPT_SENTINEL_END),
+        "",
+        modified,
+        flags=re.DOTALL,
+    )
+
+    # 3) Strip any <link rel=stylesheet> pointing at ../shared/*.css.
+    modified = re.sub(
         r'\s*<link\s+rel=["\']stylesheet["\']\s+href=["\']\.\./shared/(shared|slides)\.css["\']\s*/?>\s*',
-        re.IGNORECASE,
+        "",
+        modified,
+    )
+    # 4) Strip any <script src=../shared/slides.js>.
+    modified = re.sub(
+        r'\s*<script\s+src=["\']\.\./shared/slides\.js["\']\s*>\s*</script>\s*',
+        "",
+        modified,
     )
 
-    # Count how many link tags we'll replace. Must find shared.css and slides.css.
-    link_matches = list(link_pattern.finditer(original))
-    if len(link_matches) < 2:
-        # Already inlined or nothing to replace — skip.
-        # Still try to replace the <script src="...">.
-        pass
-
-    # Strip out both <link> tags; we'll insert the combined <style> where the first one was.
-    if link_matches:
-        first_match_start = link_matches[0].start()
-        # Remove all link tags first.
-        modified = link_pattern.sub("", original)
-        combined_css = (
-            "\n  <style>\n"
-            "  /* shared.css */\n"
-            + shared_css.strip() + "\n"
-            + "  /* slides.css */\n"
-            + slides_css.strip() + "\n"
-            + "  </style>\n"
+    # 5) Inject style block just before </head>.
+    if "</head>" in modified:
+        modified = modified.replace(
+            "</head>", f"\n  {style_block}\n</head>", 1
         )
-        # Insert combined CSS where the first <link> was.
-        # After stripping the links, we need to put the style block inside <head>.
-        # Find </head> and insert just before it.
-        if "</head>" in modified:
-            modified = modified.replace("</head>", combined_css + "</head>", 1)
-        else:
-            modified = combined_css + modified
     else:
-        modified = original
+        modified = style_block + modified
 
-    # Replace <script src="../shared/slides.js"></script> with inlined <script>...</script>.
-    script_pattern = re.compile(
-        r'<script\s+src=["\']\.\./shared/slides\.js["\']\s*>\s*</script>',
-        re.IGNORECASE,
+    # 6) Inject script block just before </body>.
+    if "</body>" in modified:
+        modified = modified.replace(
+            "</body>", f"\n  {script_block}\n</body>", 1
+        )
+    else:
+        modified = modified + "\n" + script_block
+
+    # 7) Ensure the build banner is present right after <!DOCTYPE html>.
+    modified = re.sub(
+        r"<!-- Built by slides/build_slides\.py.*?-->\n?",
+        "",
+        modified,
     )
-    combined_js = "<script>\n" + slides_js.strip() + "\n</script>"
-    modified = script_pattern.sub(combined_js, modified)
+    modified = re.sub(
+        r"(<!DOCTYPE html>\s*)",
+        r"\1" + BUILD_BANNER + "\n",
+        modified,
+        count=1,
+    )
 
-    # Add a banner comment near the top marking this as built output (helps debugging).
-    banner = "<!-- Built by slides/build_slides.py — shared CSS/JS inlined for file:// portability. Edit sources in slides/shared/ and re-run. -->\n"
-    if "Built by slides/build_slides.py" not in modified:
-        # Insert after <!DOCTYPE html>
-        modified = re.sub(r"(<!DOCTYPE html>\s*)", r"\1" + banner, modified, count=1)
+    # 8) Collapse excessive blank lines the re-write can introduce.
+    modified = re.sub(r"\n{3,}", "\n\n", modified)
 
     if modified != original:
         html_path.write_text(modified, encoding="utf-8")
@@ -101,6 +143,9 @@ def main() -> int:
     slides_css = read(SHARED_DIR / "slides.css")
     slides_js = read(SHARED_DIR / "slides.js")
 
+    style_block = build_style_block(shared_css, slides_css)
+    script_block = build_script_block(slides_js)
+
     module_dirs = sorted(p for p in SLIDES_DIR.iterdir() if p.is_dir() and p.name.startswith("module-"))
     if not module_dirs:
         print("ERROR: no slides/module-*/ folders found", file=sys.stderr)
@@ -112,8 +157,8 @@ def main() -> int:
         if not html_path.exists():
             print(f"  ! {mod.name}: no index.html, skipping")
             continue
-        if inline_deck(html_path, shared_css, slides_css, slides_js):
-            print(f"  ✓ {mod.name}: inlined shared assets")
+        if inline_deck(html_path, style_block, script_block):
+            print(f"  ✓ {mod.name}: rebuilt")
             changed += 1
         else:
             print(f"  - {mod.name}: already up to date")

--- a/slides/module-01-mental-model/index.html
+++ b/slides/module-01-mental-model/index.html
@@ -796,11 +796,821 @@ body {
   }
 }
   </style>
+
+  <!-- BEGIN-INLINED-STYLES -->
+  <style>
+  /* shared.css — generated; edit slides/shared/shared.css */
+/* ADK Course — Shared Design Tokens
+   Adapted from barcik-training-exin-ai-foundation/css/shared.css.
+   Family-consistent navy with amber accent (distinct from EXIN gold). */
+
+@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;500;600;700;800&display=swap');
+
+:root {
+  /* Brand colors */
+  --navy: #1E3A5F;
+  --navy-light: #2A5280;
+  --navy-dark: #122542;
+  --amber: #F59E0B;
+  --amber-light: #FBBF24;
+  --amber-dark: #B45309;
+  --white: #FFFFFF;
+  --gray-50: #F8F9FA;
+  --gray-100: #F1F3F5;
+  --gray-200: #E9ECEF;
+  --gray-300: #DEE2E6;
+  --gray-400: #CED4DA;
+  --gray-500: #ADB5BD;
+  --gray-600: #868E96;
+  --gray-700: #495057;
+  --gray-800: #343A40;
+  --gray-900: #212529;
+
+  /* Semantic */
+  --bg-primary: var(--white);
+  --bg-secondary: var(--gray-50);
+  --bg-card: var(--white);
+  --text-primary: var(--gray-900);
+  --text-secondary: var(--gray-700);
+  --text-muted: var(--gray-600);
+  --border-color: var(--gray-200);
+  --accent: var(--navy);
+  --accent-light: var(--navy-light);
+  --highlight: var(--amber);
+  --highlight-bg: #FEF3C7;
+  --success: #2E7D32;
+  --success-bg: #E8F5E9;
+  --error: #C62828;
+  --error-bg: #FFEBEE;
+  --info: #1565C0;
+  --info-bg: #E3F2FD;
+
+  /* Typography */
+  --font-sans: 'Nunito', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+  --text-3xl: 1.875rem;
+  --text-4xl: 2.25rem;
+
+  /* Spacing */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-10: 2.5rem;
+  --space-12: 3rem;
+  --space-16: 4rem;
+
+  /* Radius */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.07);
+  --shadow-lg: 0 10px 15px rgba(0,0,0,0.1);
+
+  /* Transitions */
+  --transition-fast: 150ms ease;
+  --transition-normal: 250ms ease;
+  --transition-slow: 350ms ease;
+}
+
+[data-theme="dark"] {
+  --bg-primary: #0D1117;
+  --bg-secondary: #161B22;
+  --bg-card: #1C2128;
+  --text-primary: #E6EDF3;
+  --text-secondary: #B1BAC4;
+  --text-muted: #8B949E;
+  --border-color: #30363D;
+  --accent: #58A6FF;
+  --accent-light: #79C0FF;
+  --highlight: var(--amber);
+  --highlight-bg: #2D2200;
+  --success: #56D364;
+  --success-bg: #0D2818;
+  --error: #F85149;
+  --error-bg: #2D1214;
+  --info: #58A6FF;
+  --info-bg: #0D1B2E;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.3);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.4);
+  --shadow-lg: 0 10px 15px rgba(0,0,0,0.5);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg-primary: #0D1117;
+    --bg-secondary: #161B22;
+    --bg-card: #1C2128;
+    --text-primary: #E6EDF3;
+    --text-secondary: #B1BAC4;
+    --text-muted: #8B949E;
+    --border-color: #30363D;
+    --accent: #58A6FF;
+    --accent-light: #79C0FF;
+    --highlight: var(--amber);
+    --highlight-bg: #2D2200;
+    --success: #56D364;
+    --success-bg: #0D2818;
+    --error: #F85149;
+    --error-bg: #2D1214;
+    --info: #58A6FF;
+    --info-bg: #0D1B2E;
+  }
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  line-height: 1.6;
+  color: var(--text-primary);
+  background-color: var(--bg-primary);
+  -webkit-font-smoothing: antialiased;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow var(--transition-normal);
+}
+
+.card:hover {
+  box-shadow: var(--shadow-md);
+}
+
+.callout {
+  padding: var(--space-4) var(--space-6);
+  border-radius: var(--radius-md);
+  margin: var(--space-4) 0;
+  border-left: 4px solid;
+}
+
+.callout-key { background: var(--highlight-bg); border-color: var(--amber); }
+.callout-gotcha { background: var(--error-bg); border-color: var(--error); }
+.callout-tip { background: var(--info-bg); border-color: var(--info); }
+.callout-success { background: var(--success-bg); border-color: var(--success); }
+
+.callout-title {
+  font-weight: 700;
+  font-size: var(--text-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: var(--space-2);
+}
+
+.text-center { text-align: center; }
+.text-muted { color: var(--text-muted); }
+.font-mono { font-family: var(--font-mono); }
+.mt-4 { margin-top: var(--space-4); }
+.mt-8 { margin-top: var(--space-8); }
+.mb-4 { margin-bottom: var(--space-4); }
+.mb-8 { margin-bottom: var(--space-8); }
+.mx-auto { margin-left: auto; margin-right: auto; }
+.max-w-4xl { max-width: 56rem; }
+.hidden { display: none !important; }
+  /* slides.css — generated; edit slides/shared/slides.css */
+/* ADK Course — Slide Presentation Theme
+   Adapted from barcik-training-exin-ai-foundation/slides/css/slides.css.
+   Adds data-type="code" slide variant for Python snippets. */
+
+:root {
+  --slide-font-size: 18px;
+  --strip-height: 48px;
+}
+
+body {
+  margin: 0;
+  overflow: hidden;
+  background: var(--bg-primary);
+}
+
+/* ── Progress Strip ──────────────────────────────── */
+.progress-strip {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  height: var(--strip-height);
+  background: var(--navy);
+  display: flex;
+  align-items: center;
+  z-index: 100;
+  padding: 0 var(--space-4);
+  gap: var(--space-4);
+  box-shadow: var(--shadow-md);
+  font-family: var(--font-sans);
+}
+
+.progress-home {
+  color: var(--amber);
+  text-decoration: none;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: var(--radius-md);
+  white-space: nowrap;
+  transition: all var(--transition-fast);
+}
+
+.progress-home:hover {
+  background: rgba(255,255,255,0.1);
+  border-color: var(--amber);
+}
+
+.progress-title {
+  color: rgba(255,255,255,0.85);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  flex: 1;
+  text-align: center;
+}
+
+.progress-title .quick-path-badge {
+  display: inline-block;
+  background: var(--amber);
+  color: var(--navy-dark);
+  font-size: 0.68rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.15rem 0.55rem;
+  border-radius: 9999px;
+  margin-left: 0.6rem;
+  vertical-align: 2px;
+}
+
+.progress-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.slide-counter {
+  color: rgba(255,255,255,0.6);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  font-family: var(--font-mono);
+  white-space: nowrap;
+}
+
+.progress-strip .theme-toggle {
+  background: rgba(255,255,255,0.1);
+  color: rgba(255,255,255,0.7);
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: var(--radius-md);
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-xs);
+  cursor: pointer;
+  font-family: var(--font-sans);
+  transition: all var(--transition-fast);
+}
+
+.progress-strip .theme-toggle:hover {
+  background: rgba(255,255,255,0.2);
+  color: white;
+}
+
+/* ── Viewport ────────────────────────────────────── */
+.slide-viewport {
+  position: fixed;
+  top: var(--strip-height);
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow: hidden;
+}
+
+/* ── Slide Base ──────────────────────────────────── */
+.slide {
+  display: none;
+  position: absolute;
+  inset: 0;
+  overflow-y: auto;
+  padding: var(--space-10) var(--space-16);
+  font-size: var(--slide-font-size);
+  line-height: 1.6;
+  font-family: var(--font-sans);
+  color: var(--text-primary);
+  background: var(--bg-primary);
+}
+
+.slide.active {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  animation: fadeIn 0.25s ease;
+}
+
+.slide > * {
+  max-width: 1100px;
+  width: 100% !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
+  box-sizing: border-box;
+  text-align: inherit;
+}
+
+.slide > .topic-badge {
+  width: auto !important;
+  max-width: none;
+  align-self: center;
+}
+
+/* ── Section Title ───────────────────────────────── */
+.slide[data-type="section-title"] {
+  background: linear-gradient(135deg, var(--navy) 0%, var(--navy-light) 100%);
+  text-align: center;
+}
+
+.slide[data-type="section-title"] h1,
+.slide[data-type="section-title"] h2,
+.slide[data-type="section-title"] h3 {
+  color: white;
+}
+
+.slide[data-type="section-title"] p {
+  color: rgba(255,255,255,0.85);
+}
+
+.slide[data-type="section-title"] .topic-badge {
+  display: inline-block;
+  background: var(--amber);
+  color: var(--navy-dark);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  padding: var(--space-2) var(--space-4);
+  border-radius: 9999px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: var(--space-4);
+  width: auto !important;
+}
+
+.slide[data-type="section-title"] .highlight-text {
+  color: var(--amber);
+  font-weight: 600;
+}
+
+/* ── Typography ──────────────────────────────────── */
+.slide h1 {
+  font-size: 2.4em;
+  font-weight: 800;
+  color: var(--navy);
+  margin-bottom: var(--space-4);
+  line-height: 1.15;
+}
+
+.slide h2 {
+  font-size: 1.6em;
+  font-weight: 700;
+  color: var(--navy);
+  margin-bottom: var(--space-4);
+  padding-bottom: var(--space-2);
+  border-bottom: 3px solid var(--amber);
+}
+
+.slide h3 {
+  font-size: 1.2em;
+  font-weight: 600;
+  color: var(--navy-light);
+  margin-bottom: var(--space-3);
+}
+
+.slide p {
+  margin-bottom: var(--space-3);
+  color: var(--text-secondary);
+}
+
+.slide strong {
+  color: var(--navy);
+  font-weight: 700;
+}
+
+.slide em {
+  color: var(--amber-dark);
+  font-style: italic;
+}
+
+.slide ul, .slide ol {
+  margin-left: 1.2em;
+  margin-bottom: var(--space-4);
+}
+
+.slide li {
+  margin-bottom: var(--space-2);
+  color: var(--text-secondary);
+}
+
+.slide li::marker {
+  color: var(--amber);
+}
+
+[data-theme="dark"] .slide h1,
+[data-theme="dark"] .slide h2 { color: var(--text-primary); }
+[data-theme="dark"] .slide h3 { color: var(--text-secondary); }
+[data-theme="dark"] .slide strong { color: var(--text-primary); }
+[data-theme="dark"] .slide h2 { border-bottom-color: var(--amber); }
+
+.highlight-text {
+  color: var(--amber-dark);
+  font-weight: 600;
+}
+
+[data-theme="dark"] .highlight-text {
+  color: var(--amber);
+}
+
+/* ── Grid ────────────────────────────────────────── */
+.slide[data-type="grid"] .grid-layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: var(--space-4);
+  margin-top: var(--space-4);
+}
+
+.grid-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5);
+  transition: all var(--transition-normal);
+}
+
+.grid-card:hover {
+  box-shadow: var(--shadow-md);
+  transform: translateY(-2px);
+  border-color: var(--accent);
+}
+
+.grid-card.highlight {
+  border-color: var(--amber);
+  box-shadow: 0 0 0 1px var(--amber), var(--shadow-sm);
+}
+
+.grid-card-title {
+  font-weight: 700;
+  color: var(--text-primary);
+  font-size: 1.05em;
+  margin-bottom: var(--space-2);
+}
+
+.grid-card-body {
+  color: var(--text-secondary);
+  font-size: 0.9em;
+  line-height: 1.5;
+}
+
+/* ── Split ───────────────────────────────────────── */
+.slide[data-type="split"] .split-layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-8);
+  margin-top: var(--space-4);
+}
+
+@media (max-width: 768px) {
+  .slide[data-type="split"] .split-layout { grid-template-columns: 1fr; }
+}
+
+/* ── Comparison ──────────────────────────────────── */
+.slide[data-type="comparison"] .comparison-layout {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: var(--space-6);
+  align-items: start;
+  margin-top: var(--space-4);
+}
+
+.vs-left, .vs-right {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+}
+
+.vs-divider {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5em;
+  font-weight: 800;
+  color: var(--text-muted);
+  align-self: center;
+}
+
+@media (max-width: 768px) {
+  .slide[data-type="comparison"] .comparison-layout {
+    grid-template-columns: 1fr;
+  }
+  .vs-divider { display: none; }
+}
+
+/* ── Quote ───────────────────────────────────────── */
+.slide[data-type="quote"] {
+  text-align: center;
+}
+
+.quote-text {
+  font-size: 1.5em;
+  font-weight: 300;
+  font-style: italic;
+  color: var(--text-primary);
+  max-width: 80%;
+  line-height: 1.5;
+  position: relative;
+  padding: 0.5em 1em;
+  margin: 0 auto;
+}
+
+.quote-text::before {
+  content: '\201C';
+  position: absolute;
+  left: -0.3em;
+  top: -0.2em;
+  font-size: 3.5em;
+  color: var(--amber);
+  font-weight: 800;
+  line-height: 1;
+  opacity: 0.3;
+}
+
+.quote-source {
+  margin-top: var(--space-4);
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  font-weight: 500;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.quote-source::before { content: '\2014\00a0'; }
+
+/* ── Key Fact ────────────────────────────────────── */
+.slide[data-type="keyfact"] {
+  text-align: center;
+}
+
+.slide[data-type="keyfact"] p {
+  font-size: 1.5em;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.35;
+}
+
+.slide[data-type="keyfact"] strong {
+  color: var(--amber-dark);
+}
+
+[data-theme="dark"] .slide[data-type="keyfact"] strong {
+  color: var(--amber);
+}
+
+/* ── Hero ────────────────────────────────────────── */
+.slide[data-type="hero"] {
+  text-align: center;
+}
+
+/* ── Example / Code ──────────────────────────────── */
+.slide[data-type="example"] {
+  border-left: 4px solid var(--info);
+}
+
+.slide[data-type="code"] pre,
+.slide pre {
+  background: var(--gray-900);
+  color: #E6EDF3;
+  border-radius: var(--radius-md);
+  padding: var(--space-4) var(--space-5);
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  line-height: 1.55;
+  margin: var(--space-3) 0;
+  box-shadow: var(--shadow-sm);
+}
+
+.slide[data-type="code"] pre code,
+.slide pre code {
+  background: none;
+  color: inherit;
+  padding: 0;
+  font-family: var(--font-mono);
+}
+
+.slide code {
+  font-family: var(--font-mono);
+  background: var(--bg-secondary);
+  color: var(--navy);
+  padding: 0.1em 0.35em;
+  border-radius: var(--radius-sm);
+  font-size: 0.9em;
+}
+
+[data-theme="dark"] .slide code {
+  color: var(--accent-light);
+  background: var(--gray-800);
+}
+
+.slide .code-caption {
+  color: var(--text-muted);
+  font-size: 0.85em;
+  font-style: italic;
+  margin-top: var(--space-2);
+}
+
+/* ── Definition Cards ────────────────────────────── */
+.def-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-left: 4px solid var(--navy-light);
+  border-radius: 0 var(--radius-lg) var(--radius-lg) 0;
+  padding: var(--space-4) var(--space-5);
+  margin-bottom: var(--space-3);
+  transition: border-color var(--transition-fast);
+}
+
+.def-card.highlight {
+  border-left-color: var(--amber);
+}
+
+.def-term {
+  font-size: var(--text-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--navy-light);
+  margin-bottom: var(--space-2);
+}
+
+[data-theme="dark"] .def-term { color: var(--accent); }
+
+.def-text {
+  color: var(--text-primary);
+  line-height: 1.5;
+}
+
+/* ── Callouts on slides ──────────────────────────── */
+.slide .callout {
+  margin: var(--space-4) 0;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* ── Tables ──────────────────────────────────────── */
+.slide table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  margin: var(--space-4) 0;
+  font-size: 0.92em;
+}
+
+.slide table th {
+  background: var(--navy);
+  color: white;
+  padding: var(--space-3) var(--space-4);
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.9em;
+}
+
+.slide table td {
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border-color);
+  color: var(--text-secondary);
+}
+
+.slide table tr:nth-child(even) { background: var(--bg-secondary); }
+.slide table tr:last-child td { border-bottom: none; }
+
+/* ── Two-Column Layout ───────────────────────────── */
+.two-col {
+  display: flex;
+  gap: var(--space-8);
+  align-items: flex-start;
+}
+
+.col { flex: 1; min-width: 0; }
+
+@media (max-width: 768px) {
+  .two-col { flex-direction: column; gap: var(--space-4); }
+}
+
+/* ── ASCII-art / diagram ─────────────────────────── */
+.slide .diagram {
+  background: var(--gray-900);
+  color: #C9D1D9;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  line-height: 1.4;
+  padding: var(--space-4) var(--space-5);
+  border-radius: var(--radius-md);
+  white-space: pre;
+  overflow-x: auto;
+  margin: var(--space-3) 0;
+}
+
+/* ── Font Controls ───────────────────────────────── */
+.font-controls {
+  position: fixed;
+  bottom: var(--space-6);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: var(--space-2);
+  z-index: 100;
+  background: var(--bg-card);
+  padding: var(--space-2);
+  border-radius: 9999px;
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-md);
+  opacity: 0.5;
+  transition: opacity var(--transition-fast);
+}
+
+.font-controls:hover { opacity: 1; }
+
+.font-controls button {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.font-controls button:hover {
+  background: var(--navy);
+  color: white;
+  border-color: var(--navy);
+}
+
+/* ── Animations ──────────────────────────────────── */
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Print ───────────────────────────────────────── */
+@media print {
+  .progress-strip, .font-controls { display: none !important; }
+  .slide-viewport { position: static; overflow: visible; }
+  .slide {
+    display: block !important;
+    position: static !important;
+    page-break-after: always;
+    padding: 2cm;
+  }
+  .slide[data-type="section-title"] {
+    background: var(--navy) !important;
+    color: white !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+  .slide pre {
+    background: var(--gray-100) !important;
+    color: var(--gray-900) !important;
+    border: 1px solid var(--gray-400);
+  }
+}
+  </style>
+  <!-- END-INLINED-STYLES -->
 </head>
 <body>
   <nav class="progress-strip">
     <a href="../../index.html" class="progress-home">Course</a>
-    <div class="progress-title">M01 — Why agents, why ADK</div>
+    <div class="progress-title">M01 — Why agents, why ADK<span class="quick-path-badge">⚡ Quick path</span></div>
     <div class="progress-meta">
       <span class="slide-counter">1 / 1</span>
       <button class="theme-toggle">Theme</button>
@@ -1216,5 +2026,148 @@ model = LiteLlm(model="ollama_chat/qwen3:8b")</code></pre>
 
 })();
 </script>
+
+  <!-- BEGIN-INLINED-SCRIPT -->
+<script>
+/* ADK Course — Slide Engine
+   Adapted from barcik-training-exin-ai-foundation/slides/js/slides.js.
+   Per-module decks; lightweight nav with keyboard, touch, hash routing,
+   font controls, theme toggle. */
+
+(function () {
+  'use strict';
+
+  const slides = document.querySelectorAll('.slide');
+  const total = slides.length;
+  let current = 0;
+
+  function goTo(index) {
+    if (index < 0 || index >= total) return;
+    slides[current].classList.remove('active');
+    current = index;
+    slides[current].classList.add('active');
+    updateCounter();
+    window.scrollTo(0, 0);
+    history.replaceState(null, '', '#slide-' + (current + 1));
+  }
+
+  function next() { goTo(current + 1); }
+  function prev() { goTo(current - 1); }
+
+  document.addEventListener('keydown', function (e) {
+    if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+      case ' ':
+        e.preventDefault();
+        next();
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        e.preventDefault();
+        prev();
+        break;
+      case 'Home':
+        e.preventDefault();
+        goTo(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        goTo(total - 1);
+        break;
+    }
+  });
+
+  var viewport = document.querySelector('.slide-viewport');
+  if (viewport) {
+    viewport.addEventListener('click', function (e) {
+      if (e.target === this || e.target.classList.contains('slide')) {
+        var rect = this.getBoundingClientRect();
+        var x = e.clientX - rect.left;
+        if (x > rect.width * 0.75) next();
+        else if (x < rect.width * 0.25) prev();
+      }
+    });
+  }
+
+  var counter = document.querySelector('.slide-counter');
+  function updateCounter() {
+    if (counter) counter.textContent = (current + 1) + ' / ' + total;
+  }
+
+  var baseFontSize = parseInt(localStorage.getItem('adkSlideFontSize')) || 18;
+  applyFontSize();
+
+  window.adjustFont = function (delta) {
+    if (delta === 0) {
+      baseFontSize = 18;
+    } else {
+      baseFontSize = Math.max(14, Math.min(28, baseFontSize + delta));
+    }
+    applyFontSize();
+    localStorage.setItem('adkSlideFontSize', baseFontSize);
+  };
+
+  function applyFontSize() {
+    document.documentElement.style.setProperty('--slide-font-size', baseFontSize + 'px');
+  }
+
+  var themeBtn = document.querySelector('.theme-toggle');
+  var savedTheme = localStorage.getItem('adkTheme');
+  if (savedTheme) {
+    document.documentElement.setAttribute('data-theme', savedTheme);
+  }
+
+  if (themeBtn) {
+    themeBtn.addEventListener('click', function () {
+      var html = document.documentElement;
+      var nextTheme = html.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+      html.setAttribute('data-theme', nextTheme);
+      localStorage.setItem('adkTheme', nextTheme);
+    });
+  }
+
+  var touchStartX = 0;
+  var touchStartY = 0;
+
+  document.addEventListener('touchstart', function (e) {
+    touchStartX = e.changedTouches[0].screenX;
+    touchStartY = e.changedTouches[0].screenY;
+  }, { passive: true });
+
+  document.addEventListener('touchend', function (e) {
+    var dx = e.changedTouches[0].screenX - touchStartX;
+    var dy = e.changedTouches[0].screenY - touchStartY;
+    if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > 50) {
+      if (dx < 0) next();
+      else prev();
+    }
+  }, { passive: true });
+
+  var hash = window.location.hash;
+  if (hash && hash.startsWith('#slide-')) {
+    var n = parseInt(hash.replace('#slide-', ''));
+    if (!isNaN(n) && n >= 1 && n <= total) {
+      current = n - 1;
+    }
+  }
+
+  slides[current].classList.add('active');
+  updateCounter();
+
+  window.addEventListener('hashchange', function () {
+    var h = window.location.hash;
+    if (h && h.startsWith('#slide-')) {
+      var n = parseInt(h.replace('#slide-', ''));
+      if (!isNaN(n) && n >= 1 && n <= total && n - 1 !== current) {
+        goTo(n - 1);
+      }
+    }
+  });
+
+})();
+</script>
+<!-- END-INLINED-SCRIPT -->
 </body>
 </html>

--- a/slides/module-02-tools/index.html
+++ b/slides/module-02-tools/index.html
@@ -796,11 +796,821 @@ body {
   }
 }
   </style>
+
+  <!-- BEGIN-INLINED-STYLES -->
+  <style>
+  /* shared.css — generated; edit slides/shared/shared.css */
+/* ADK Course — Shared Design Tokens
+   Adapted from barcik-training-exin-ai-foundation/css/shared.css.
+   Family-consistent navy with amber accent (distinct from EXIN gold). */
+
+@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;500;600;700;800&display=swap');
+
+:root {
+  /* Brand colors */
+  --navy: #1E3A5F;
+  --navy-light: #2A5280;
+  --navy-dark: #122542;
+  --amber: #F59E0B;
+  --amber-light: #FBBF24;
+  --amber-dark: #B45309;
+  --white: #FFFFFF;
+  --gray-50: #F8F9FA;
+  --gray-100: #F1F3F5;
+  --gray-200: #E9ECEF;
+  --gray-300: #DEE2E6;
+  --gray-400: #CED4DA;
+  --gray-500: #ADB5BD;
+  --gray-600: #868E96;
+  --gray-700: #495057;
+  --gray-800: #343A40;
+  --gray-900: #212529;
+
+  /* Semantic */
+  --bg-primary: var(--white);
+  --bg-secondary: var(--gray-50);
+  --bg-card: var(--white);
+  --text-primary: var(--gray-900);
+  --text-secondary: var(--gray-700);
+  --text-muted: var(--gray-600);
+  --border-color: var(--gray-200);
+  --accent: var(--navy);
+  --accent-light: var(--navy-light);
+  --highlight: var(--amber);
+  --highlight-bg: #FEF3C7;
+  --success: #2E7D32;
+  --success-bg: #E8F5E9;
+  --error: #C62828;
+  --error-bg: #FFEBEE;
+  --info: #1565C0;
+  --info-bg: #E3F2FD;
+
+  /* Typography */
+  --font-sans: 'Nunito', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+  --text-3xl: 1.875rem;
+  --text-4xl: 2.25rem;
+
+  /* Spacing */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-10: 2.5rem;
+  --space-12: 3rem;
+  --space-16: 4rem;
+
+  /* Radius */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.07);
+  --shadow-lg: 0 10px 15px rgba(0,0,0,0.1);
+
+  /* Transitions */
+  --transition-fast: 150ms ease;
+  --transition-normal: 250ms ease;
+  --transition-slow: 350ms ease;
+}
+
+[data-theme="dark"] {
+  --bg-primary: #0D1117;
+  --bg-secondary: #161B22;
+  --bg-card: #1C2128;
+  --text-primary: #E6EDF3;
+  --text-secondary: #B1BAC4;
+  --text-muted: #8B949E;
+  --border-color: #30363D;
+  --accent: #58A6FF;
+  --accent-light: #79C0FF;
+  --highlight: var(--amber);
+  --highlight-bg: #2D2200;
+  --success: #56D364;
+  --success-bg: #0D2818;
+  --error: #F85149;
+  --error-bg: #2D1214;
+  --info: #58A6FF;
+  --info-bg: #0D1B2E;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.3);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.4);
+  --shadow-lg: 0 10px 15px rgba(0,0,0,0.5);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg-primary: #0D1117;
+    --bg-secondary: #161B22;
+    --bg-card: #1C2128;
+    --text-primary: #E6EDF3;
+    --text-secondary: #B1BAC4;
+    --text-muted: #8B949E;
+    --border-color: #30363D;
+    --accent: #58A6FF;
+    --accent-light: #79C0FF;
+    --highlight: var(--amber);
+    --highlight-bg: #2D2200;
+    --success: #56D364;
+    --success-bg: #0D2818;
+    --error: #F85149;
+    --error-bg: #2D1214;
+    --info: #58A6FF;
+    --info-bg: #0D1B2E;
+  }
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  line-height: 1.6;
+  color: var(--text-primary);
+  background-color: var(--bg-primary);
+  -webkit-font-smoothing: antialiased;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow var(--transition-normal);
+}
+
+.card:hover {
+  box-shadow: var(--shadow-md);
+}
+
+.callout {
+  padding: var(--space-4) var(--space-6);
+  border-radius: var(--radius-md);
+  margin: var(--space-4) 0;
+  border-left: 4px solid;
+}
+
+.callout-key { background: var(--highlight-bg); border-color: var(--amber); }
+.callout-gotcha { background: var(--error-bg); border-color: var(--error); }
+.callout-tip { background: var(--info-bg); border-color: var(--info); }
+.callout-success { background: var(--success-bg); border-color: var(--success); }
+
+.callout-title {
+  font-weight: 700;
+  font-size: var(--text-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: var(--space-2);
+}
+
+.text-center { text-align: center; }
+.text-muted { color: var(--text-muted); }
+.font-mono { font-family: var(--font-mono); }
+.mt-4 { margin-top: var(--space-4); }
+.mt-8 { margin-top: var(--space-8); }
+.mb-4 { margin-bottom: var(--space-4); }
+.mb-8 { margin-bottom: var(--space-8); }
+.mx-auto { margin-left: auto; margin-right: auto; }
+.max-w-4xl { max-width: 56rem; }
+.hidden { display: none !important; }
+  /* slides.css — generated; edit slides/shared/slides.css */
+/* ADK Course — Slide Presentation Theme
+   Adapted from barcik-training-exin-ai-foundation/slides/css/slides.css.
+   Adds data-type="code" slide variant for Python snippets. */
+
+:root {
+  --slide-font-size: 18px;
+  --strip-height: 48px;
+}
+
+body {
+  margin: 0;
+  overflow: hidden;
+  background: var(--bg-primary);
+}
+
+/* ── Progress Strip ──────────────────────────────── */
+.progress-strip {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  height: var(--strip-height);
+  background: var(--navy);
+  display: flex;
+  align-items: center;
+  z-index: 100;
+  padding: 0 var(--space-4);
+  gap: var(--space-4);
+  box-shadow: var(--shadow-md);
+  font-family: var(--font-sans);
+}
+
+.progress-home {
+  color: var(--amber);
+  text-decoration: none;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: var(--radius-md);
+  white-space: nowrap;
+  transition: all var(--transition-fast);
+}
+
+.progress-home:hover {
+  background: rgba(255,255,255,0.1);
+  border-color: var(--amber);
+}
+
+.progress-title {
+  color: rgba(255,255,255,0.85);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  flex: 1;
+  text-align: center;
+}
+
+.progress-title .quick-path-badge {
+  display: inline-block;
+  background: var(--amber);
+  color: var(--navy-dark);
+  font-size: 0.68rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.15rem 0.55rem;
+  border-radius: 9999px;
+  margin-left: 0.6rem;
+  vertical-align: 2px;
+}
+
+.progress-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.slide-counter {
+  color: rgba(255,255,255,0.6);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  font-family: var(--font-mono);
+  white-space: nowrap;
+}
+
+.progress-strip .theme-toggle {
+  background: rgba(255,255,255,0.1);
+  color: rgba(255,255,255,0.7);
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: var(--radius-md);
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-xs);
+  cursor: pointer;
+  font-family: var(--font-sans);
+  transition: all var(--transition-fast);
+}
+
+.progress-strip .theme-toggle:hover {
+  background: rgba(255,255,255,0.2);
+  color: white;
+}
+
+/* ── Viewport ────────────────────────────────────── */
+.slide-viewport {
+  position: fixed;
+  top: var(--strip-height);
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow: hidden;
+}
+
+/* ── Slide Base ──────────────────────────────────── */
+.slide {
+  display: none;
+  position: absolute;
+  inset: 0;
+  overflow-y: auto;
+  padding: var(--space-10) var(--space-16);
+  font-size: var(--slide-font-size);
+  line-height: 1.6;
+  font-family: var(--font-sans);
+  color: var(--text-primary);
+  background: var(--bg-primary);
+}
+
+.slide.active {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  animation: fadeIn 0.25s ease;
+}
+
+.slide > * {
+  max-width: 1100px;
+  width: 100% !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
+  box-sizing: border-box;
+  text-align: inherit;
+}
+
+.slide > .topic-badge {
+  width: auto !important;
+  max-width: none;
+  align-self: center;
+}
+
+/* ── Section Title ───────────────────────────────── */
+.slide[data-type="section-title"] {
+  background: linear-gradient(135deg, var(--navy) 0%, var(--navy-light) 100%);
+  text-align: center;
+}
+
+.slide[data-type="section-title"] h1,
+.slide[data-type="section-title"] h2,
+.slide[data-type="section-title"] h3 {
+  color: white;
+}
+
+.slide[data-type="section-title"] p {
+  color: rgba(255,255,255,0.85);
+}
+
+.slide[data-type="section-title"] .topic-badge {
+  display: inline-block;
+  background: var(--amber);
+  color: var(--navy-dark);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  padding: var(--space-2) var(--space-4);
+  border-radius: 9999px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: var(--space-4);
+  width: auto !important;
+}
+
+.slide[data-type="section-title"] .highlight-text {
+  color: var(--amber);
+  font-weight: 600;
+}
+
+/* ── Typography ──────────────────────────────────── */
+.slide h1 {
+  font-size: 2.4em;
+  font-weight: 800;
+  color: var(--navy);
+  margin-bottom: var(--space-4);
+  line-height: 1.15;
+}
+
+.slide h2 {
+  font-size: 1.6em;
+  font-weight: 700;
+  color: var(--navy);
+  margin-bottom: var(--space-4);
+  padding-bottom: var(--space-2);
+  border-bottom: 3px solid var(--amber);
+}
+
+.slide h3 {
+  font-size: 1.2em;
+  font-weight: 600;
+  color: var(--navy-light);
+  margin-bottom: var(--space-3);
+}
+
+.slide p {
+  margin-bottom: var(--space-3);
+  color: var(--text-secondary);
+}
+
+.slide strong {
+  color: var(--navy);
+  font-weight: 700;
+}
+
+.slide em {
+  color: var(--amber-dark);
+  font-style: italic;
+}
+
+.slide ul, .slide ol {
+  margin-left: 1.2em;
+  margin-bottom: var(--space-4);
+}
+
+.slide li {
+  margin-bottom: var(--space-2);
+  color: var(--text-secondary);
+}
+
+.slide li::marker {
+  color: var(--amber);
+}
+
+[data-theme="dark"] .slide h1,
+[data-theme="dark"] .slide h2 { color: var(--text-primary); }
+[data-theme="dark"] .slide h3 { color: var(--text-secondary); }
+[data-theme="dark"] .slide strong { color: var(--text-primary); }
+[data-theme="dark"] .slide h2 { border-bottom-color: var(--amber); }
+
+.highlight-text {
+  color: var(--amber-dark);
+  font-weight: 600;
+}
+
+[data-theme="dark"] .highlight-text {
+  color: var(--amber);
+}
+
+/* ── Grid ────────────────────────────────────────── */
+.slide[data-type="grid"] .grid-layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: var(--space-4);
+  margin-top: var(--space-4);
+}
+
+.grid-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5);
+  transition: all var(--transition-normal);
+}
+
+.grid-card:hover {
+  box-shadow: var(--shadow-md);
+  transform: translateY(-2px);
+  border-color: var(--accent);
+}
+
+.grid-card.highlight {
+  border-color: var(--amber);
+  box-shadow: 0 0 0 1px var(--amber), var(--shadow-sm);
+}
+
+.grid-card-title {
+  font-weight: 700;
+  color: var(--text-primary);
+  font-size: 1.05em;
+  margin-bottom: var(--space-2);
+}
+
+.grid-card-body {
+  color: var(--text-secondary);
+  font-size: 0.9em;
+  line-height: 1.5;
+}
+
+/* ── Split ───────────────────────────────────────── */
+.slide[data-type="split"] .split-layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-8);
+  margin-top: var(--space-4);
+}
+
+@media (max-width: 768px) {
+  .slide[data-type="split"] .split-layout { grid-template-columns: 1fr; }
+}
+
+/* ── Comparison ──────────────────────────────────── */
+.slide[data-type="comparison"] .comparison-layout {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: var(--space-6);
+  align-items: start;
+  margin-top: var(--space-4);
+}
+
+.vs-left, .vs-right {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+}
+
+.vs-divider {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5em;
+  font-weight: 800;
+  color: var(--text-muted);
+  align-self: center;
+}
+
+@media (max-width: 768px) {
+  .slide[data-type="comparison"] .comparison-layout {
+    grid-template-columns: 1fr;
+  }
+  .vs-divider { display: none; }
+}
+
+/* ── Quote ───────────────────────────────────────── */
+.slide[data-type="quote"] {
+  text-align: center;
+}
+
+.quote-text {
+  font-size: 1.5em;
+  font-weight: 300;
+  font-style: italic;
+  color: var(--text-primary);
+  max-width: 80%;
+  line-height: 1.5;
+  position: relative;
+  padding: 0.5em 1em;
+  margin: 0 auto;
+}
+
+.quote-text::before {
+  content: '\201C';
+  position: absolute;
+  left: -0.3em;
+  top: -0.2em;
+  font-size: 3.5em;
+  color: var(--amber);
+  font-weight: 800;
+  line-height: 1;
+  opacity: 0.3;
+}
+
+.quote-source {
+  margin-top: var(--space-4);
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  font-weight: 500;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.quote-source::before { content: '\2014\00a0'; }
+
+/* ── Key Fact ────────────────────────────────────── */
+.slide[data-type="keyfact"] {
+  text-align: center;
+}
+
+.slide[data-type="keyfact"] p {
+  font-size: 1.5em;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.35;
+}
+
+.slide[data-type="keyfact"] strong {
+  color: var(--amber-dark);
+}
+
+[data-theme="dark"] .slide[data-type="keyfact"] strong {
+  color: var(--amber);
+}
+
+/* ── Hero ────────────────────────────────────────── */
+.slide[data-type="hero"] {
+  text-align: center;
+}
+
+/* ── Example / Code ──────────────────────────────── */
+.slide[data-type="example"] {
+  border-left: 4px solid var(--info);
+}
+
+.slide[data-type="code"] pre,
+.slide pre {
+  background: var(--gray-900);
+  color: #E6EDF3;
+  border-radius: var(--radius-md);
+  padding: var(--space-4) var(--space-5);
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  line-height: 1.55;
+  margin: var(--space-3) 0;
+  box-shadow: var(--shadow-sm);
+}
+
+.slide[data-type="code"] pre code,
+.slide pre code {
+  background: none;
+  color: inherit;
+  padding: 0;
+  font-family: var(--font-mono);
+}
+
+.slide code {
+  font-family: var(--font-mono);
+  background: var(--bg-secondary);
+  color: var(--navy);
+  padding: 0.1em 0.35em;
+  border-radius: var(--radius-sm);
+  font-size: 0.9em;
+}
+
+[data-theme="dark"] .slide code {
+  color: var(--accent-light);
+  background: var(--gray-800);
+}
+
+.slide .code-caption {
+  color: var(--text-muted);
+  font-size: 0.85em;
+  font-style: italic;
+  margin-top: var(--space-2);
+}
+
+/* ── Definition Cards ────────────────────────────── */
+.def-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-left: 4px solid var(--navy-light);
+  border-radius: 0 var(--radius-lg) var(--radius-lg) 0;
+  padding: var(--space-4) var(--space-5);
+  margin-bottom: var(--space-3);
+  transition: border-color var(--transition-fast);
+}
+
+.def-card.highlight {
+  border-left-color: var(--amber);
+}
+
+.def-term {
+  font-size: var(--text-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--navy-light);
+  margin-bottom: var(--space-2);
+}
+
+[data-theme="dark"] .def-term { color: var(--accent); }
+
+.def-text {
+  color: var(--text-primary);
+  line-height: 1.5;
+}
+
+/* ── Callouts on slides ──────────────────────────── */
+.slide .callout {
+  margin: var(--space-4) 0;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* ── Tables ──────────────────────────────────────── */
+.slide table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  margin: var(--space-4) 0;
+  font-size: 0.92em;
+}
+
+.slide table th {
+  background: var(--navy);
+  color: white;
+  padding: var(--space-3) var(--space-4);
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.9em;
+}
+
+.slide table td {
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border-color);
+  color: var(--text-secondary);
+}
+
+.slide table tr:nth-child(even) { background: var(--bg-secondary); }
+.slide table tr:last-child td { border-bottom: none; }
+
+/* ── Two-Column Layout ───────────────────────────── */
+.two-col {
+  display: flex;
+  gap: var(--space-8);
+  align-items: flex-start;
+}
+
+.col { flex: 1; min-width: 0; }
+
+@media (max-width: 768px) {
+  .two-col { flex-direction: column; gap: var(--space-4); }
+}
+
+/* ── ASCII-art / diagram ─────────────────────────── */
+.slide .diagram {
+  background: var(--gray-900);
+  color: #C9D1D9;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  line-height: 1.4;
+  padding: var(--space-4) var(--space-5);
+  border-radius: var(--radius-md);
+  white-space: pre;
+  overflow-x: auto;
+  margin: var(--space-3) 0;
+}
+
+/* ── Font Controls ───────────────────────────────── */
+.font-controls {
+  position: fixed;
+  bottom: var(--space-6);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: var(--space-2);
+  z-index: 100;
+  background: var(--bg-card);
+  padding: var(--space-2);
+  border-radius: 9999px;
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-md);
+  opacity: 0.5;
+  transition: opacity var(--transition-fast);
+}
+
+.font-controls:hover { opacity: 1; }
+
+.font-controls button {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.font-controls button:hover {
+  background: var(--navy);
+  color: white;
+  border-color: var(--navy);
+}
+
+/* ── Animations ──────────────────────────────────── */
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Print ───────────────────────────────────────── */
+@media print {
+  .progress-strip, .font-controls { display: none !important; }
+  .slide-viewport { position: static; overflow: visible; }
+  .slide {
+    display: block !important;
+    position: static !important;
+    page-break-after: always;
+    padding: 2cm;
+  }
+  .slide[data-type="section-title"] {
+    background: var(--navy) !important;
+    color: white !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+  .slide pre {
+    background: var(--gray-100) !important;
+    color: var(--gray-900) !important;
+    border: 1px solid var(--gray-400);
+  }
+}
+  </style>
+  <!-- END-INLINED-STYLES -->
 </head>
 <body>
   <nav class="progress-strip">
     <a href="../../index.html" class="progress-home">Course</a>
-    <div class="progress-title">M02 — Tools as verbs</div>
+    <div class="progress-title">M02 — Tools as verbs<span class="quick-path-badge">⚡ Quick path</span></div>
     <div class="progress-meta">
       <span class="slide-counter">1 / 1</span>
       <button class="theme-toggle">Theme</button>
@@ -1278,5 +2088,148 @@ orchestrator = LlmAgent(
 
 })();
 </script>
+
+  <!-- BEGIN-INLINED-SCRIPT -->
+<script>
+/* ADK Course — Slide Engine
+   Adapted from barcik-training-exin-ai-foundation/slides/js/slides.js.
+   Per-module decks; lightweight nav with keyboard, touch, hash routing,
+   font controls, theme toggle. */
+
+(function () {
+  'use strict';
+
+  const slides = document.querySelectorAll('.slide');
+  const total = slides.length;
+  let current = 0;
+
+  function goTo(index) {
+    if (index < 0 || index >= total) return;
+    slides[current].classList.remove('active');
+    current = index;
+    slides[current].classList.add('active');
+    updateCounter();
+    window.scrollTo(0, 0);
+    history.replaceState(null, '', '#slide-' + (current + 1));
+  }
+
+  function next() { goTo(current + 1); }
+  function prev() { goTo(current - 1); }
+
+  document.addEventListener('keydown', function (e) {
+    if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+      case ' ':
+        e.preventDefault();
+        next();
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        e.preventDefault();
+        prev();
+        break;
+      case 'Home':
+        e.preventDefault();
+        goTo(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        goTo(total - 1);
+        break;
+    }
+  });
+
+  var viewport = document.querySelector('.slide-viewport');
+  if (viewport) {
+    viewport.addEventListener('click', function (e) {
+      if (e.target === this || e.target.classList.contains('slide')) {
+        var rect = this.getBoundingClientRect();
+        var x = e.clientX - rect.left;
+        if (x > rect.width * 0.75) next();
+        else if (x < rect.width * 0.25) prev();
+      }
+    });
+  }
+
+  var counter = document.querySelector('.slide-counter');
+  function updateCounter() {
+    if (counter) counter.textContent = (current + 1) + ' / ' + total;
+  }
+
+  var baseFontSize = parseInt(localStorage.getItem('adkSlideFontSize')) || 18;
+  applyFontSize();
+
+  window.adjustFont = function (delta) {
+    if (delta === 0) {
+      baseFontSize = 18;
+    } else {
+      baseFontSize = Math.max(14, Math.min(28, baseFontSize + delta));
+    }
+    applyFontSize();
+    localStorage.setItem('adkSlideFontSize', baseFontSize);
+  };
+
+  function applyFontSize() {
+    document.documentElement.style.setProperty('--slide-font-size', baseFontSize + 'px');
+  }
+
+  var themeBtn = document.querySelector('.theme-toggle');
+  var savedTheme = localStorage.getItem('adkTheme');
+  if (savedTheme) {
+    document.documentElement.setAttribute('data-theme', savedTheme);
+  }
+
+  if (themeBtn) {
+    themeBtn.addEventListener('click', function () {
+      var html = document.documentElement;
+      var nextTheme = html.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+      html.setAttribute('data-theme', nextTheme);
+      localStorage.setItem('adkTheme', nextTheme);
+    });
+  }
+
+  var touchStartX = 0;
+  var touchStartY = 0;
+
+  document.addEventListener('touchstart', function (e) {
+    touchStartX = e.changedTouches[0].screenX;
+    touchStartY = e.changedTouches[0].screenY;
+  }, { passive: true });
+
+  document.addEventListener('touchend', function (e) {
+    var dx = e.changedTouches[0].screenX - touchStartX;
+    var dy = e.changedTouches[0].screenY - touchStartY;
+    if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > 50) {
+      if (dx < 0) next();
+      else prev();
+    }
+  }, { passive: true });
+
+  var hash = window.location.hash;
+  if (hash && hash.startsWith('#slide-')) {
+    var n = parseInt(hash.replace('#slide-', ''));
+    if (!isNaN(n) && n >= 1 && n <= total) {
+      current = n - 1;
+    }
+  }
+
+  slides[current].classList.add('active');
+  updateCounter();
+
+  window.addEventListener('hashchange', function () {
+    var h = window.location.hash;
+    if (h && h.startsWith('#slide-')) {
+      var n = parseInt(h.replace('#slide-', ''));
+      if (!isNaN(n) && n >= 1 && n <= total && n - 1 !== current) {
+        goTo(n - 1);
+      }
+    }
+  });
+
+})();
+</script>
+<!-- END-INLINED-SCRIPT -->
 </body>
 </html>

--- a/slides/module-03-sessions-state/index.html
+++ b/slides/module-03-sessions-state/index.html
@@ -796,6 +796,816 @@ body {
   }
 }
   </style>
+
+  <!-- BEGIN-INLINED-STYLES -->
+  <style>
+  /* shared.css — generated; edit slides/shared/shared.css */
+/* ADK Course — Shared Design Tokens
+   Adapted from barcik-training-exin-ai-foundation/css/shared.css.
+   Family-consistent navy with amber accent (distinct from EXIN gold). */
+
+@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;500;600;700;800&display=swap');
+
+:root {
+  /* Brand colors */
+  --navy: #1E3A5F;
+  --navy-light: #2A5280;
+  --navy-dark: #122542;
+  --amber: #F59E0B;
+  --amber-light: #FBBF24;
+  --amber-dark: #B45309;
+  --white: #FFFFFF;
+  --gray-50: #F8F9FA;
+  --gray-100: #F1F3F5;
+  --gray-200: #E9ECEF;
+  --gray-300: #DEE2E6;
+  --gray-400: #CED4DA;
+  --gray-500: #ADB5BD;
+  --gray-600: #868E96;
+  --gray-700: #495057;
+  --gray-800: #343A40;
+  --gray-900: #212529;
+
+  /* Semantic */
+  --bg-primary: var(--white);
+  --bg-secondary: var(--gray-50);
+  --bg-card: var(--white);
+  --text-primary: var(--gray-900);
+  --text-secondary: var(--gray-700);
+  --text-muted: var(--gray-600);
+  --border-color: var(--gray-200);
+  --accent: var(--navy);
+  --accent-light: var(--navy-light);
+  --highlight: var(--amber);
+  --highlight-bg: #FEF3C7;
+  --success: #2E7D32;
+  --success-bg: #E8F5E9;
+  --error: #C62828;
+  --error-bg: #FFEBEE;
+  --info: #1565C0;
+  --info-bg: #E3F2FD;
+
+  /* Typography */
+  --font-sans: 'Nunito', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+  --text-3xl: 1.875rem;
+  --text-4xl: 2.25rem;
+
+  /* Spacing */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-10: 2.5rem;
+  --space-12: 3rem;
+  --space-16: 4rem;
+
+  /* Radius */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.07);
+  --shadow-lg: 0 10px 15px rgba(0,0,0,0.1);
+
+  /* Transitions */
+  --transition-fast: 150ms ease;
+  --transition-normal: 250ms ease;
+  --transition-slow: 350ms ease;
+}
+
+[data-theme="dark"] {
+  --bg-primary: #0D1117;
+  --bg-secondary: #161B22;
+  --bg-card: #1C2128;
+  --text-primary: #E6EDF3;
+  --text-secondary: #B1BAC4;
+  --text-muted: #8B949E;
+  --border-color: #30363D;
+  --accent: #58A6FF;
+  --accent-light: #79C0FF;
+  --highlight: var(--amber);
+  --highlight-bg: #2D2200;
+  --success: #56D364;
+  --success-bg: #0D2818;
+  --error: #F85149;
+  --error-bg: #2D1214;
+  --info: #58A6FF;
+  --info-bg: #0D1B2E;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.3);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.4);
+  --shadow-lg: 0 10px 15px rgba(0,0,0,0.5);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg-primary: #0D1117;
+    --bg-secondary: #161B22;
+    --bg-card: #1C2128;
+    --text-primary: #E6EDF3;
+    --text-secondary: #B1BAC4;
+    --text-muted: #8B949E;
+    --border-color: #30363D;
+    --accent: #58A6FF;
+    --accent-light: #79C0FF;
+    --highlight: var(--amber);
+    --highlight-bg: #2D2200;
+    --success: #56D364;
+    --success-bg: #0D2818;
+    --error: #F85149;
+    --error-bg: #2D1214;
+    --info: #58A6FF;
+    --info-bg: #0D1B2E;
+  }
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  line-height: 1.6;
+  color: var(--text-primary);
+  background-color: var(--bg-primary);
+  -webkit-font-smoothing: antialiased;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow var(--transition-normal);
+}
+
+.card:hover {
+  box-shadow: var(--shadow-md);
+}
+
+.callout {
+  padding: var(--space-4) var(--space-6);
+  border-radius: var(--radius-md);
+  margin: var(--space-4) 0;
+  border-left: 4px solid;
+}
+
+.callout-key { background: var(--highlight-bg); border-color: var(--amber); }
+.callout-gotcha { background: var(--error-bg); border-color: var(--error); }
+.callout-tip { background: var(--info-bg); border-color: var(--info); }
+.callout-success { background: var(--success-bg); border-color: var(--success); }
+
+.callout-title {
+  font-weight: 700;
+  font-size: var(--text-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: var(--space-2);
+}
+
+.text-center { text-align: center; }
+.text-muted { color: var(--text-muted); }
+.font-mono { font-family: var(--font-mono); }
+.mt-4 { margin-top: var(--space-4); }
+.mt-8 { margin-top: var(--space-8); }
+.mb-4 { margin-bottom: var(--space-4); }
+.mb-8 { margin-bottom: var(--space-8); }
+.mx-auto { margin-left: auto; margin-right: auto; }
+.max-w-4xl { max-width: 56rem; }
+.hidden { display: none !important; }
+  /* slides.css — generated; edit slides/shared/slides.css */
+/* ADK Course — Slide Presentation Theme
+   Adapted from barcik-training-exin-ai-foundation/slides/css/slides.css.
+   Adds data-type="code" slide variant for Python snippets. */
+
+:root {
+  --slide-font-size: 18px;
+  --strip-height: 48px;
+}
+
+body {
+  margin: 0;
+  overflow: hidden;
+  background: var(--bg-primary);
+}
+
+/* ── Progress Strip ──────────────────────────────── */
+.progress-strip {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  height: var(--strip-height);
+  background: var(--navy);
+  display: flex;
+  align-items: center;
+  z-index: 100;
+  padding: 0 var(--space-4);
+  gap: var(--space-4);
+  box-shadow: var(--shadow-md);
+  font-family: var(--font-sans);
+}
+
+.progress-home {
+  color: var(--amber);
+  text-decoration: none;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: var(--radius-md);
+  white-space: nowrap;
+  transition: all var(--transition-fast);
+}
+
+.progress-home:hover {
+  background: rgba(255,255,255,0.1);
+  border-color: var(--amber);
+}
+
+.progress-title {
+  color: rgba(255,255,255,0.85);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  flex: 1;
+  text-align: center;
+}
+
+.progress-title .quick-path-badge {
+  display: inline-block;
+  background: var(--amber);
+  color: var(--navy-dark);
+  font-size: 0.68rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.15rem 0.55rem;
+  border-radius: 9999px;
+  margin-left: 0.6rem;
+  vertical-align: 2px;
+}
+
+.progress-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.slide-counter {
+  color: rgba(255,255,255,0.6);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  font-family: var(--font-mono);
+  white-space: nowrap;
+}
+
+.progress-strip .theme-toggle {
+  background: rgba(255,255,255,0.1);
+  color: rgba(255,255,255,0.7);
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: var(--radius-md);
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-xs);
+  cursor: pointer;
+  font-family: var(--font-sans);
+  transition: all var(--transition-fast);
+}
+
+.progress-strip .theme-toggle:hover {
+  background: rgba(255,255,255,0.2);
+  color: white;
+}
+
+/* ── Viewport ────────────────────────────────────── */
+.slide-viewport {
+  position: fixed;
+  top: var(--strip-height);
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow: hidden;
+}
+
+/* ── Slide Base ──────────────────────────────────── */
+.slide {
+  display: none;
+  position: absolute;
+  inset: 0;
+  overflow-y: auto;
+  padding: var(--space-10) var(--space-16);
+  font-size: var(--slide-font-size);
+  line-height: 1.6;
+  font-family: var(--font-sans);
+  color: var(--text-primary);
+  background: var(--bg-primary);
+}
+
+.slide.active {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  animation: fadeIn 0.25s ease;
+}
+
+.slide > * {
+  max-width: 1100px;
+  width: 100% !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
+  box-sizing: border-box;
+  text-align: inherit;
+}
+
+.slide > .topic-badge {
+  width: auto !important;
+  max-width: none;
+  align-self: center;
+}
+
+/* ── Section Title ───────────────────────────────── */
+.slide[data-type="section-title"] {
+  background: linear-gradient(135deg, var(--navy) 0%, var(--navy-light) 100%);
+  text-align: center;
+}
+
+.slide[data-type="section-title"] h1,
+.slide[data-type="section-title"] h2,
+.slide[data-type="section-title"] h3 {
+  color: white;
+}
+
+.slide[data-type="section-title"] p {
+  color: rgba(255,255,255,0.85);
+}
+
+.slide[data-type="section-title"] .topic-badge {
+  display: inline-block;
+  background: var(--amber);
+  color: var(--navy-dark);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  padding: var(--space-2) var(--space-4);
+  border-radius: 9999px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: var(--space-4);
+  width: auto !important;
+}
+
+.slide[data-type="section-title"] .highlight-text {
+  color: var(--amber);
+  font-weight: 600;
+}
+
+/* ── Typography ──────────────────────────────────── */
+.slide h1 {
+  font-size: 2.4em;
+  font-weight: 800;
+  color: var(--navy);
+  margin-bottom: var(--space-4);
+  line-height: 1.15;
+}
+
+.slide h2 {
+  font-size: 1.6em;
+  font-weight: 700;
+  color: var(--navy);
+  margin-bottom: var(--space-4);
+  padding-bottom: var(--space-2);
+  border-bottom: 3px solid var(--amber);
+}
+
+.slide h3 {
+  font-size: 1.2em;
+  font-weight: 600;
+  color: var(--navy-light);
+  margin-bottom: var(--space-3);
+}
+
+.slide p {
+  margin-bottom: var(--space-3);
+  color: var(--text-secondary);
+}
+
+.slide strong {
+  color: var(--navy);
+  font-weight: 700;
+}
+
+.slide em {
+  color: var(--amber-dark);
+  font-style: italic;
+}
+
+.slide ul, .slide ol {
+  margin-left: 1.2em;
+  margin-bottom: var(--space-4);
+}
+
+.slide li {
+  margin-bottom: var(--space-2);
+  color: var(--text-secondary);
+}
+
+.slide li::marker {
+  color: var(--amber);
+}
+
+[data-theme="dark"] .slide h1,
+[data-theme="dark"] .slide h2 { color: var(--text-primary); }
+[data-theme="dark"] .slide h3 { color: var(--text-secondary); }
+[data-theme="dark"] .slide strong { color: var(--text-primary); }
+[data-theme="dark"] .slide h2 { border-bottom-color: var(--amber); }
+
+.highlight-text {
+  color: var(--amber-dark);
+  font-weight: 600;
+}
+
+[data-theme="dark"] .highlight-text {
+  color: var(--amber);
+}
+
+/* ── Grid ────────────────────────────────────────── */
+.slide[data-type="grid"] .grid-layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: var(--space-4);
+  margin-top: var(--space-4);
+}
+
+.grid-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5);
+  transition: all var(--transition-normal);
+}
+
+.grid-card:hover {
+  box-shadow: var(--shadow-md);
+  transform: translateY(-2px);
+  border-color: var(--accent);
+}
+
+.grid-card.highlight {
+  border-color: var(--amber);
+  box-shadow: 0 0 0 1px var(--amber), var(--shadow-sm);
+}
+
+.grid-card-title {
+  font-weight: 700;
+  color: var(--text-primary);
+  font-size: 1.05em;
+  margin-bottom: var(--space-2);
+}
+
+.grid-card-body {
+  color: var(--text-secondary);
+  font-size: 0.9em;
+  line-height: 1.5;
+}
+
+/* ── Split ───────────────────────────────────────── */
+.slide[data-type="split"] .split-layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-8);
+  margin-top: var(--space-4);
+}
+
+@media (max-width: 768px) {
+  .slide[data-type="split"] .split-layout { grid-template-columns: 1fr; }
+}
+
+/* ── Comparison ──────────────────────────────────── */
+.slide[data-type="comparison"] .comparison-layout {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: var(--space-6);
+  align-items: start;
+  margin-top: var(--space-4);
+}
+
+.vs-left, .vs-right {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+}
+
+.vs-divider {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5em;
+  font-weight: 800;
+  color: var(--text-muted);
+  align-self: center;
+}
+
+@media (max-width: 768px) {
+  .slide[data-type="comparison"] .comparison-layout {
+    grid-template-columns: 1fr;
+  }
+  .vs-divider { display: none; }
+}
+
+/* ── Quote ───────────────────────────────────────── */
+.slide[data-type="quote"] {
+  text-align: center;
+}
+
+.quote-text {
+  font-size: 1.5em;
+  font-weight: 300;
+  font-style: italic;
+  color: var(--text-primary);
+  max-width: 80%;
+  line-height: 1.5;
+  position: relative;
+  padding: 0.5em 1em;
+  margin: 0 auto;
+}
+
+.quote-text::before {
+  content: '\201C';
+  position: absolute;
+  left: -0.3em;
+  top: -0.2em;
+  font-size: 3.5em;
+  color: var(--amber);
+  font-weight: 800;
+  line-height: 1;
+  opacity: 0.3;
+}
+
+.quote-source {
+  margin-top: var(--space-4);
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  font-weight: 500;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.quote-source::before { content: '\2014\00a0'; }
+
+/* ── Key Fact ────────────────────────────────────── */
+.slide[data-type="keyfact"] {
+  text-align: center;
+}
+
+.slide[data-type="keyfact"] p {
+  font-size: 1.5em;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.35;
+}
+
+.slide[data-type="keyfact"] strong {
+  color: var(--amber-dark);
+}
+
+[data-theme="dark"] .slide[data-type="keyfact"] strong {
+  color: var(--amber);
+}
+
+/* ── Hero ────────────────────────────────────────── */
+.slide[data-type="hero"] {
+  text-align: center;
+}
+
+/* ── Example / Code ──────────────────────────────── */
+.slide[data-type="example"] {
+  border-left: 4px solid var(--info);
+}
+
+.slide[data-type="code"] pre,
+.slide pre {
+  background: var(--gray-900);
+  color: #E6EDF3;
+  border-radius: var(--radius-md);
+  padding: var(--space-4) var(--space-5);
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  line-height: 1.55;
+  margin: var(--space-3) 0;
+  box-shadow: var(--shadow-sm);
+}
+
+.slide[data-type="code"] pre code,
+.slide pre code {
+  background: none;
+  color: inherit;
+  padding: 0;
+  font-family: var(--font-mono);
+}
+
+.slide code {
+  font-family: var(--font-mono);
+  background: var(--bg-secondary);
+  color: var(--navy);
+  padding: 0.1em 0.35em;
+  border-radius: var(--radius-sm);
+  font-size: 0.9em;
+}
+
+[data-theme="dark"] .slide code {
+  color: var(--accent-light);
+  background: var(--gray-800);
+}
+
+.slide .code-caption {
+  color: var(--text-muted);
+  font-size: 0.85em;
+  font-style: italic;
+  margin-top: var(--space-2);
+}
+
+/* ── Definition Cards ────────────────────────────── */
+.def-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-left: 4px solid var(--navy-light);
+  border-radius: 0 var(--radius-lg) var(--radius-lg) 0;
+  padding: var(--space-4) var(--space-5);
+  margin-bottom: var(--space-3);
+  transition: border-color var(--transition-fast);
+}
+
+.def-card.highlight {
+  border-left-color: var(--amber);
+}
+
+.def-term {
+  font-size: var(--text-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--navy-light);
+  margin-bottom: var(--space-2);
+}
+
+[data-theme="dark"] .def-term { color: var(--accent); }
+
+.def-text {
+  color: var(--text-primary);
+  line-height: 1.5;
+}
+
+/* ── Callouts on slides ──────────────────────────── */
+.slide .callout {
+  margin: var(--space-4) 0;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* ── Tables ──────────────────────────────────────── */
+.slide table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  margin: var(--space-4) 0;
+  font-size: 0.92em;
+}
+
+.slide table th {
+  background: var(--navy);
+  color: white;
+  padding: var(--space-3) var(--space-4);
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.9em;
+}
+
+.slide table td {
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border-color);
+  color: var(--text-secondary);
+}
+
+.slide table tr:nth-child(even) { background: var(--bg-secondary); }
+.slide table tr:last-child td { border-bottom: none; }
+
+/* ── Two-Column Layout ───────────────────────────── */
+.two-col {
+  display: flex;
+  gap: var(--space-8);
+  align-items: flex-start;
+}
+
+.col { flex: 1; min-width: 0; }
+
+@media (max-width: 768px) {
+  .two-col { flex-direction: column; gap: var(--space-4); }
+}
+
+/* ── ASCII-art / diagram ─────────────────────────── */
+.slide .diagram {
+  background: var(--gray-900);
+  color: #C9D1D9;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  line-height: 1.4;
+  padding: var(--space-4) var(--space-5);
+  border-radius: var(--radius-md);
+  white-space: pre;
+  overflow-x: auto;
+  margin: var(--space-3) 0;
+}
+
+/* ── Font Controls ───────────────────────────────── */
+.font-controls {
+  position: fixed;
+  bottom: var(--space-6);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: var(--space-2);
+  z-index: 100;
+  background: var(--bg-card);
+  padding: var(--space-2);
+  border-radius: 9999px;
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-md);
+  opacity: 0.5;
+  transition: opacity var(--transition-fast);
+}
+
+.font-controls:hover { opacity: 1; }
+
+.font-controls button {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.font-controls button:hover {
+  background: var(--navy);
+  color: white;
+  border-color: var(--navy);
+}
+
+/* ── Animations ──────────────────────────────────── */
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Print ───────────────────────────────────────── */
+@media print {
+  .progress-strip, .font-controls { display: none !important; }
+  .slide-viewport { position: static; overflow: visible; }
+  .slide {
+    display: block !important;
+    position: static !important;
+    page-break-after: always;
+    padding: 2cm;
+  }
+  .slide[data-type="section-title"] {
+    background: var(--navy) !important;
+    color: white !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+  .slide pre {
+    background: var(--gray-100) !important;
+    color: var(--gray-900) !important;
+    border: 1px solid var(--gray-400);
+  }
+}
+  </style>
+  <!-- END-INLINED-STYLES -->
 </head>
 <body>
   <nav class="progress-strip">
@@ -1143,5 +1953,148 @@ Session 2  ───────────────────────
 
 })();
 </script>
+
+  <!-- BEGIN-INLINED-SCRIPT -->
+<script>
+/* ADK Course — Slide Engine
+   Adapted from barcik-training-exin-ai-foundation/slides/js/slides.js.
+   Per-module decks; lightweight nav with keyboard, touch, hash routing,
+   font controls, theme toggle. */
+
+(function () {
+  'use strict';
+
+  const slides = document.querySelectorAll('.slide');
+  const total = slides.length;
+  let current = 0;
+
+  function goTo(index) {
+    if (index < 0 || index >= total) return;
+    slides[current].classList.remove('active');
+    current = index;
+    slides[current].classList.add('active');
+    updateCounter();
+    window.scrollTo(0, 0);
+    history.replaceState(null, '', '#slide-' + (current + 1));
+  }
+
+  function next() { goTo(current + 1); }
+  function prev() { goTo(current - 1); }
+
+  document.addEventListener('keydown', function (e) {
+    if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+      case ' ':
+        e.preventDefault();
+        next();
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        e.preventDefault();
+        prev();
+        break;
+      case 'Home':
+        e.preventDefault();
+        goTo(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        goTo(total - 1);
+        break;
+    }
+  });
+
+  var viewport = document.querySelector('.slide-viewport');
+  if (viewport) {
+    viewport.addEventListener('click', function (e) {
+      if (e.target === this || e.target.classList.contains('slide')) {
+        var rect = this.getBoundingClientRect();
+        var x = e.clientX - rect.left;
+        if (x > rect.width * 0.75) next();
+        else if (x < rect.width * 0.25) prev();
+      }
+    });
+  }
+
+  var counter = document.querySelector('.slide-counter');
+  function updateCounter() {
+    if (counter) counter.textContent = (current + 1) + ' / ' + total;
+  }
+
+  var baseFontSize = parseInt(localStorage.getItem('adkSlideFontSize')) || 18;
+  applyFontSize();
+
+  window.adjustFont = function (delta) {
+    if (delta === 0) {
+      baseFontSize = 18;
+    } else {
+      baseFontSize = Math.max(14, Math.min(28, baseFontSize + delta));
+    }
+    applyFontSize();
+    localStorage.setItem('adkSlideFontSize', baseFontSize);
+  };
+
+  function applyFontSize() {
+    document.documentElement.style.setProperty('--slide-font-size', baseFontSize + 'px');
+  }
+
+  var themeBtn = document.querySelector('.theme-toggle');
+  var savedTheme = localStorage.getItem('adkTheme');
+  if (savedTheme) {
+    document.documentElement.setAttribute('data-theme', savedTheme);
+  }
+
+  if (themeBtn) {
+    themeBtn.addEventListener('click', function () {
+      var html = document.documentElement;
+      var nextTheme = html.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+      html.setAttribute('data-theme', nextTheme);
+      localStorage.setItem('adkTheme', nextTheme);
+    });
+  }
+
+  var touchStartX = 0;
+  var touchStartY = 0;
+
+  document.addEventListener('touchstart', function (e) {
+    touchStartX = e.changedTouches[0].screenX;
+    touchStartY = e.changedTouches[0].screenY;
+  }, { passive: true });
+
+  document.addEventListener('touchend', function (e) {
+    var dx = e.changedTouches[0].screenX - touchStartX;
+    var dy = e.changedTouches[0].screenY - touchStartY;
+    if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > 50) {
+      if (dx < 0) next();
+      else prev();
+    }
+  }, { passive: true });
+
+  var hash = window.location.hash;
+  if (hash && hash.startsWith('#slide-')) {
+    var n = parseInt(hash.replace('#slide-', ''));
+    if (!isNaN(n) && n >= 1 && n <= total) {
+      current = n - 1;
+    }
+  }
+
+  slides[current].classList.add('active');
+  updateCounter();
+
+  window.addEventListener('hashchange', function () {
+    var h = window.location.hash;
+    if (h && h.startsWith('#slide-')) {
+      var n = parseInt(h.replace('#slide-', ''));
+      if (!isNaN(n) && n >= 1 && n <= total && n - 1 !== current) {
+        goTo(n - 1);
+      }
+    }
+  });
+
+})();
+</script>
+<!-- END-INLINED-SCRIPT -->
 </body>
 </html>

--- a/slides/module-04-model-swap/index.html
+++ b/slides/module-04-model-swap/index.html
@@ -796,6 +796,816 @@ body {
   }
 }
   </style>
+
+  <!-- BEGIN-INLINED-STYLES -->
+  <style>
+  /* shared.css — generated; edit slides/shared/shared.css */
+/* ADK Course — Shared Design Tokens
+   Adapted from barcik-training-exin-ai-foundation/css/shared.css.
+   Family-consistent navy with amber accent (distinct from EXIN gold). */
+
+@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;500;600;700;800&display=swap');
+
+:root {
+  /* Brand colors */
+  --navy: #1E3A5F;
+  --navy-light: #2A5280;
+  --navy-dark: #122542;
+  --amber: #F59E0B;
+  --amber-light: #FBBF24;
+  --amber-dark: #B45309;
+  --white: #FFFFFF;
+  --gray-50: #F8F9FA;
+  --gray-100: #F1F3F5;
+  --gray-200: #E9ECEF;
+  --gray-300: #DEE2E6;
+  --gray-400: #CED4DA;
+  --gray-500: #ADB5BD;
+  --gray-600: #868E96;
+  --gray-700: #495057;
+  --gray-800: #343A40;
+  --gray-900: #212529;
+
+  /* Semantic */
+  --bg-primary: var(--white);
+  --bg-secondary: var(--gray-50);
+  --bg-card: var(--white);
+  --text-primary: var(--gray-900);
+  --text-secondary: var(--gray-700);
+  --text-muted: var(--gray-600);
+  --border-color: var(--gray-200);
+  --accent: var(--navy);
+  --accent-light: var(--navy-light);
+  --highlight: var(--amber);
+  --highlight-bg: #FEF3C7;
+  --success: #2E7D32;
+  --success-bg: #E8F5E9;
+  --error: #C62828;
+  --error-bg: #FFEBEE;
+  --info: #1565C0;
+  --info-bg: #E3F2FD;
+
+  /* Typography */
+  --font-sans: 'Nunito', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+  --text-3xl: 1.875rem;
+  --text-4xl: 2.25rem;
+
+  /* Spacing */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-10: 2.5rem;
+  --space-12: 3rem;
+  --space-16: 4rem;
+
+  /* Radius */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.07);
+  --shadow-lg: 0 10px 15px rgba(0,0,0,0.1);
+
+  /* Transitions */
+  --transition-fast: 150ms ease;
+  --transition-normal: 250ms ease;
+  --transition-slow: 350ms ease;
+}
+
+[data-theme="dark"] {
+  --bg-primary: #0D1117;
+  --bg-secondary: #161B22;
+  --bg-card: #1C2128;
+  --text-primary: #E6EDF3;
+  --text-secondary: #B1BAC4;
+  --text-muted: #8B949E;
+  --border-color: #30363D;
+  --accent: #58A6FF;
+  --accent-light: #79C0FF;
+  --highlight: var(--amber);
+  --highlight-bg: #2D2200;
+  --success: #56D364;
+  --success-bg: #0D2818;
+  --error: #F85149;
+  --error-bg: #2D1214;
+  --info: #58A6FF;
+  --info-bg: #0D1B2E;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.3);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.4);
+  --shadow-lg: 0 10px 15px rgba(0,0,0,0.5);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg-primary: #0D1117;
+    --bg-secondary: #161B22;
+    --bg-card: #1C2128;
+    --text-primary: #E6EDF3;
+    --text-secondary: #B1BAC4;
+    --text-muted: #8B949E;
+    --border-color: #30363D;
+    --accent: #58A6FF;
+    --accent-light: #79C0FF;
+    --highlight: var(--amber);
+    --highlight-bg: #2D2200;
+    --success: #56D364;
+    --success-bg: #0D2818;
+    --error: #F85149;
+    --error-bg: #2D1214;
+    --info: #58A6FF;
+    --info-bg: #0D1B2E;
+  }
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  line-height: 1.6;
+  color: var(--text-primary);
+  background-color: var(--bg-primary);
+  -webkit-font-smoothing: antialiased;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow var(--transition-normal);
+}
+
+.card:hover {
+  box-shadow: var(--shadow-md);
+}
+
+.callout {
+  padding: var(--space-4) var(--space-6);
+  border-radius: var(--radius-md);
+  margin: var(--space-4) 0;
+  border-left: 4px solid;
+}
+
+.callout-key { background: var(--highlight-bg); border-color: var(--amber); }
+.callout-gotcha { background: var(--error-bg); border-color: var(--error); }
+.callout-tip { background: var(--info-bg); border-color: var(--info); }
+.callout-success { background: var(--success-bg); border-color: var(--success); }
+
+.callout-title {
+  font-weight: 700;
+  font-size: var(--text-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: var(--space-2);
+}
+
+.text-center { text-align: center; }
+.text-muted { color: var(--text-muted); }
+.font-mono { font-family: var(--font-mono); }
+.mt-4 { margin-top: var(--space-4); }
+.mt-8 { margin-top: var(--space-8); }
+.mb-4 { margin-bottom: var(--space-4); }
+.mb-8 { margin-bottom: var(--space-8); }
+.mx-auto { margin-left: auto; margin-right: auto; }
+.max-w-4xl { max-width: 56rem; }
+.hidden { display: none !important; }
+  /* slides.css — generated; edit slides/shared/slides.css */
+/* ADK Course — Slide Presentation Theme
+   Adapted from barcik-training-exin-ai-foundation/slides/css/slides.css.
+   Adds data-type="code" slide variant for Python snippets. */
+
+:root {
+  --slide-font-size: 18px;
+  --strip-height: 48px;
+}
+
+body {
+  margin: 0;
+  overflow: hidden;
+  background: var(--bg-primary);
+}
+
+/* ── Progress Strip ──────────────────────────────── */
+.progress-strip {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  height: var(--strip-height);
+  background: var(--navy);
+  display: flex;
+  align-items: center;
+  z-index: 100;
+  padding: 0 var(--space-4);
+  gap: var(--space-4);
+  box-shadow: var(--shadow-md);
+  font-family: var(--font-sans);
+}
+
+.progress-home {
+  color: var(--amber);
+  text-decoration: none;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: var(--radius-md);
+  white-space: nowrap;
+  transition: all var(--transition-fast);
+}
+
+.progress-home:hover {
+  background: rgba(255,255,255,0.1);
+  border-color: var(--amber);
+}
+
+.progress-title {
+  color: rgba(255,255,255,0.85);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  flex: 1;
+  text-align: center;
+}
+
+.progress-title .quick-path-badge {
+  display: inline-block;
+  background: var(--amber);
+  color: var(--navy-dark);
+  font-size: 0.68rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.15rem 0.55rem;
+  border-radius: 9999px;
+  margin-left: 0.6rem;
+  vertical-align: 2px;
+}
+
+.progress-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.slide-counter {
+  color: rgba(255,255,255,0.6);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  font-family: var(--font-mono);
+  white-space: nowrap;
+}
+
+.progress-strip .theme-toggle {
+  background: rgba(255,255,255,0.1);
+  color: rgba(255,255,255,0.7);
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: var(--radius-md);
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-xs);
+  cursor: pointer;
+  font-family: var(--font-sans);
+  transition: all var(--transition-fast);
+}
+
+.progress-strip .theme-toggle:hover {
+  background: rgba(255,255,255,0.2);
+  color: white;
+}
+
+/* ── Viewport ────────────────────────────────────── */
+.slide-viewport {
+  position: fixed;
+  top: var(--strip-height);
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow: hidden;
+}
+
+/* ── Slide Base ──────────────────────────────────── */
+.slide {
+  display: none;
+  position: absolute;
+  inset: 0;
+  overflow-y: auto;
+  padding: var(--space-10) var(--space-16);
+  font-size: var(--slide-font-size);
+  line-height: 1.6;
+  font-family: var(--font-sans);
+  color: var(--text-primary);
+  background: var(--bg-primary);
+}
+
+.slide.active {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  animation: fadeIn 0.25s ease;
+}
+
+.slide > * {
+  max-width: 1100px;
+  width: 100% !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
+  box-sizing: border-box;
+  text-align: inherit;
+}
+
+.slide > .topic-badge {
+  width: auto !important;
+  max-width: none;
+  align-self: center;
+}
+
+/* ── Section Title ───────────────────────────────── */
+.slide[data-type="section-title"] {
+  background: linear-gradient(135deg, var(--navy) 0%, var(--navy-light) 100%);
+  text-align: center;
+}
+
+.slide[data-type="section-title"] h1,
+.slide[data-type="section-title"] h2,
+.slide[data-type="section-title"] h3 {
+  color: white;
+}
+
+.slide[data-type="section-title"] p {
+  color: rgba(255,255,255,0.85);
+}
+
+.slide[data-type="section-title"] .topic-badge {
+  display: inline-block;
+  background: var(--amber);
+  color: var(--navy-dark);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  padding: var(--space-2) var(--space-4);
+  border-radius: 9999px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: var(--space-4);
+  width: auto !important;
+}
+
+.slide[data-type="section-title"] .highlight-text {
+  color: var(--amber);
+  font-weight: 600;
+}
+
+/* ── Typography ──────────────────────────────────── */
+.slide h1 {
+  font-size: 2.4em;
+  font-weight: 800;
+  color: var(--navy);
+  margin-bottom: var(--space-4);
+  line-height: 1.15;
+}
+
+.slide h2 {
+  font-size: 1.6em;
+  font-weight: 700;
+  color: var(--navy);
+  margin-bottom: var(--space-4);
+  padding-bottom: var(--space-2);
+  border-bottom: 3px solid var(--amber);
+}
+
+.slide h3 {
+  font-size: 1.2em;
+  font-weight: 600;
+  color: var(--navy-light);
+  margin-bottom: var(--space-3);
+}
+
+.slide p {
+  margin-bottom: var(--space-3);
+  color: var(--text-secondary);
+}
+
+.slide strong {
+  color: var(--navy);
+  font-weight: 700;
+}
+
+.slide em {
+  color: var(--amber-dark);
+  font-style: italic;
+}
+
+.slide ul, .slide ol {
+  margin-left: 1.2em;
+  margin-bottom: var(--space-4);
+}
+
+.slide li {
+  margin-bottom: var(--space-2);
+  color: var(--text-secondary);
+}
+
+.slide li::marker {
+  color: var(--amber);
+}
+
+[data-theme="dark"] .slide h1,
+[data-theme="dark"] .slide h2 { color: var(--text-primary); }
+[data-theme="dark"] .slide h3 { color: var(--text-secondary); }
+[data-theme="dark"] .slide strong { color: var(--text-primary); }
+[data-theme="dark"] .slide h2 { border-bottom-color: var(--amber); }
+
+.highlight-text {
+  color: var(--amber-dark);
+  font-weight: 600;
+}
+
+[data-theme="dark"] .highlight-text {
+  color: var(--amber);
+}
+
+/* ── Grid ────────────────────────────────────────── */
+.slide[data-type="grid"] .grid-layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: var(--space-4);
+  margin-top: var(--space-4);
+}
+
+.grid-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5);
+  transition: all var(--transition-normal);
+}
+
+.grid-card:hover {
+  box-shadow: var(--shadow-md);
+  transform: translateY(-2px);
+  border-color: var(--accent);
+}
+
+.grid-card.highlight {
+  border-color: var(--amber);
+  box-shadow: 0 0 0 1px var(--amber), var(--shadow-sm);
+}
+
+.grid-card-title {
+  font-weight: 700;
+  color: var(--text-primary);
+  font-size: 1.05em;
+  margin-bottom: var(--space-2);
+}
+
+.grid-card-body {
+  color: var(--text-secondary);
+  font-size: 0.9em;
+  line-height: 1.5;
+}
+
+/* ── Split ───────────────────────────────────────── */
+.slide[data-type="split"] .split-layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-8);
+  margin-top: var(--space-4);
+}
+
+@media (max-width: 768px) {
+  .slide[data-type="split"] .split-layout { grid-template-columns: 1fr; }
+}
+
+/* ── Comparison ──────────────────────────────────── */
+.slide[data-type="comparison"] .comparison-layout {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: var(--space-6);
+  align-items: start;
+  margin-top: var(--space-4);
+}
+
+.vs-left, .vs-right {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+}
+
+.vs-divider {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5em;
+  font-weight: 800;
+  color: var(--text-muted);
+  align-self: center;
+}
+
+@media (max-width: 768px) {
+  .slide[data-type="comparison"] .comparison-layout {
+    grid-template-columns: 1fr;
+  }
+  .vs-divider { display: none; }
+}
+
+/* ── Quote ───────────────────────────────────────── */
+.slide[data-type="quote"] {
+  text-align: center;
+}
+
+.quote-text {
+  font-size: 1.5em;
+  font-weight: 300;
+  font-style: italic;
+  color: var(--text-primary);
+  max-width: 80%;
+  line-height: 1.5;
+  position: relative;
+  padding: 0.5em 1em;
+  margin: 0 auto;
+}
+
+.quote-text::before {
+  content: '\201C';
+  position: absolute;
+  left: -0.3em;
+  top: -0.2em;
+  font-size: 3.5em;
+  color: var(--amber);
+  font-weight: 800;
+  line-height: 1;
+  opacity: 0.3;
+}
+
+.quote-source {
+  margin-top: var(--space-4);
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  font-weight: 500;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.quote-source::before { content: '\2014\00a0'; }
+
+/* ── Key Fact ────────────────────────────────────── */
+.slide[data-type="keyfact"] {
+  text-align: center;
+}
+
+.slide[data-type="keyfact"] p {
+  font-size: 1.5em;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.35;
+}
+
+.slide[data-type="keyfact"] strong {
+  color: var(--amber-dark);
+}
+
+[data-theme="dark"] .slide[data-type="keyfact"] strong {
+  color: var(--amber);
+}
+
+/* ── Hero ────────────────────────────────────────── */
+.slide[data-type="hero"] {
+  text-align: center;
+}
+
+/* ── Example / Code ──────────────────────────────── */
+.slide[data-type="example"] {
+  border-left: 4px solid var(--info);
+}
+
+.slide[data-type="code"] pre,
+.slide pre {
+  background: var(--gray-900);
+  color: #E6EDF3;
+  border-radius: var(--radius-md);
+  padding: var(--space-4) var(--space-5);
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  line-height: 1.55;
+  margin: var(--space-3) 0;
+  box-shadow: var(--shadow-sm);
+}
+
+.slide[data-type="code"] pre code,
+.slide pre code {
+  background: none;
+  color: inherit;
+  padding: 0;
+  font-family: var(--font-mono);
+}
+
+.slide code {
+  font-family: var(--font-mono);
+  background: var(--bg-secondary);
+  color: var(--navy);
+  padding: 0.1em 0.35em;
+  border-radius: var(--radius-sm);
+  font-size: 0.9em;
+}
+
+[data-theme="dark"] .slide code {
+  color: var(--accent-light);
+  background: var(--gray-800);
+}
+
+.slide .code-caption {
+  color: var(--text-muted);
+  font-size: 0.85em;
+  font-style: italic;
+  margin-top: var(--space-2);
+}
+
+/* ── Definition Cards ────────────────────────────── */
+.def-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-left: 4px solid var(--navy-light);
+  border-radius: 0 var(--radius-lg) var(--radius-lg) 0;
+  padding: var(--space-4) var(--space-5);
+  margin-bottom: var(--space-3);
+  transition: border-color var(--transition-fast);
+}
+
+.def-card.highlight {
+  border-left-color: var(--amber);
+}
+
+.def-term {
+  font-size: var(--text-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--navy-light);
+  margin-bottom: var(--space-2);
+}
+
+[data-theme="dark"] .def-term { color: var(--accent); }
+
+.def-text {
+  color: var(--text-primary);
+  line-height: 1.5;
+}
+
+/* ── Callouts on slides ──────────────────────────── */
+.slide .callout {
+  margin: var(--space-4) 0;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* ── Tables ──────────────────────────────────────── */
+.slide table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  margin: var(--space-4) 0;
+  font-size: 0.92em;
+}
+
+.slide table th {
+  background: var(--navy);
+  color: white;
+  padding: var(--space-3) var(--space-4);
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.9em;
+}
+
+.slide table td {
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border-color);
+  color: var(--text-secondary);
+}
+
+.slide table tr:nth-child(even) { background: var(--bg-secondary); }
+.slide table tr:last-child td { border-bottom: none; }
+
+/* ── Two-Column Layout ───────────────────────────── */
+.two-col {
+  display: flex;
+  gap: var(--space-8);
+  align-items: flex-start;
+}
+
+.col { flex: 1; min-width: 0; }
+
+@media (max-width: 768px) {
+  .two-col { flex-direction: column; gap: var(--space-4); }
+}
+
+/* ── ASCII-art / diagram ─────────────────────────── */
+.slide .diagram {
+  background: var(--gray-900);
+  color: #C9D1D9;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  line-height: 1.4;
+  padding: var(--space-4) var(--space-5);
+  border-radius: var(--radius-md);
+  white-space: pre;
+  overflow-x: auto;
+  margin: var(--space-3) 0;
+}
+
+/* ── Font Controls ───────────────────────────────── */
+.font-controls {
+  position: fixed;
+  bottom: var(--space-6);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: var(--space-2);
+  z-index: 100;
+  background: var(--bg-card);
+  padding: var(--space-2);
+  border-radius: 9999px;
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-md);
+  opacity: 0.5;
+  transition: opacity var(--transition-fast);
+}
+
+.font-controls:hover { opacity: 1; }
+
+.font-controls button {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.font-controls button:hover {
+  background: var(--navy);
+  color: white;
+  border-color: var(--navy);
+}
+
+/* ── Animations ──────────────────────────────────── */
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Print ───────────────────────────────────────── */
+@media print {
+  .progress-strip, .font-controls { display: none !important; }
+  .slide-viewport { position: static; overflow: visible; }
+  .slide {
+    display: block !important;
+    position: static !important;
+    page-break-after: always;
+    padding: 2cm;
+  }
+  .slide[data-type="section-title"] {
+    background: var(--navy) !important;
+    color: white !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+  .slide pre {
+    background: var(--gray-100) !important;
+    color: var(--gray-900) !important;
+    border: 1px solid var(--gray-400);
+  }
+}
+  </style>
+  <!-- END-INLINED-STYLES -->
 </head>
 <body>
   <nav class="progress-strip">
@@ -1140,5 +1950,148 @@ explain in 2-3 sentences.
 
 })();
 </script>
+
+  <!-- BEGIN-INLINED-SCRIPT -->
+<script>
+/* ADK Course — Slide Engine
+   Adapted from barcik-training-exin-ai-foundation/slides/js/slides.js.
+   Per-module decks; lightweight nav with keyboard, touch, hash routing,
+   font controls, theme toggle. */
+
+(function () {
+  'use strict';
+
+  const slides = document.querySelectorAll('.slide');
+  const total = slides.length;
+  let current = 0;
+
+  function goTo(index) {
+    if (index < 0 || index >= total) return;
+    slides[current].classList.remove('active');
+    current = index;
+    slides[current].classList.add('active');
+    updateCounter();
+    window.scrollTo(0, 0);
+    history.replaceState(null, '', '#slide-' + (current + 1));
+  }
+
+  function next() { goTo(current + 1); }
+  function prev() { goTo(current - 1); }
+
+  document.addEventListener('keydown', function (e) {
+    if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+      case ' ':
+        e.preventDefault();
+        next();
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        e.preventDefault();
+        prev();
+        break;
+      case 'Home':
+        e.preventDefault();
+        goTo(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        goTo(total - 1);
+        break;
+    }
+  });
+
+  var viewport = document.querySelector('.slide-viewport');
+  if (viewport) {
+    viewport.addEventListener('click', function (e) {
+      if (e.target === this || e.target.classList.contains('slide')) {
+        var rect = this.getBoundingClientRect();
+        var x = e.clientX - rect.left;
+        if (x > rect.width * 0.75) next();
+        else if (x < rect.width * 0.25) prev();
+      }
+    });
+  }
+
+  var counter = document.querySelector('.slide-counter');
+  function updateCounter() {
+    if (counter) counter.textContent = (current + 1) + ' / ' + total;
+  }
+
+  var baseFontSize = parseInt(localStorage.getItem('adkSlideFontSize')) || 18;
+  applyFontSize();
+
+  window.adjustFont = function (delta) {
+    if (delta === 0) {
+      baseFontSize = 18;
+    } else {
+      baseFontSize = Math.max(14, Math.min(28, baseFontSize + delta));
+    }
+    applyFontSize();
+    localStorage.setItem('adkSlideFontSize', baseFontSize);
+  };
+
+  function applyFontSize() {
+    document.documentElement.style.setProperty('--slide-font-size', baseFontSize + 'px');
+  }
+
+  var themeBtn = document.querySelector('.theme-toggle');
+  var savedTheme = localStorage.getItem('adkTheme');
+  if (savedTheme) {
+    document.documentElement.setAttribute('data-theme', savedTheme);
+  }
+
+  if (themeBtn) {
+    themeBtn.addEventListener('click', function () {
+      var html = document.documentElement;
+      var nextTheme = html.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+      html.setAttribute('data-theme', nextTheme);
+      localStorage.setItem('adkTheme', nextTheme);
+    });
+  }
+
+  var touchStartX = 0;
+  var touchStartY = 0;
+
+  document.addEventListener('touchstart', function (e) {
+    touchStartX = e.changedTouches[0].screenX;
+    touchStartY = e.changedTouches[0].screenY;
+  }, { passive: true });
+
+  document.addEventListener('touchend', function (e) {
+    var dx = e.changedTouches[0].screenX - touchStartX;
+    var dy = e.changedTouches[0].screenY - touchStartY;
+    if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > 50) {
+      if (dx < 0) next();
+      else prev();
+    }
+  }, { passive: true });
+
+  var hash = window.location.hash;
+  if (hash && hash.startsWith('#slide-')) {
+    var n = parseInt(hash.replace('#slide-', ''));
+    if (!isNaN(n) && n >= 1 && n <= total) {
+      current = n - 1;
+    }
+  }
+
+  slides[current].classList.add('active');
+  updateCounter();
+
+  window.addEventListener('hashchange', function () {
+    var h = window.location.hash;
+    if (h && h.startsWith('#slide-')) {
+      var n = parseInt(h.replace('#slide-', ''));
+      if (!isNaN(n) && n >= 1 && n <= total && n - 1 !== current) {
+        goTo(n - 1);
+      }
+    }
+  });
+
+})();
+</script>
+<!-- END-INLINED-SCRIPT -->
 </body>
 </html>

--- a/slides/module-05-workflow-agents/index.html
+++ b/slides/module-05-workflow-agents/index.html
@@ -796,11 +796,821 @@ body {
   }
 }
   </style>
+
+  <!-- BEGIN-INLINED-STYLES -->
+  <style>
+  /* shared.css — generated; edit slides/shared/shared.css */
+/* ADK Course — Shared Design Tokens
+   Adapted from barcik-training-exin-ai-foundation/css/shared.css.
+   Family-consistent navy with amber accent (distinct from EXIN gold). */
+
+@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;500;600;700;800&display=swap');
+
+:root {
+  /* Brand colors */
+  --navy: #1E3A5F;
+  --navy-light: #2A5280;
+  --navy-dark: #122542;
+  --amber: #F59E0B;
+  --amber-light: #FBBF24;
+  --amber-dark: #B45309;
+  --white: #FFFFFF;
+  --gray-50: #F8F9FA;
+  --gray-100: #F1F3F5;
+  --gray-200: #E9ECEF;
+  --gray-300: #DEE2E6;
+  --gray-400: #CED4DA;
+  --gray-500: #ADB5BD;
+  --gray-600: #868E96;
+  --gray-700: #495057;
+  --gray-800: #343A40;
+  --gray-900: #212529;
+
+  /* Semantic */
+  --bg-primary: var(--white);
+  --bg-secondary: var(--gray-50);
+  --bg-card: var(--white);
+  --text-primary: var(--gray-900);
+  --text-secondary: var(--gray-700);
+  --text-muted: var(--gray-600);
+  --border-color: var(--gray-200);
+  --accent: var(--navy);
+  --accent-light: var(--navy-light);
+  --highlight: var(--amber);
+  --highlight-bg: #FEF3C7;
+  --success: #2E7D32;
+  --success-bg: #E8F5E9;
+  --error: #C62828;
+  --error-bg: #FFEBEE;
+  --info: #1565C0;
+  --info-bg: #E3F2FD;
+
+  /* Typography */
+  --font-sans: 'Nunito', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+  --text-3xl: 1.875rem;
+  --text-4xl: 2.25rem;
+
+  /* Spacing */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-10: 2.5rem;
+  --space-12: 3rem;
+  --space-16: 4rem;
+
+  /* Radius */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.07);
+  --shadow-lg: 0 10px 15px rgba(0,0,0,0.1);
+
+  /* Transitions */
+  --transition-fast: 150ms ease;
+  --transition-normal: 250ms ease;
+  --transition-slow: 350ms ease;
+}
+
+[data-theme="dark"] {
+  --bg-primary: #0D1117;
+  --bg-secondary: #161B22;
+  --bg-card: #1C2128;
+  --text-primary: #E6EDF3;
+  --text-secondary: #B1BAC4;
+  --text-muted: #8B949E;
+  --border-color: #30363D;
+  --accent: #58A6FF;
+  --accent-light: #79C0FF;
+  --highlight: var(--amber);
+  --highlight-bg: #2D2200;
+  --success: #56D364;
+  --success-bg: #0D2818;
+  --error: #F85149;
+  --error-bg: #2D1214;
+  --info: #58A6FF;
+  --info-bg: #0D1B2E;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.3);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.4);
+  --shadow-lg: 0 10px 15px rgba(0,0,0,0.5);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg-primary: #0D1117;
+    --bg-secondary: #161B22;
+    --bg-card: #1C2128;
+    --text-primary: #E6EDF3;
+    --text-secondary: #B1BAC4;
+    --text-muted: #8B949E;
+    --border-color: #30363D;
+    --accent: #58A6FF;
+    --accent-light: #79C0FF;
+    --highlight: var(--amber);
+    --highlight-bg: #2D2200;
+    --success: #56D364;
+    --success-bg: #0D2818;
+    --error: #F85149;
+    --error-bg: #2D1214;
+    --info: #58A6FF;
+    --info-bg: #0D1B2E;
+  }
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  line-height: 1.6;
+  color: var(--text-primary);
+  background-color: var(--bg-primary);
+  -webkit-font-smoothing: antialiased;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow var(--transition-normal);
+}
+
+.card:hover {
+  box-shadow: var(--shadow-md);
+}
+
+.callout {
+  padding: var(--space-4) var(--space-6);
+  border-radius: var(--radius-md);
+  margin: var(--space-4) 0;
+  border-left: 4px solid;
+}
+
+.callout-key { background: var(--highlight-bg); border-color: var(--amber); }
+.callout-gotcha { background: var(--error-bg); border-color: var(--error); }
+.callout-tip { background: var(--info-bg); border-color: var(--info); }
+.callout-success { background: var(--success-bg); border-color: var(--success); }
+
+.callout-title {
+  font-weight: 700;
+  font-size: var(--text-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: var(--space-2);
+}
+
+.text-center { text-align: center; }
+.text-muted { color: var(--text-muted); }
+.font-mono { font-family: var(--font-mono); }
+.mt-4 { margin-top: var(--space-4); }
+.mt-8 { margin-top: var(--space-8); }
+.mb-4 { margin-bottom: var(--space-4); }
+.mb-8 { margin-bottom: var(--space-8); }
+.mx-auto { margin-left: auto; margin-right: auto; }
+.max-w-4xl { max-width: 56rem; }
+.hidden { display: none !important; }
+  /* slides.css — generated; edit slides/shared/slides.css */
+/* ADK Course — Slide Presentation Theme
+   Adapted from barcik-training-exin-ai-foundation/slides/css/slides.css.
+   Adds data-type="code" slide variant for Python snippets. */
+
+:root {
+  --slide-font-size: 18px;
+  --strip-height: 48px;
+}
+
+body {
+  margin: 0;
+  overflow: hidden;
+  background: var(--bg-primary);
+}
+
+/* ── Progress Strip ──────────────────────────────── */
+.progress-strip {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  height: var(--strip-height);
+  background: var(--navy);
+  display: flex;
+  align-items: center;
+  z-index: 100;
+  padding: 0 var(--space-4);
+  gap: var(--space-4);
+  box-shadow: var(--shadow-md);
+  font-family: var(--font-sans);
+}
+
+.progress-home {
+  color: var(--amber);
+  text-decoration: none;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: var(--radius-md);
+  white-space: nowrap;
+  transition: all var(--transition-fast);
+}
+
+.progress-home:hover {
+  background: rgba(255,255,255,0.1);
+  border-color: var(--amber);
+}
+
+.progress-title {
+  color: rgba(255,255,255,0.85);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  flex: 1;
+  text-align: center;
+}
+
+.progress-title .quick-path-badge {
+  display: inline-block;
+  background: var(--amber);
+  color: var(--navy-dark);
+  font-size: 0.68rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.15rem 0.55rem;
+  border-radius: 9999px;
+  margin-left: 0.6rem;
+  vertical-align: 2px;
+}
+
+.progress-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.slide-counter {
+  color: rgba(255,255,255,0.6);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  font-family: var(--font-mono);
+  white-space: nowrap;
+}
+
+.progress-strip .theme-toggle {
+  background: rgba(255,255,255,0.1);
+  color: rgba(255,255,255,0.7);
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: var(--radius-md);
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-xs);
+  cursor: pointer;
+  font-family: var(--font-sans);
+  transition: all var(--transition-fast);
+}
+
+.progress-strip .theme-toggle:hover {
+  background: rgba(255,255,255,0.2);
+  color: white;
+}
+
+/* ── Viewport ────────────────────────────────────── */
+.slide-viewport {
+  position: fixed;
+  top: var(--strip-height);
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow: hidden;
+}
+
+/* ── Slide Base ──────────────────────────────────── */
+.slide {
+  display: none;
+  position: absolute;
+  inset: 0;
+  overflow-y: auto;
+  padding: var(--space-10) var(--space-16);
+  font-size: var(--slide-font-size);
+  line-height: 1.6;
+  font-family: var(--font-sans);
+  color: var(--text-primary);
+  background: var(--bg-primary);
+}
+
+.slide.active {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  animation: fadeIn 0.25s ease;
+}
+
+.slide > * {
+  max-width: 1100px;
+  width: 100% !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
+  box-sizing: border-box;
+  text-align: inherit;
+}
+
+.slide > .topic-badge {
+  width: auto !important;
+  max-width: none;
+  align-self: center;
+}
+
+/* ── Section Title ───────────────────────────────── */
+.slide[data-type="section-title"] {
+  background: linear-gradient(135deg, var(--navy) 0%, var(--navy-light) 100%);
+  text-align: center;
+}
+
+.slide[data-type="section-title"] h1,
+.slide[data-type="section-title"] h2,
+.slide[data-type="section-title"] h3 {
+  color: white;
+}
+
+.slide[data-type="section-title"] p {
+  color: rgba(255,255,255,0.85);
+}
+
+.slide[data-type="section-title"] .topic-badge {
+  display: inline-block;
+  background: var(--amber);
+  color: var(--navy-dark);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  padding: var(--space-2) var(--space-4);
+  border-radius: 9999px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: var(--space-4);
+  width: auto !important;
+}
+
+.slide[data-type="section-title"] .highlight-text {
+  color: var(--amber);
+  font-weight: 600;
+}
+
+/* ── Typography ──────────────────────────────────── */
+.slide h1 {
+  font-size: 2.4em;
+  font-weight: 800;
+  color: var(--navy);
+  margin-bottom: var(--space-4);
+  line-height: 1.15;
+}
+
+.slide h2 {
+  font-size: 1.6em;
+  font-weight: 700;
+  color: var(--navy);
+  margin-bottom: var(--space-4);
+  padding-bottom: var(--space-2);
+  border-bottom: 3px solid var(--amber);
+}
+
+.slide h3 {
+  font-size: 1.2em;
+  font-weight: 600;
+  color: var(--navy-light);
+  margin-bottom: var(--space-3);
+}
+
+.slide p {
+  margin-bottom: var(--space-3);
+  color: var(--text-secondary);
+}
+
+.slide strong {
+  color: var(--navy);
+  font-weight: 700;
+}
+
+.slide em {
+  color: var(--amber-dark);
+  font-style: italic;
+}
+
+.slide ul, .slide ol {
+  margin-left: 1.2em;
+  margin-bottom: var(--space-4);
+}
+
+.slide li {
+  margin-bottom: var(--space-2);
+  color: var(--text-secondary);
+}
+
+.slide li::marker {
+  color: var(--amber);
+}
+
+[data-theme="dark"] .slide h1,
+[data-theme="dark"] .slide h2 { color: var(--text-primary); }
+[data-theme="dark"] .slide h3 { color: var(--text-secondary); }
+[data-theme="dark"] .slide strong { color: var(--text-primary); }
+[data-theme="dark"] .slide h2 { border-bottom-color: var(--amber); }
+
+.highlight-text {
+  color: var(--amber-dark);
+  font-weight: 600;
+}
+
+[data-theme="dark"] .highlight-text {
+  color: var(--amber);
+}
+
+/* ── Grid ────────────────────────────────────────── */
+.slide[data-type="grid"] .grid-layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: var(--space-4);
+  margin-top: var(--space-4);
+}
+
+.grid-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5);
+  transition: all var(--transition-normal);
+}
+
+.grid-card:hover {
+  box-shadow: var(--shadow-md);
+  transform: translateY(-2px);
+  border-color: var(--accent);
+}
+
+.grid-card.highlight {
+  border-color: var(--amber);
+  box-shadow: 0 0 0 1px var(--amber), var(--shadow-sm);
+}
+
+.grid-card-title {
+  font-weight: 700;
+  color: var(--text-primary);
+  font-size: 1.05em;
+  margin-bottom: var(--space-2);
+}
+
+.grid-card-body {
+  color: var(--text-secondary);
+  font-size: 0.9em;
+  line-height: 1.5;
+}
+
+/* ── Split ───────────────────────────────────────── */
+.slide[data-type="split"] .split-layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-8);
+  margin-top: var(--space-4);
+}
+
+@media (max-width: 768px) {
+  .slide[data-type="split"] .split-layout { grid-template-columns: 1fr; }
+}
+
+/* ── Comparison ──────────────────────────────────── */
+.slide[data-type="comparison"] .comparison-layout {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: var(--space-6);
+  align-items: start;
+  margin-top: var(--space-4);
+}
+
+.vs-left, .vs-right {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+}
+
+.vs-divider {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5em;
+  font-weight: 800;
+  color: var(--text-muted);
+  align-self: center;
+}
+
+@media (max-width: 768px) {
+  .slide[data-type="comparison"] .comparison-layout {
+    grid-template-columns: 1fr;
+  }
+  .vs-divider { display: none; }
+}
+
+/* ── Quote ───────────────────────────────────────── */
+.slide[data-type="quote"] {
+  text-align: center;
+}
+
+.quote-text {
+  font-size: 1.5em;
+  font-weight: 300;
+  font-style: italic;
+  color: var(--text-primary);
+  max-width: 80%;
+  line-height: 1.5;
+  position: relative;
+  padding: 0.5em 1em;
+  margin: 0 auto;
+}
+
+.quote-text::before {
+  content: '\201C';
+  position: absolute;
+  left: -0.3em;
+  top: -0.2em;
+  font-size: 3.5em;
+  color: var(--amber);
+  font-weight: 800;
+  line-height: 1;
+  opacity: 0.3;
+}
+
+.quote-source {
+  margin-top: var(--space-4);
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  font-weight: 500;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.quote-source::before { content: '\2014\00a0'; }
+
+/* ── Key Fact ────────────────────────────────────── */
+.slide[data-type="keyfact"] {
+  text-align: center;
+}
+
+.slide[data-type="keyfact"] p {
+  font-size: 1.5em;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.35;
+}
+
+.slide[data-type="keyfact"] strong {
+  color: var(--amber-dark);
+}
+
+[data-theme="dark"] .slide[data-type="keyfact"] strong {
+  color: var(--amber);
+}
+
+/* ── Hero ────────────────────────────────────────── */
+.slide[data-type="hero"] {
+  text-align: center;
+}
+
+/* ── Example / Code ──────────────────────────────── */
+.slide[data-type="example"] {
+  border-left: 4px solid var(--info);
+}
+
+.slide[data-type="code"] pre,
+.slide pre {
+  background: var(--gray-900);
+  color: #E6EDF3;
+  border-radius: var(--radius-md);
+  padding: var(--space-4) var(--space-5);
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  line-height: 1.55;
+  margin: var(--space-3) 0;
+  box-shadow: var(--shadow-sm);
+}
+
+.slide[data-type="code"] pre code,
+.slide pre code {
+  background: none;
+  color: inherit;
+  padding: 0;
+  font-family: var(--font-mono);
+}
+
+.slide code {
+  font-family: var(--font-mono);
+  background: var(--bg-secondary);
+  color: var(--navy);
+  padding: 0.1em 0.35em;
+  border-radius: var(--radius-sm);
+  font-size: 0.9em;
+}
+
+[data-theme="dark"] .slide code {
+  color: var(--accent-light);
+  background: var(--gray-800);
+}
+
+.slide .code-caption {
+  color: var(--text-muted);
+  font-size: 0.85em;
+  font-style: italic;
+  margin-top: var(--space-2);
+}
+
+/* ── Definition Cards ────────────────────────────── */
+.def-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-left: 4px solid var(--navy-light);
+  border-radius: 0 var(--radius-lg) var(--radius-lg) 0;
+  padding: var(--space-4) var(--space-5);
+  margin-bottom: var(--space-3);
+  transition: border-color var(--transition-fast);
+}
+
+.def-card.highlight {
+  border-left-color: var(--amber);
+}
+
+.def-term {
+  font-size: var(--text-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--navy-light);
+  margin-bottom: var(--space-2);
+}
+
+[data-theme="dark"] .def-term { color: var(--accent); }
+
+.def-text {
+  color: var(--text-primary);
+  line-height: 1.5;
+}
+
+/* ── Callouts on slides ──────────────────────────── */
+.slide .callout {
+  margin: var(--space-4) 0;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* ── Tables ──────────────────────────────────────── */
+.slide table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  margin: var(--space-4) 0;
+  font-size: 0.92em;
+}
+
+.slide table th {
+  background: var(--navy);
+  color: white;
+  padding: var(--space-3) var(--space-4);
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.9em;
+}
+
+.slide table td {
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border-color);
+  color: var(--text-secondary);
+}
+
+.slide table tr:nth-child(even) { background: var(--bg-secondary); }
+.slide table tr:last-child td { border-bottom: none; }
+
+/* ── Two-Column Layout ───────────────────────────── */
+.two-col {
+  display: flex;
+  gap: var(--space-8);
+  align-items: flex-start;
+}
+
+.col { flex: 1; min-width: 0; }
+
+@media (max-width: 768px) {
+  .two-col { flex-direction: column; gap: var(--space-4); }
+}
+
+/* ── ASCII-art / diagram ─────────────────────────── */
+.slide .diagram {
+  background: var(--gray-900);
+  color: #C9D1D9;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  line-height: 1.4;
+  padding: var(--space-4) var(--space-5);
+  border-radius: var(--radius-md);
+  white-space: pre;
+  overflow-x: auto;
+  margin: var(--space-3) 0;
+}
+
+/* ── Font Controls ───────────────────────────────── */
+.font-controls {
+  position: fixed;
+  bottom: var(--space-6);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: var(--space-2);
+  z-index: 100;
+  background: var(--bg-card);
+  padding: var(--space-2);
+  border-radius: 9999px;
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-md);
+  opacity: 0.5;
+  transition: opacity var(--transition-fast);
+}
+
+.font-controls:hover { opacity: 1; }
+
+.font-controls button {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.font-controls button:hover {
+  background: var(--navy);
+  color: white;
+  border-color: var(--navy);
+}
+
+/* ── Animations ──────────────────────────────────── */
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Print ───────────────────────────────────────── */
+@media print {
+  .progress-strip, .font-controls { display: none !important; }
+  .slide-viewport { position: static; overflow: visible; }
+  .slide {
+    display: block !important;
+    position: static !important;
+    page-break-after: always;
+    padding: 2cm;
+  }
+  .slide[data-type="section-title"] {
+    background: var(--navy) !important;
+    color: white !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+  .slide pre {
+    background: var(--gray-100) !important;
+    color: var(--gray-900) !important;
+    border: 1px solid var(--gray-400);
+  }
+}
+  </style>
+  <!-- END-INLINED-STYLES -->
 </head>
 <body>
   <nav class="progress-strip">
     <a href="../../index.html" class="progress-home">Course</a>
-    <div class="progress-title">M05 — Workflow Agents</div>
+    <div class="progress-title">M05 — Workflow Agents<span class="quick-path-badge">⚡ Quick path</span></div>
     <div class="progress-meta">
       <span class="slide-counter">1 / 1</span>
       <button class="theme-toggle">Theme</button>
@@ -1212,5 +2022,148 @@ refiner = LoopAgent(
 
 })();
 </script>
+
+  <!-- BEGIN-INLINED-SCRIPT -->
+<script>
+/* ADK Course — Slide Engine
+   Adapted from barcik-training-exin-ai-foundation/slides/js/slides.js.
+   Per-module decks; lightweight nav with keyboard, touch, hash routing,
+   font controls, theme toggle. */
+
+(function () {
+  'use strict';
+
+  const slides = document.querySelectorAll('.slide');
+  const total = slides.length;
+  let current = 0;
+
+  function goTo(index) {
+    if (index < 0 || index >= total) return;
+    slides[current].classList.remove('active');
+    current = index;
+    slides[current].classList.add('active');
+    updateCounter();
+    window.scrollTo(0, 0);
+    history.replaceState(null, '', '#slide-' + (current + 1));
+  }
+
+  function next() { goTo(current + 1); }
+  function prev() { goTo(current - 1); }
+
+  document.addEventListener('keydown', function (e) {
+    if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+      case ' ':
+        e.preventDefault();
+        next();
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        e.preventDefault();
+        prev();
+        break;
+      case 'Home':
+        e.preventDefault();
+        goTo(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        goTo(total - 1);
+        break;
+    }
+  });
+
+  var viewport = document.querySelector('.slide-viewport');
+  if (viewport) {
+    viewport.addEventListener('click', function (e) {
+      if (e.target === this || e.target.classList.contains('slide')) {
+        var rect = this.getBoundingClientRect();
+        var x = e.clientX - rect.left;
+        if (x > rect.width * 0.75) next();
+        else if (x < rect.width * 0.25) prev();
+      }
+    });
+  }
+
+  var counter = document.querySelector('.slide-counter');
+  function updateCounter() {
+    if (counter) counter.textContent = (current + 1) + ' / ' + total;
+  }
+
+  var baseFontSize = parseInt(localStorage.getItem('adkSlideFontSize')) || 18;
+  applyFontSize();
+
+  window.adjustFont = function (delta) {
+    if (delta === 0) {
+      baseFontSize = 18;
+    } else {
+      baseFontSize = Math.max(14, Math.min(28, baseFontSize + delta));
+    }
+    applyFontSize();
+    localStorage.setItem('adkSlideFontSize', baseFontSize);
+  };
+
+  function applyFontSize() {
+    document.documentElement.style.setProperty('--slide-font-size', baseFontSize + 'px');
+  }
+
+  var themeBtn = document.querySelector('.theme-toggle');
+  var savedTheme = localStorage.getItem('adkTheme');
+  if (savedTheme) {
+    document.documentElement.setAttribute('data-theme', savedTheme);
+  }
+
+  if (themeBtn) {
+    themeBtn.addEventListener('click', function () {
+      var html = document.documentElement;
+      var nextTheme = html.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+      html.setAttribute('data-theme', nextTheme);
+      localStorage.setItem('adkTheme', nextTheme);
+    });
+  }
+
+  var touchStartX = 0;
+  var touchStartY = 0;
+
+  document.addEventListener('touchstart', function (e) {
+    touchStartX = e.changedTouches[0].screenX;
+    touchStartY = e.changedTouches[0].screenY;
+  }, { passive: true });
+
+  document.addEventListener('touchend', function (e) {
+    var dx = e.changedTouches[0].screenX - touchStartX;
+    var dy = e.changedTouches[0].screenY - touchStartY;
+    if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > 50) {
+      if (dx < 0) next();
+      else prev();
+    }
+  }, { passive: true });
+
+  var hash = window.location.hash;
+  if (hash && hash.startsWith('#slide-')) {
+    var n = parseInt(hash.replace('#slide-', ''));
+    if (!isNaN(n) && n >= 1 && n <= total) {
+      current = n - 1;
+    }
+  }
+
+  slides[current].classList.add('active');
+  updateCounter();
+
+  window.addEventListener('hashchange', function () {
+    var h = window.location.hash;
+    if (h && h.startsWith('#slide-')) {
+      var n = parseInt(h.replace('#slide-', ''));
+      if (!isNaN(n) && n >= 1 && n <= total && n - 1 !== current) {
+        goTo(n - 1);
+      }
+    }
+  });
+
+})();
+</script>
+<!-- END-INLINED-SCRIPT -->
 </body>
 </html>

--- a/slides/module-06-multi-agent/index.html
+++ b/slides/module-06-multi-agent/index.html
@@ -796,6 +796,816 @@ body {
   }
 }
   </style>
+
+  <!-- BEGIN-INLINED-STYLES -->
+  <style>
+  /* shared.css — generated; edit slides/shared/shared.css */
+/* ADK Course — Shared Design Tokens
+   Adapted from barcik-training-exin-ai-foundation/css/shared.css.
+   Family-consistent navy with amber accent (distinct from EXIN gold). */
+
+@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;500;600;700;800&display=swap');
+
+:root {
+  /* Brand colors */
+  --navy: #1E3A5F;
+  --navy-light: #2A5280;
+  --navy-dark: #122542;
+  --amber: #F59E0B;
+  --amber-light: #FBBF24;
+  --amber-dark: #B45309;
+  --white: #FFFFFF;
+  --gray-50: #F8F9FA;
+  --gray-100: #F1F3F5;
+  --gray-200: #E9ECEF;
+  --gray-300: #DEE2E6;
+  --gray-400: #CED4DA;
+  --gray-500: #ADB5BD;
+  --gray-600: #868E96;
+  --gray-700: #495057;
+  --gray-800: #343A40;
+  --gray-900: #212529;
+
+  /* Semantic */
+  --bg-primary: var(--white);
+  --bg-secondary: var(--gray-50);
+  --bg-card: var(--white);
+  --text-primary: var(--gray-900);
+  --text-secondary: var(--gray-700);
+  --text-muted: var(--gray-600);
+  --border-color: var(--gray-200);
+  --accent: var(--navy);
+  --accent-light: var(--navy-light);
+  --highlight: var(--amber);
+  --highlight-bg: #FEF3C7;
+  --success: #2E7D32;
+  --success-bg: #E8F5E9;
+  --error: #C62828;
+  --error-bg: #FFEBEE;
+  --info: #1565C0;
+  --info-bg: #E3F2FD;
+
+  /* Typography */
+  --font-sans: 'Nunito', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+  --text-3xl: 1.875rem;
+  --text-4xl: 2.25rem;
+
+  /* Spacing */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-10: 2.5rem;
+  --space-12: 3rem;
+  --space-16: 4rem;
+
+  /* Radius */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.07);
+  --shadow-lg: 0 10px 15px rgba(0,0,0,0.1);
+
+  /* Transitions */
+  --transition-fast: 150ms ease;
+  --transition-normal: 250ms ease;
+  --transition-slow: 350ms ease;
+}
+
+[data-theme="dark"] {
+  --bg-primary: #0D1117;
+  --bg-secondary: #161B22;
+  --bg-card: #1C2128;
+  --text-primary: #E6EDF3;
+  --text-secondary: #B1BAC4;
+  --text-muted: #8B949E;
+  --border-color: #30363D;
+  --accent: #58A6FF;
+  --accent-light: #79C0FF;
+  --highlight: var(--amber);
+  --highlight-bg: #2D2200;
+  --success: #56D364;
+  --success-bg: #0D2818;
+  --error: #F85149;
+  --error-bg: #2D1214;
+  --info: #58A6FF;
+  --info-bg: #0D1B2E;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.3);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.4);
+  --shadow-lg: 0 10px 15px rgba(0,0,0,0.5);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg-primary: #0D1117;
+    --bg-secondary: #161B22;
+    --bg-card: #1C2128;
+    --text-primary: #E6EDF3;
+    --text-secondary: #B1BAC4;
+    --text-muted: #8B949E;
+    --border-color: #30363D;
+    --accent: #58A6FF;
+    --accent-light: #79C0FF;
+    --highlight: var(--amber);
+    --highlight-bg: #2D2200;
+    --success: #56D364;
+    --success-bg: #0D2818;
+    --error: #F85149;
+    --error-bg: #2D1214;
+    --info: #58A6FF;
+    --info-bg: #0D1B2E;
+  }
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  line-height: 1.6;
+  color: var(--text-primary);
+  background-color: var(--bg-primary);
+  -webkit-font-smoothing: antialiased;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow var(--transition-normal);
+}
+
+.card:hover {
+  box-shadow: var(--shadow-md);
+}
+
+.callout {
+  padding: var(--space-4) var(--space-6);
+  border-radius: var(--radius-md);
+  margin: var(--space-4) 0;
+  border-left: 4px solid;
+}
+
+.callout-key { background: var(--highlight-bg); border-color: var(--amber); }
+.callout-gotcha { background: var(--error-bg); border-color: var(--error); }
+.callout-tip { background: var(--info-bg); border-color: var(--info); }
+.callout-success { background: var(--success-bg); border-color: var(--success); }
+
+.callout-title {
+  font-weight: 700;
+  font-size: var(--text-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: var(--space-2);
+}
+
+.text-center { text-align: center; }
+.text-muted { color: var(--text-muted); }
+.font-mono { font-family: var(--font-mono); }
+.mt-4 { margin-top: var(--space-4); }
+.mt-8 { margin-top: var(--space-8); }
+.mb-4 { margin-bottom: var(--space-4); }
+.mb-8 { margin-bottom: var(--space-8); }
+.mx-auto { margin-left: auto; margin-right: auto; }
+.max-w-4xl { max-width: 56rem; }
+.hidden { display: none !important; }
+  /* slides.css — generated; edit slides/shared/slides.css */
+/* ADK Course — Slide Presentation Theme
+   Adapted from barcik-training-exin-ai-foundation/slides/css/slides.css.
+   Adds data-type="code" slide variant for Python snippets. */
+
+:root {
+  --slide-font-size: 18px;
+  --strip-height: 48px;
+}
+
+body {
+  margin: 0;
+  overflow: hidden;
+  background: var(--bg-primary);
+}
+
+/* ── Progress Strip ──────────────────────────────── */
+.progress-strip {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  height: var(--strip-height);
+  background: var(--navy);
+  display: flex;
+  align-items: center;
+  z-index: 100;
+  padding: 0 var(--space-4);
+  gap: var(--space-4);
+  box-shadow: var(--shadow-md);
+  font-family: var(--font-sans);
+}
+
+.progress-home {
+  color: var(--amber);
+  text-decoration: none;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: var(--radius-md);
+  white-space: nowrap;
+  transition: all var(--transition-fast);
+}
+
+.progress-home:hover {
+  background: rgba(255,255,255,0.1);
+  border-color: var(--amber);
+}
+
+.progress-title {
+  color: rgba(255,255,255,0.85);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  flex: 1;
+  text-align: center;
+}
+
+.progress-title .quick-path-badge {
+  display: inline-block;
+  background: var(--amber);
+  color: var(--navy-dark);
+  font-size: 0.68rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.15rem 0.55rem;
+  border-radius: 9999px;
+  margin-left: 0.6rem;
+  vertical-align: 2px;
+}
+
+.progress-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.slide-counter {
+  color: rgba(255,255,255,0.6);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  font-family: var(--font-mono);
+  white-space: nowrap;
+}
+
+.progress-strip .theme-toggle {
+  background: rgba(255,255,255,0.1);
+  color: rgba(255,255,255,0.7);
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: var(--radius-md);
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-xs);
+  cursor: pointer;
+  font-family: var(--font-sans);
+  transition: all var(--transition-fast);
+}
+
+.progress-strip .theme-toggle:hover {
+  background: rgba(255,255,255,0.2);
+  color: white;
+}
+
+/* ── Viewport ────────────────────────────────────── */
+.slide-viewport {
+  position: fixed;
+  top: var(--strip-height);
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow: hidden;
+}
+
+/* ── Slide Base ──────────────────────────────────── */
+.slide {
+  display: none;
+  position: absolute;
+  inset: 0;
+  overflow-y: auto;
+  padding: var(--space-10) var(--space-16);
+  font-size: var(--slide-font-size);
+  line-height: 1.6;
+  font-family: var(--font-sans);
+  color: var(--text-primary);
+  background: var(--bg-primary);
+}
+
+.slide.active {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  animation: fadeIn 0.25s ease;
+}
+
+.slide > * {
+  max-width: 1100px;
+  width: 100% !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
+  box-sizing: border-box;
+  text-align: inherit;
+}
+
+.slide > .topic-badge {
+  width: auto !important;
+  max-width: none;
+  align-self: center;
+}
+
+/* ── Section Title ───────────────────────────────── */
+.slide[data-type="section-title"] {
+  background: linear-gradient(135deg, var(--navy) 0%, var(--navy-light) 100%);
+  text-align: center;
+}
+
+.slide[data-type="section-title"] h1,
+.slide[data-type="section-title"] h2,
+.slide[data-type="section-title"] h3 {
+  color: white;
+}
+
+.slide[data-type="section-title"] p {
+  color: rgba(255,255,255,0.85);
+}
+
+.slide[data-type="section-title"] .topic-badge {
+  display: inline-block;
+  background: var(--amber);
+  color: var(--navy-dark);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  padding: var(--space-2) var(--space-4);
+  border-radius: 9999px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: var(--space-4);
+  width: auto !important;
+}
+
+.slide[data-type="section-title"] .highlight-text {
+  color: var(--amber);
+  font-weight: 600;
+}
+
+/* ── Typography ──────────────────────────────────── */
+.slide h1 {
+  font-size: 2.4em;
+  font-weight: 800;
+  color: var(--navy);
+  margin-bottom: var(--space-4);
+  line-height: 1.15;
+}
+
+.slide h2 {
+  font-size: 1.6em;
+  font-weight: 700;
+  color: var(--navy);
+  margin-bottom: var(--space-4);
+  padding-bottom: var(--space-2);
+  border-bottom: 3px solid var(--amber);
+}
+
+.slide h3 {
+  font-size: 1.2em;
+  font-weight: 600;
+  color: var(--navy-light);
+  margin-bottom: var(--space-3);
+}
+
+.slide p {
+  margin-bottom: var(--space-3);
+  color: var(--text-secondary);
+}
+
+.slide strong {
+  color: var(--navy);
+  font-weight: 700;
+}
+
+.slide em {
+  color: var(--amber-dark);
+  font-style: italic;
+}
+
+.slide ul, .slide ol {
+  margin-left: 1.2em;
+  margin-bottom: var(--space-4);
+}
+
+.slide li {
+  margin-bottom: var(--space-2);
+  color: var(--text-secondary);
+}
+
+.slide li::marker {
+  color: var(--amber);
+}
+
+[data-theme="dark"] .slide h1,
+[data-theme="dark"] .slide h2 { color: var(--text-primary); }
+[data-theme="dark"] .slide h3 { color: var(--text-secondary); }
+[data-theme="dark"] .slide strong { color: var(--text-primary); }
+[data-theme="dark"] .slide h2 { border-bottom-color: var(--amber); }
+
+.highlight-text {
+  color: var(--amber-dark);
+  font-weight: 600;
+}
+
+[data-theme="dark"] .highlight-text {
+  color: var(--amber);
+}
+
+/* ── Grid ────────────────────────────────────────── */
+.slide[data-type="grid"] .grid-layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: var(--space-4);
+  margin-top: var(--space-4);
+}
+
+.grid-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5);
+  transition: all var(--transition-normal);
+}
+
+.grid-card:hover {
+  box-shadow: var(--shadow-md);
+  transform: translateY(-2px);
+  border-color: var(--accent);
+}
+
+.grid-card.highlight {
+  border-color: var(--amber);
+  box-shadow: 0 0 0 1px var(--amber), var(--shadow-sm);
+}
+
+.grid-card-title {
+  font-weight: 700;
+  color: var(--text-primary);
+  font-size: 1.05em;
+  margin-bottom: var(--space-2);
+}
+
+.grid-card-body {
+  color: var(--text-secondary);
+  font-size: 0.9em;
+  line-height: 1.5;
+}
+
+/* ── Split ───────────────────────────────────────── */
+.slide[data-type="split"] .split-layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-8);
+  margin-top: var(--space-4);
+}
+
+@media (max-width: 768px) {
+  .slide[data-type="split"] .split-layout { grid-template-columns: 1fr; }
+}
+
+/* ── Comparison ──────────────────────────────────── */
+.slide[data-type="comparison"] .comparison-layout {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: var(--space-6);
+  align-items: start;
+  margin-top: var(--space-4);
+}
+
+.vs-left, .vs-right {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+}
+
+.vs-divider {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5em;
+  font-weight: 800;
+  color: var(--text-muted);
+  align-self: center;
+}
+
+@media (max-width: 768px) {
+  .slide[data-type="comparison"] .comparison-layout {
+    grid-template-columns: 1fr;
+  }
+  .vs-divider { display: none; }
+}
+
+/* ── Quote ───────────────────────────────────────── */
+.slide[data-type="quote"] {
+  text-align: center;
+}
+
+.quote-text {
+  font-size: 1.5em;
+  font-weight: 300;
+  font-style: italic;
+  color: var(--text-primary);
+  max-width: 80%;
+  line-height: 1.5;
+  position: relative;
+  padding: 0.5em 1em;
+  margin: 0 auto;
+}
+
+.quote-text::before {
+  content: '\201C';
+  position: absolute;
+  left: -0.3em;
+  top: -0.2em;
+  font-size: 3.5em;
+  color: var(--amber);
+  font-weight: 800;
+  line-height: 1;
+  opacity: 0.3;
+}
+
+.quote-source {
+  margin-top: var(--space-4);
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  font-weight: 500;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.quote-source::before { content: '\2014\00a0'; }
+
+/* ── Key Fact ────────────────────────────────────── */
+.slide[data-type="keyfact"] {
+  text-align: center;
+}
+
+.slide[data-type="keyfact"] p {
+  font-size: 1.5em;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.35;
+}
+
+.slide[data-type="keyfact"] strong {
+  color: var(--amber-dark);
+}
+
+[data-theme="dark"] .slide[data-type="keyfact"] strong {
+  color: var(--amber);
+}
+
+/* ── Hero ────────────────────────────────────────── */
+.slide[data-type="hero"] {
+  text-align: center;
+}
+
+/* ── Example / Code ──────────────────────────────── */
+.slide[data-type="example"] {
+  border-left: 4px solid var(--info);
+}
+
+.slide[data-type="code"] pre,
+.slide pre {
+  background: var(--gray-900);
+  color: #E6EDF3;
+  border-radius: var(--radius-md);
+  padding: var(--space-4) var(--space-5);
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  line-height: 1.55;
+  margin: var(--space-3) 0;
+  box-shadow: var(--shadow-sm);
+}
+
+.slide[data-type="code"] pre code,
+.slide pre code {
+  background: none;
+  color: inherit;
+  padding: 0;
+  font-family: var(--font-mono);
+}
+
+.slide code {
+  font-family: var(--font-mono);
+  background: var(--bg-secondary);
+  color: var(--navy);
+  padding: 0.1em 0.35em;
+  border-radius: var(--radius-sm);
+  font-size: 0.9em;
+}
+
+[data-theme="dark"] .slide code {
+  color: var(--accent-light);
+  background: var(--gray-800);
+}
+
+.slide .code-caption {
+  color: var(--text-muted);
+  font-size: 0.85em;
+  font-style: italic;
+  margin-top: var(--space-2);
+}
+
+/* ── Definition Cards ────────────────────────────── */
+.def-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-left: 4px solid var(--navy-light);
+  border-radius: 0 var(--radius-lg) var(--radius-lg) 0;
+  padding: var(--space-4) var(--space-5);
+  margin-bottom: var(--space-3);
+  transition: border-color var(--transition-fast);
+}
+
+.def-card.highlight {
+  border-left-color: var(--amber);
+}
+
+.def-term {
+  font-size: var(--text-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--navy-light);
+  margin-bottom: var(--space-2);
+}
+
+[data-theme="dark"] .def-term { color: var(--accent); }
+
+.def-text {
+  color: var(--text-primary);
+  line-height: 1.5;
+}
+
+/* ── Callouts on slides ──────────────────────────── */
+.slide .callout {
+  margin: var(--space-4) 0;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* ── Tables ──────────────────────────────────────── */
+.slide table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  margin: var(--space-4) 0;
+  font-size: 0.92em;
+}
+
+.slide table th {
+  background: var(--navy);
+  color: white;
+  padding: var(--space-3) var(--space-4);
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.9em;
+}
+
+.slide table td {
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border-color);
+  color: var(--text-secondary);
+}
+
+.slide table tr:nth-child(even) { background: var(--bg-secondary); }
+.slide table tr:last-child td { border-bottom: none; }
+
+/* ── Two-Column Layout ───────────────────────────── */
+.two-col {
+  display: flex;
+  gap: var(--space-8);
+  align-items: flex-start;
+}
+
+.col { flex: 1; min-width: 0; }
+
+@media (max-width: 768px) {
+  .two-col { flex-direction: column; gap: var(--space-4); }
+}
+
+/* ── ASCII-art / diagram ─────────────────────────── */
+.slide .diagram {
+  background: var(--gray-900);
+  color: #C9D1D9;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  line-height: 1.4;
+  padding: var(--space-4) var(--space-5);
+  border-radius: var(--radius-md);
+  white-space: pre;
+  overflow-x: auto;
+  margin: var(--space-3) 0;
+}
+
+/* ── Font Controls ───────────────────────────────── */
+.font-controls {
+  position: fixed;
+  bottom: var(--space-6);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: var(--space-2);
+  z-index: 100;
+  background: var(--bg-card);
+  padding: var(--space-2);
+  border-radius: 9999px;
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-md);
+  opacity: 0.5;
+  transition: opacity var(--transition-fast);
+}
+
+.font-controls:hover { opacity: 1; }
+
+.font-controls button {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.font-controls button:hover {
+  background: var(--navy);
+  color: white;
+  border-color: var(--navy);
+}
+
+/* ── Animations ──────────────────────────────────── */
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Print ───────────────────────────────────────── */
+@media print {
+  .progress-strip, .font-controls { display: none !important; }
+  .slide-viewport { position: static; overflow: visible; }
+  .slide {
+    display: block !important;
+    position: static !important;
+    page-break-after: always;
+    padding: 2cm;
+  }
+  .slide[data-type="section-title"] {
+    background: var(--navy) !important;
+    color: white !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+  .slide pre {
+    background: var(--gray-100) !important;
+    color: var(--gray-900) !important;
+    border: 1px solid var(--gray-400);
+  }
+}
+  </style>
+  <!-- END-INLINED-STYLES -->
 </head>
 <body>
   <nav class="progress-strip">
@@ -1170,5 +1980,148 @@ coordinator = LlmAgent(
 
 })();
 </script>
+
+  <!-- BEGIN-INLINED-SCRIPT -->
+<script>
+/* ADK Course — Slide Engine
+   Adapted from barcik-training-exin-ai-foundation/slides/js/slides.js.
+   Per-module decks; lightweight nav with keyboard, touch, hash routing,
+   font controls, theme toggle. */
+
+(function () {
+  'use strict';
+
+  const slides = document.querySelectorAll('.slide');
+  const total = slides.length;
+  let current = 0;
+
+  function goTo(index) {
+    if (index < 0 || index >= total) return;
+    slides[current].classList.remove('active');
+    current = index;
+    slides[current].classList.add('active');
+    updateCounter();
+    window.scrollTo(0, 0);
+    history.replaceState(null, '', '#slide-' + (current + 1));
+  }
+
+  function next() { goTo(current + 1); }
+  function prev() { goTo(current - 1); }
+
+  document.addEventListener('keydown', function (e) {
+    if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+      case ' ':
+        e.preventDefault();
+        next();
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        e.preventDefault();
+        prev();
+        break;
+      case 'Home':
+        e.preventDefault();
+        goTo(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        goTo(total - 1);
+        break;
+    }
+  });
+
+  var viewport = document.querySelector('.slide-viewport');
+  if (viewport) {
+    viewport.addEventListener('click', function (e) {
+      if (e.target === this || e.target.classList.contains('slide')) {
+        var rect = this.getBoundingClientRect();
+        var x = e.clientX - rect.left;
+        if (x > rect.width * 0.75) next();
+        else if (x < rect.width * 0.25) prev();
+      }
+    });
+  }
+
+  var counter = document.querySelector('.slide-counter');
+  function updateCounter() {
+    if (counter) counter.textContent = (current + 1) + ' / ' + total;
+  }
+
+  var baseFontSize = parseInt(localStorage.getItem('adkSlideFontSize')) || 18;
+  applyFontSize();
+
+  window.adjustFont = function (delta) {
+    if (delta === 0) {
+      baseFontSize = 18;
+    } else {
+      baseFontSize = Math.max(14, Math.min(28, baseFontSize + delta));
+    }
+    applyFontSize();
+    localStorage.setItem('adkSlideFontSize', baseFontSize);
+  };
+
+  function applyFontSize() {
+    document.documentElement.style.setProperty('--slide-font-size', baseFontSize + 'px');
+  }
+
+  var themeBtn = document.querySelector('.theme-toggle');
+  var savedTheme = localStorage.getItem('adkTheme');
+  if (savedTheme) {
+    document.documentElement.setAttribute('data-theme', savedTheme);
+  }
+
+  if (themeBtn) {
+    themeBtn.addEventListener('click', function () {
+      var html = document.documentElement;
+      var nextTheme = html.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+      html.setAttribute('data-theme', nextTheme);
+      localStorage.setItem('adkTheme', nextTheme);
+    });
+  }
+
+  var touchStartX = 0;
+  var touchStartY = 0;
+
+  document.addEventListener('touchstart', function (e) {
+    touchStartX = e.changedTouches[0].screenX;
+    touchStartY = e.changedTouches[0].screenY;
+  }, { passive: true });
+
+  document.addEventListener('touchend', function (e) {
+    var dx = e.changedTouches[0].screenX - touchStartX;
+    var dy = e.changedTouches[0].screenY - touchStartY;
+    if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > 50) {
+      if (dx < 0) next();
+      else prev();
+    }
+  }, { passive: true });
+
+  var hash = window.location.hash;
+  if (hash && hash.startsWith('#slide-')) {
+    var n = parseInt(hash.replace('#slide-', ''));
+    if (!isNaN(n) && n >= 1 && n <= total) {
+      current = n - 1;
+    }
+  }
+
+  slides[current].classList.add('active');
+  updateCounter();
+
+  window.addEventListener('hashchange', function () {
+    var h = window.location.hash;
+    if (h && h.startsWith('#slide-')) {
+      var n = parseInt(h.replace('#slide-', ''));
+      if (!isNaN(n) && n >= 1 && n <= total && n - 1 !== current) {
+        goTo(n - 1);
+      }
+    }
+  });
+
+})();
+</script>
+<!-- END-INLINED-SCRIPT -->
 </body>
 </html>

--- a/slides/module-07-callbacks/index.html
+++ b/slides/module-07-callbacks/index.html
@@ -796,6 +796,816 @@ body {
   }
 }
   </style>
+
+  <!-- BEGIN-INLINED-STYLES -->
+  <style>
+  /* shared.css — generated; edit slides/shared/shared.css */
+/* ADK Course — Shared Design Tokens
+   Adapted from barcik-training-exin-ai-foundation/css/shared.css.
+   Family-consistent navy with amber accent (distinct from EXIN gold). */
+
+@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;500;600;700;800&display=swap');
+
+:root {
+  /* Brand colors */
+  --navy: #1E3A5F;
+  --navy-light: #2A5280;
+  --navy-dark: #122542;
+  --amber: #F59E0B;
+  --amber-light: #FBBF24;
+  --amber-dark: #B45309;
+  --white: #FFFFFF;
+  --gray-50: #F8F9FA;
+  --gray-100: #F1F3F5;
+  --gray-200: #E9ECEF;
+  --gray-300: #DEE2E6;
+  --gray-400: #CED4DA;
+  --gray-500: #ADB5BD;
+  --gray-600: #868E96;
+  --gray-700: #495057;
+  --gray-800: #343A40;
+  --gray-900: #212529;
+
+  /* Semantic */
+  --bg-primary: var(--white);
+  --bg-secondary: var(--gray-50);
+  --bg-card: var(--white);
+  --text-primary: var(--gray-900);
+  --text-secondary: var(--gray-700);
+  --text-muted: var(--gray-600);
+  --border-color: var(--gray-200);
+  --accent: var(--navy);
+  --accent-light: var(--navy-light);
+  --highlight: var(--amber);
+  --highlight-bg: #FEF3C7;
+  --success: #2E7D32;
+  --success-bg: #E8F5E9;
+  --error: #C62828;
+  --error-bg: #FFEBEE;
+  --info: #1565C0;
+  --info-bg: #E3F2FD;
+
+  /* Typography */
+  --font-sans: 'Nunito', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+  --text-3xl: 1.875rem;
+  --text-4xl: 2.25rem;
+
+  /* Spacing */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-10: 2.5rem;
+  --space-12: 3rem;
+  --space-16: 4rem;
+
+  /* Radius */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.07);
+  --shadow-lg: 0 10px 15px rgba(0,0,0,0.1);
+
+  /* Transitions */
+  --transition-fast: 150ms ease;
+  --transition-normal: 250ms ease;
+  --transition-slow: 350ms ease;
+}
+
+[data-theme="dark"] {
+  --bg-primary: #0D1117;
+  --bg-secondary: #161B22;
+  --bg-card: #1C2128;
+  --text-primary: #E6EDF3;
+  --text-secondary: #B1BAC4;
+  --text-muted: #8B949E;
+  --border-color: #30363D;
+  --accent: #58A6FF;
+  --accent-light: #79C0FF;
+  --highlight: var(--amber);
+  --highlight-bg: #2D2200;
+  --success: #56D364;
+  --success-bg: #0D2818;
+  --error: #F85149;
+  --error-bg: #2D1214;
+  --info: #58A6FF;
+  --info-bg: #0D1B2E;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.3);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.4);
+  --shadow-lg: 0 10px 15px rgba(0,0,0,0.5);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg-primary: #0D1117;
+    --bg-secondary: #161B22;
+    --bg-card: #1C2128;
+    --text-primary: #E6EDF3;
+    --text-secondary: #B1BAC4;
+    --text-muted: #8B949E;
+    --border-color: #30363D;
+    --accent: #58A6FF;
+    --accent-light: #79C0FF;
+    --highlight: var(--amber);
+    --highlight-bg: #2D2200;
+    --success: #56D364;
+    --success-bg: #0D2818;
+    --error: #F85149;
+    --error-bg: #2D1214;
+    --info: #58A6FF;
+    --info-bg: #0D1B2E;
+  }
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  line-height: 1.6;
+  color: var(--text-primary);
+  background-color: var(--bg-primary);
+  -webkit-font-smoothing: antialiased;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow var(--transition-normal);
+}
+
+.card:hover {
+  box-shadow: var(--shadow-md);
+}
+
+.callout {
+  padding: var(--space-4) var(--space-6);
+  border-radius: var(--radius-md);
+  margin: var(--space-4) 0;
+  border-left: 4px solid;
+}
+
+.callout-key { background: var(--highlight-bg); border-color: var(--amber); }
+.callout-gotcha { background: var(--error-bg); border-color: var(--error); }
+.callout-tip { background: var(--info-bg); border-color: var(--info); }
+.callout-success { background: var(--success-bg); border-color: var(--success); }
+
+.callout-title {
+  font-weight: 700;
+  font-size: var(--text-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: var(--space-2);
+}
+
+.text-center { text-align: center; }
+.text-muted { color: var(--text-muted); }
+.font-mono { font-family: var(--font-mono); }
+.mt-4 { margin-top: var(--space-4); }
+.mt-8 { margin-top: var(--space-8); }
+.mb-4 { margin-bottom: var(--space-4); }
+.mb-8 { margin-bottom: var(--space-8); }
+.mx-auto { margin-left: auto; margin-right: auto; }
+.max-w-4xl { max-width: 56rem; }
+.hidden { display: none !important; }
+  /* slides.css — generated; edit slides/shared/slides.css */
+/* ADK Course — Slide Presentation Theme
+   Adapted from barcik-training-exin-ai-foundation/slides/css/slides.css.
+   Adds data-type="code" slide variant for Python snippets. */
+
+:root {
+  --slide-font-size: 18px;
+  --strip-height: 48px;
+}
+
+body {
+  margin: 0;
+  overflow: hidden;
+  background: var(--bg-primary);
+}
+
+/* ── Progress Strip ──────────────────────────────── */
+.progress-strip {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  height: var(--strip-height);
+  background: var(--navy);
+  display: flex;
+  align-items: center;
+  z-index: 100;
+  padding: 0 var(--space-4);
+  gap: var(--space-4);
+  box-shadow: var(--shadow-md);
+  font-family: var(--font-sans);
+}
+
+.progress-home {
+  color: var(--amber);
+  text-decoration: none;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: var(--radius-md);
+  white-space: nowrap;
+  transition: all var(--transition-fast);
+}
+
+.progress-home:hover {
+  background: rgba(255,255,255,0.1);
+  border-color: var(--amber);
+}
+
+.progress-title {
+  color: rgba(255,255,255,0.85);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  flex: 1;
+  text-align: center;
+}
+
+.progress-title .quick-path-badge {
+  display: inline-block;
+  background: var(--amber);
+  color: var(--navy-dark);
+  font-size: 0.68rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.15rem 0.55rem;
+  border-radius: 9999px;
+  margin-left: 0.6rem;
+  vertical-align: 2px;
+}
+
+.progress-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.slide-counter {
+  color: rgba(255,255,255,0.6);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  font-family: var(--font-mono);
+  white-space: nowrap;
+}
+
+.progress-strip .theme-toggle {
+  background: rgba(255,255,255,0.1);
+  color: rgba(255,255,255,0.7);
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: var(--radius-md);
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-xs);
+  cursor: pointer;
+  font-family: var(--font-sans);
+  transition: all var(--transition-fast);
+}
+
+.progress-strip .theme-toggle:hover {
+  background: rgba(255,255,255,0.2);
+  color: white;
+}
+
+/* ── Viewport ────────────────────────────────────── */
+.slide-viewport {
+  position: fixed;
+  top: var(--strip-height);
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow: hidden;
+}
+
+/* ── Slide Base ──────────────────────────────────── */
+.slide {
+  display: none;
+  position: absolute;
+  inset: 0;
+  overflow-y: auto;
+  padding: var(--space-10) var(--space-16);
+  font-size: var(--slide-font-size);
+  line-height: 1.6;
+  font-family: var(--font-sans);
+  color: var(--text-primary);
+  background: var(--bg-primary);
+}
+
+.slide.active {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  animation: fadeIn 0.25s ease;
+}
+
+.slide > * {
+  max-width: 1100px;
+  width: 100% !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
+  box-sizing: border-box;
+  text-align: inherit;
+}
+
+.slide > .topic-badge {
+  width: auto !important;
+  max-width: none;
+  align-self: center;
+}
+
+/* ── Section Title ───────────────────────────────── */
+.slide[data-type="section-title"] {
+  background: linear-gradient(135deg, var(--navy) 0%, var(--navy-light) 100%);
+  text-align: center;
+}
+
+.slide[data-type="section-title"] h1,
+.slide[data-type="section-title"] h2,
+.slide[data-type="section-title"] h3 {
+  color: white;
+}
+
+.slide[data-type="section-title"] p {
+  color: rgba(255,255,255,0.85);
+}
+
+.slide[data-type="section-title"] .topic-badge {
+  display: inline-block;
+  background: var(--amber);
+  color: var(--navy-dark);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  padding: var(--space-2) var(--space-4);
+  border-radius: 9999px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: var(--space-4);
+  width: auto !important;
+}
+
+.slide[data-type="section-title"] .highlight-text {
+  color: var(--amber);
+  font-weight: 600;
+}
+
+/* ── Typography ──────────────────────────────────── */
+.slide h1 {
+  font-size: 2.4em;
+  font-weight: 800;
+  color: var(--navy);
+  margin-bottom: var(--space-4);
+  line-height: 1.15;
+}
+
+.slide h2 {
+  font-size: 1.6em;
+  font-weight: 700;
+  color: var(--navy);
+  margin-bottom: var(--space-4);
+  padding-bottom: var(--space-2);
+  border-bottom: 3px solid var(--amber);
+}
+
+.slide h3 {
+  font-size: 1.2em;
+  font-weight: 600;
+  color: var(--navy-light);
+  margin-bottom: var(--space-3);
+}
+
+.slide p {
+  margin-bottom: var(--space-3);
+  color: var(--text-secondary);
+}
+
+.slide strong {
+  color: var(--navy);
+  font-weight: 700;
+}
+
+.slide em {
+  color: var(--amber-dark);
+  font-style: italic;
+}
+
+.slide ul, .slide ol {
+  margin-left: 1.2em;
+  margin-bottom: var(--space-4);
+}
+
+.slide li {
+  margin-bottom: var(--space-2);
+  color: var(--text-secondary);
+}
+
+.slide li::marker {
+  color: var(--amber);
+}
+
+[data-theme="dark"] .slide h1,
+[data-theme="dark"] .slide h2 { color: var(--text-primary); }
+[data-theme="dark"] .slide h3 { color: var(--text-secondary); }
+[data-theme="dark"] .slide strong { color: var(--text-primary); }
+[data-theme="dark"] .slide h2 { border-bottom-color: var(--amber); }
+
+.highlight-text {
+  color: var(--amber-dark);
+  font-weight: 600;
+}
+
+[data-theme="dark"] .highlight-text {
+  color: var(--amber);
+}
+
+/* ── Grid ────────────────────────────────────────── */
+.slide[data-type="grid"] .grid-layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: var(--space-4);
+  margin-top: var(--space-4);
+}
+
+.grid-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5);
+  transition: all var(--transition-normal);
+}
+
+.grid-card:hover {
+  box-shadow: var(--shadow-md);
+  transform: translateY(-2px);
+  border-color: var(--accent);
+}
+
+.grid-card.highlight {
+  border-color: var(--amber);
+  box-shadow: 0 0 0 1px var(--amber), var(--shadow-sm);
+}
+
+.grid-card-title {
+  font-weight: 700;
+  color: var(--text-primary);
+  font-size: 1.05em;
+  margin-bottom: var(--space-2);
+}
+
+.grid-card-body {
+  color: var(--text-secondary);
+  font-size: 0.9em;
+  line-height: 1.5;
+}
+
+/* ── Split ───────────────────────────────────────── */
+.slide[data-type="split"] .split-layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-8);
+  margin-top: var(--space-4);
+}
+
+@media (max-width: 768px) {
+  .slide[data-type="split"] .split-layout { grid-template-columns: 1fr; }
+}
+
+/* ── Comparison ──────────────────────────────────── */
+.slide[data-type="comparison"] .comparison-layout {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: var(--space-6);
+  align-items: start;
+  margin-top: var(--space-4);
+}
+
+.vs-left, .vs-right {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+}
+
+.vs-divider {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5em;
+  font-weight: 800;
+  color: var(--text-muted);
+  align-self: center;
+}
+
+@media (max-width: 768px) {
+  .slide[data-type="comparison"] .comparison-layout {
+    grid-template-columns: 1fr;
+  }
+  .vs-divider { display: none; }
+}
+
+/* ── Quote ───────────────────────────────────────── */
+.slide[data-type="quote"] {
+  text-align: center;
+}
+
+.quote-text {
+  font-size: 1.5em;
+  font-weight: 300;
+  font-style: italic;
+  color: var(--text-primary);
+  max-width: 80%;
+  line-height: 1.5;
+  position: relative;
+  padding: 0.5em 1em;
+  margin: 0 auto;
+}
+
+.quote-text::before {
+  content: '\201C';
+  position: absolute;
+  left: -0.3em;
+  top: -0.2em;
+  font-size: 3.5em;
+  color: var(--amber);
+  font-weight: 800;
+  line-height: 1;
+  opacity: 0.3;
+}
+
+.quote-source {
+  margin-top: var(--space-4);
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  font-weight: 500;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.quote-source::before { content: '\2014\00a0'; }
+
+/* ── Key Fact ────────────────────────────────────── */
+.slide[data-type="keyfact"] {
+  text-align: center;
+}
+
+.slide[data-type="keyfact"] p {
+  font-size: 1.5em;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.35;
+}
+
+.slide[data-type="keyfact"] strong {
+  color: var(--amber-dark);
+}
+
+[data-theme="dark"] .slide[data-type="keyfact"] strong {
+  color: var(--amber);
+}
+
+/* ── Hero ────────────────────────────────────────── */
+.slide[data-type="hero"] {
+  text-align: center;
+}
+
+/* ── Example / Code ──────────────────────────────── */
+.slide[data-type="example"] {
+  border-left: 4px solid var(--info);
+}
+
+.slide[data-type="code"] pre,
+.slide pre {
+  background: var(--gray-900);
+  color: #E6EDF3;
+  border-radius: var(--radius-md);
+  padding: var(--space-4) var(--space-5);
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  line-height: 1.55;
+  margin: var(--space-3) 0;
+  box-shadow: var(--shadow-sm);
+}
+
+.slide[data-type="code"] pre code,
+.slide pre code {
+  background: none;
+  color: inherit;
+  padding: 0;
+  font-family: var(--font-mono);
+}
+
+.slide code {
+  font-family: var(--font-mono);
+  background: var(--bg-secondary);
+  color: var(--navy);
+  padding: 0.1em 0.35em;
+  border-radius: var(--radius-sm);
+  font-size: 0.9em;
+}
+
+[data-theme="dark"] .slide code {
+  color: var(--accent-light);
+  background: var(--gray-800);
+}
+
+.slide .code-caption {
+  color: var(--text-muted);
+  font-size: 0.85em;
+  font-style: italic;
+  margin-top: var(--space-2);
+}
+
+/* ── Definition Cards ────────────────────────────── */
+.def-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-left: 4px solid var(--navy-light);
+  border-radius: 0 var(--radius-lg) var(--radius-lg) 0;
+  padding: var(--space-4) var(--space-5);
+  margin-bottom: var(--space-3);
+  transition: border-color var(--transition-fast);
+}
+
+.def-card.highlight {
+  border-left-color: var(--amber);
+}
+
+.def-term {
+  font-size: var(--text-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--navy-light);
+  margin-bottom: var(--space-2);
+}
+
+[data-theme="dark"] .def-term { color: var(--accent); }
+
+.def-text {
+  color: var(--text-primary);
+  line-height: 1.5;
+}
+
+/* ── Callouts on slides ──────────────────────────── */
+.slide .callout {
+  margin: var(--space-4) 0;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* ── Tables ──────────────────────────────────────── */
+.slide table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  margin: var(--space-4) 0;
+  font-size: 0.92em;
+}
+
+.slide table th {
+  background: var(--navy);
+  color: white;
+  padding: var(--space-3) var(--space-4);
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.9em;
+}
+
+.slide table td {
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border-color);
+  color: var(--text-secondary);
+}
+
+.slide table tr:nth-child(even) { background: var(--bg-secondary); }
+.slide table tr:last-child td { border-bottom: none; }
+
+/* ── Two-Column Layout ───────────────────────────── */
+.two-col {
+  display: flex;
+  gap: var(--space-8);
+  align-items: flex-start;
+}
+
+.col { flex: 1; min-width: 0; }
+
+@media (max-width: 768px) {
+  .two-col { flex-direction: column; gap: var(--space-4); }
+}
+
+/* ── ASCII-art / diagram ─────────────────────────── */
+.slide .diagram {
+  background: var(--gray-900);
+  color: #C9D1D9;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  line-height: 1.4;
+  padding: var(--space-4) var(--space-5);
+  border-radius: var(--radius-md);
+  white-space: pre;
+  overflow-x: auto;
+  margin: var(--space-3) 0;
+}
+
+/* ── Font Controls ───────────────────────────────── */
+.font-controls {
+  position: fixed;
+  bottom: var(--space-6);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: var(--space-2);
+  z-index: 100;
+  background: var(--bg-card);
+  padding: var(--space-2);
+  border-radius: 9999px;
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-md);
+  opacity: 0.5;
+  transition: opacity var(--transition-fast);
+}
+
+.font-controls:hover { opacity: 1; }
+
+.font-controls button {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.font-controls button:hover {
+  background: var(--navy);
+  color: white;
+  border-color: var(--navy);
+}
+
+/* ── Animations ──────────────────────────────────── */
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Print ───────────────────────────────────────── */
+@media print {
+  .progress-strip, .font-controls { display: none !important; }
+  .slide-viewport { position: static; overflow: visible; }
+  .slide {
+    display: block !important;
+    position: static !important;
+    page-break-after: always;
+    padding: 2cm;
+  }
+  .slide[data-type="section-title"] {
+    background: var(--navy) !important;
+    color: white !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+  .slide pre {
+    background: var(--gray-100) !important;
+    color: var(--gray-900) !important;
+    border: 1px solid var(--gray-400);
+  }
+}
+  </style>
+  <!-- END-INLINED-STYLES -->
 </head>
 <body>
   <nav class="progress-strip">
@@ -1152,5 +1962,148 @@ stock_agent = LlmAgent(
 
 })();
 </script>
+
+  <!-- BEGIN-INLINED-SCRIPT -->
+<script>
+/* ADK Course — Slide Engine
+   Adapted from barcik-training-exin-ai-foundation/slides/js/slides.js.
+   Per-module decks; lightweight nav with keyboard, touch, hash routing,
+   font controls, theme toggle. */
+
+(function () {
+  'use strict';
+
+  const slides = document.querySelectorAll('.slide');
+  const total = slides.length;
+  let current = 0;
+
+  function goTo(index) {
+    if (index < 0 || index >= total) return;
+    slides[current].classList.remove('active');
+    current = index;
+    slides[current].classList.add('active');
+    updateCounter();
+    window.scrollTo(0, 0);
+    history.replaceState(null, '', '#slide-' + (current + 1));
+  }
+
+  function next() { goTo(current + 1); }
+  function prev() { goTo(current - 1); }
+
+  document.addEventListener('keydown', function (e) {
+    if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+      case ' ':
+        e.preventDefault();
+        next();
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        e.preventDefault();
+        prev();
+        break;
+      case 'Home':
+        e.preventDefault();
+        goTo(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        goTo(total - 1);
+        break;
+    }
+  });
+
+  var viewport = document.querySelector('.slide-viewport');
+  if (viewport) {
+    viewport.addEventListener('click', function (e) {
+      if (e.target === this || e.target.classList.contains('slide')) {
+        var rect = this.getBoundingClientRect();
+        var x = e.clientX - rect.left;
+        if (x > rect.width * 0.75) next();
+        else if (x < rect.width * 0.25) prev();
+      }
+    });
+  }
+
+  var counter = document.querySelector('.slide-counter');
+  function updateCounter() {
+    if (counter) counter.textContent = (current + 1) + ' / ' + total;
+  }
+
+  var baseFontSize = parseInt(localStorage.getItem('adkSlideFontSize')) || 18;
+  applyFontSize();
+
+  window.adjustFont = function (delta) {
+    if (delta === 0) {
+      baseFontSize = 18;
+    } else {
+      baseFontSize = Math.max(14, Math.min(28, baseFontSize + delta));
+    }
+    applyFontSize();
+    localStorage.setItem('adkSlideFontSize', baseFontSize);
+  };
+
+  function applyFontSize() {
+    document.documentElement.style.setProperty('--slide-font-size', baseFontSize + 'px');
+  }
+
+  var themeBtn = document.querySelector('.theme-toggle');
+  var savedTheme = localStorage.getItem('adkTheme');
+  if (savedTheme) {
+    document.documentElement.setAttribute('data-theme', savedTheme);
+  }
+
+  if (themeBtn) {
+    themeBtn.addEventListener('click', function () {
+      var html = document.documentElement;
+      var nextTheme = html.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+      html.setAttribute('data-theme', nextTheme);
+      localStorage.setItem('adkTheme', nextTheme);
+    });
+  }
+
+  var touchStartX = 0;
+  var touchStartY = 0;
+
+  document.addEventListener('touchstart', function (e) {
+    touchStartX = e.changedTouches[0].screenX;
+    touchStartY = e.changedTouches[0].screenY;
+  }, { passive: true });
+
+  document.addEventListener('touchend', function (e) {
+    var dx = e.changedTouches[0].screenX - touchStartX;
+    var dy = e.changedTouches[0].screenY - touchStartY;
+    if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > 50) {
+      if (dx < 0) next();
+      else prev();
+    }
+  }, { passive: true });
+
+  var hash = window.location.hash;
+  if (hash && hash.startsWith('#slide-')) {
+    var n = parseInt(hash.replace('#slide-', ''));
+    if (!isNaN(n) && n >= 1 && n <= total) {
+      current = n - 1;
+    }
+  }
+
+  slides[current].classList.add('active');
+  updateCounter();
+
+  window.addEventListener('hashchange', function () {
+    var h = window.location.hash;
+    if (h && h.startsWith('#slide-')) {
+      var n = parseInt(h.replace('#slide-', ''));
+      if (!isNaN(n) && n >= 1 && n <= total && n - 1 !== current) {
+        goTo(n - 1);
+      }
+    }
+  });
+
+})();
+</script>
+<!-- END-INLINED-SCRIPT -->
 </body>
 </html>

--- a/slides/module-08-memory/index.html
+++ b/slides/module-08-memory/index.html
@@ -796,6 +796,816 @@ body {
   }
 }
   </style>
+
+  <!-- BEGIN-INLINED-STYLES -->
+  <style>
+  /* shared.css — generated; edit slides/shared/shared.css */
+/* ADK Course — Shared Design Tokens
+   Adapted from barcik-training-exin-ai-foundation/css/shared.css.
+   Family-consistent navy with amber accent (distinct from EXIN gold). */
+
+@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;500;600;700;800&display=swap');
+
+:root {
+  /* Brand colors */
+  --navy: #1E3A5F;
+  --navy-light: #2A5280;
+  --navy-dark: #122542;
+  --amber: #F59E0B;
+  --amber-light: #FBBF24;
+  --amber-dark: #B45309;
+  --white: #FFFFFF;
+  --gray-50: #F8F9FA;
+  --gray-100: #F1F3F5;
+  --gray-200: #E9ECEF;
+  --gray-300: #DEE2E6;
+  --gray-400: #CED4DA;
+  --gray-500: #ADB5BD;
+  --gray-600: #868E96;
+  --gray-700: #495057;
+  --gray-800: #343A40;
+  --gray-900: #212529;
+
+  /* Semantic */
+  --bg-primary: var(--white);
+  --bg-secondary: var(--gray-50);
+  --bg-card: var(--white);
+  --text-primary: var(--gray-900);
+  --text-secondary: var(--gray-700);
+  --text-muted: var(--gray-600);
+  --border-color: var(--gray-200);
+  --accent: var(--navy);
+  --accent-light: var(--navy-light);
+  --highlight: var(--amber);
+  --highlight-bg: #FEF3C7;
+  --success: #2E7D32;
+  --success-bg: #E8F5E9;
+  --error: #C62828;
+  --error-bg: #FFEBEE;
+  --info: #1565C0;
+  --info-bg: #E3F2FD;
+
+  /* Typography */
+  --font-sans: 'Nunito', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+  --text-3xl: 1.875rem;
+  --text-4xl: 2.25rem;
+
+  /* Spacing */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-10: 2.5rem;
+  --space-12: 3rem;
+  --space-16: 4rem;
+
+  /* Radius */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.07);
+  --shadow-lg: 0 10px 15px rgba(0,0,0,0.1);
+
+  /* Transitions */
+  --transition-fast: 150ms ease;
+  --transition-normal: 250ms ease;
+  --transition-slow: 350ms ease;
+}
+
+[data-theme="dark"] {
+  --bg-primary: #0D1117;
+  --bg-secondary: #161B22;
+  --bg-card: #1C2128;
+  --text-primary: #E6EDF3;
+  --text-secondary: #B1BAC4;
+  --text-muted: #8B949E;
+  --border-color: #30363D;
+  --accent: #58A6FF;
+  --accent-light: #79C0FF;
+  --highlight: var(--amber);
+  --highlight-bg: #2D2200;
+  --success: #56D364;
+  --success-bg: #0D2818;
+  --error: #F85149;
+  --error-bg: #2D1214;
+  --info: #58A6FF;
+  --info-bg: #0D1B2E;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.3);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.4);
+  --shadow-lg: 0 10px 15px rgba(0,0,0,0.5);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg-primary: #0D1117;
+    --bg-secondary: #161B22;
+    --bg-card: #1C2128;
+    --text-primary: #E6EDF3;
+    --text-secondary: #B1BAC4;
+    --text-muted: #8B949E;
+    --border-color: #30363D;
+    --accent: #58A6FF;
+    --accent-light: #79C0FF;
+    --highlight: var(--amber);
+    --highlight-bg: #2D2200;
+    --success: #56D364;
+    --success-bg: #0D2818;
+    --error: #F85149;
+    --error-bg: #2D1214;
+    --info: #58A6FF;
+    --info-bg: #0D1B2E;
+  }
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  line-height: 1.6;
+  color: var(--text-primary);
+  background-color: var(--bg-primary);
+  -webkit-font-smoothing: antialiased;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow var(--transition-normal);
+}
+
+.card:hover {
+  box-shadow: var(--shadow-md);
+}
+
+.callout {
+  padding: var(--space-4) var(--space-6);
+  border-radius: var(--radius-md);
+  margin: var(--space-4) 0;
+  border-left: 4px solid;
+}
+
+.callout-key { background: var(--highlight-bg); border-color: var(--amber); }
+.callout-gotcha { background: var(--error-bg); border-color: var(--error); }
+.callout-tip { background: var(--info-bg); border-color: var(--info); }
+.callout-success { background: var(--success-bg); border-color: var(--success); }
+
+.callout-title {
+  font-weight: 700;
+  font-size: var(--text-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: var(--space-2);
+}
+
+.text-center { text-align: center; }
+.text-muted { color: var(--text-muted); }
+.font-mono { font-family: var(--font-mono); }
+.mt-4 { margin-top: var(--space-4); }
+.mt-8 { margin-top: var(--space-8); }
+.mb-4 { margin-bottom: var(--space-4); }
+.mb-8 { margin-bottom: var(--space-8); }
+.mx-auto { margin-left: auto; margin-right: auto; }
+.max-w-4xl { max-width: 56rem; }
+.hidden { display: none !important; }
+  /* slides.css — generated; edit slides/shared/slides.css */
+/* ADK Course — Slide Presentation Theme
+   Adapted from barcik-training-exin-ai-foundation/slides/css/slides.css.
+   Adds data-type="code" slide variant for Python snippets. */
+
+:root {
+  --slide-font-size: 18px;
+  --strip-height: 48px;
+}
+
+body {
+  margin: 0;
+  overflow: hidden;
+  background: var(--bg-primary);
+}
+
+/* ── Progress Strip ──────────────────────────────── */
+.progress-strip {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  height: var(--strip-height);
+  background: var(--navy);
+  display: flex;
+  align-items: center;
+  z-index: 100;
+  padding: 0 var(--space-4);
+  gap: var(--space-4);
+  box-shadow: var(--shadow-md);
+  font-family: var(--font-sans);
+}
+
+.progress-home {
+  color: var(--amber);
+  text-decoration: none;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: var(--radius-md);
+  white-space: nowrap;
+  transition: all var(--transition-fast);
+}
+
+.progress-home:hover {
+  background: rgba(255,255,255,0.1);
+  border-color: var(--amber);
+}
+
+.progress-title {
+  color: rgba(255,255,255,0.85);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  flex: 1;
+  text-align: center;
+}
+
+.progress-title .quick-path-badge {
+  display: inline-block;
+  background: var(--amber);
+  color: var(--navy-dark);
+  font-size: 0.68rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.15rem 0.55rem;
+  border-radius: 9999px;
+  margin-left: 0.6rem;
+  vertical-align: 2px;
+}
+
+.progress-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.slide-counter {
+  color: rgba(255,255,255,0.6);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  font-family: var(--font-mono);
+  white-space: nowrap;
+}
+
+.progress-strip .theme-toggle {
+  background: rgba(255,255,255,0.1);
+  color: rgba(255,255,255,0.7);
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: var(--radius-md);
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-xs);
+  cursor: pointer;
+  font-family: var(--font-sans);
+  transition: all var(--transition-fast);
+}
+
+.progress-strip .theme-toggle:hover {
+  background: rgba(255,255,255,0.2);
+  color: white;
+}
+
+/* ── Viewport ────────────────────────────────────── */
+.slide-viewport {
+  position: fixed;
+  top: var(--strip-height);
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow: hidden;
+}
+
+/* ── Slide Base ──────────────────────────────────── */
+.slide {
+  display: none;
+  position: absolute;
+  inset: 0;
+  overflow-y: auto;
+  padding: var(--space-10) var(--space-16);
+  font-size: var(--slide-font-size);
+  line-height: 1.6;
+  font-family: var(--font-sans);
+  color: var(--text-primary);
+  background: var(--bg-primary);
+}
+
+.slide.active {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  animation: fadeIn 0.25s ease;
+}
+
+.slide > * {
+  max-width: 1100px;
+  width: 100% !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
+  box-sizing: border-box;
+  text-align: inherit;
+}
+
+.slide > .topic-badge {
+  width: auto !important;
+  max-width: none;
+  align-self: center;
+}
+
+/* ── Section Title ───────────────────────────────── */
+.slide[data-type="section-title"] {
+  background: linear-gradient(135deg, var(--navy) 0%, var(--navy-light) 100%);
+  text-align: center;
+}
+
+.slide[data-type="section-title"] h1,
+.slide[data-type="section-title"] h2,
+.slide[data-type="section-title"] h3 {
+  color: white;
+}
+
+.slide[data-type="section-title"] p {
+  color: rgba(255,255,255,0.85);
+}
+
+.slide[data-type="section-title"] .topic-badge {
+  display: inline-block;
+  background: var(--amber);
+  color: var(--navy-dark);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  padding: var(--space-2) var(--space-4);
+  border-radius: 9999px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: var(--space-4);
+  width: auto !important;
+}
+
+.slide[data-type="section-title"] .highlight-text {
+  color: var(--amber);
+  font-weight: 600;
+}
+
+/* ── Typography ──────────────────────────────────── */
+.slide h1 {
+  font-size: 2.4em;
+  font-weight: 800;
+  color: var(--navy);
+  margin-bottom: var(--space-4);
+  line-height: 1.15;
+}
+
+.slide h2 {
+  font-size: 1.6em;
+  font-weight: 700;
+  color: var(--navy);
+  margin-bottom: var(--space-4);
+  padding-bottom: var(--space-2);
+  border-bottom: 3px solid var(--amber);
+}
+
+.slide h3 {
+  font-size: 1.2em;
+  font-weight: 600;
+  color: var(--navy-light);
+  margin-bottom: var(--space-3);
+}
+
+.slide p {
+  margin-bottom: var(--space-3);
+  color: var(--text-secondary);
+}
+
+.slide strong {
+  color: var(--navy);
+  font-weight: 700;
+}
+
+.slide em {
+  color: var(--amber-dark);
+  font-style: italic;
+}
+
+.slide ul, .slide ol {
+  margin-left: 1.2em;
+  margin-bottom: var(--space-4);
+}
+
+.slide li {
+  margin-bottom: var(--space-2);
+  color: var(--text-secondary);
+}
+
+.slide li::marker {
+  color: var(--amber);
+}
+
+[data-theme="dark"] .slide h1,
+[data-theme="dark"] .slide h2 { color: var(--text-primary); }
+[data-theme="dark"] .slide h3 { color: var(--text-secondary); }
+[data-theme="dark"] .slide strong { color: var(--text-primary); }
+[data-theme="dark"] .slide h2 { border-bottom-color: var(--amber); }
+
+.highlight-text {
+  color: var(--amber-dark);
+  font-weight: 600;
+}
+
+[data-theme="dark"] .highlight-text {
+  color: var(--amber);
+}
+
+/* ── Grid ────────────────────────────────────────── */
+.slide[data-type="grid"] .grid-layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: var(--space-4);
+  margin-top: var(--space-4);
+}
+
+.grid-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5);
+  transition: all var(--transition-normal);
+}
+
+.grid-card:hover {
+  box-shadow: var(--shadow-md);
+  transform: translateY(-2px);
+  border-color: var(--accent);
+}
+
+.grid-card.highlight {
+  border-color: var(--amber);
+  box-shadow: 0 0 0 1px var(--amber), var(--shadow-sm);
+}
+
+.grid-card-title {
+  font-weight: 700;
+  color: var(--text-primary);
+  font-size: 1.05em;
+  margin-bottom: var(--space-2);
+}
+
+.grid-card-body {
+  color: var(--text-secondary);
+  font-size: 0.9em;
+  line-height: 1.5;
+}
+
+/* ── Split ───────────────────────────────────────── */
+.slide[data-type="split"] .split-layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-8);
+  margin-top: var(--space-4);
+}
+
+@media (max-width: 768px) {
+  .slide[data-type="split"] .split-layout { grid-template-columns: 1fr; }
+}
+
+/* ── Comparison ──────────────────────────────────── */
+.slide[data-type="comparison"] .comparison-layout {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: var(--space-6);
+  align-items: start;
+  margin-top: var(--space-4);
+}
+
+.vs-left, .vs-right {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+}
+
+.vs-divider {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5em;
+  font-weight: 800;
+  color: var(--text-muted);
+  align-self: center;
+}
+
+@media (max-width: 768px) {
+  .slide[data-type="comparison"] .comparison-layout {
+    grid-template-columns: 1fr;
+  }
+  .vs-divider { display: none; }
+}
+
+/* ── Quote ───────────────────────────────────────── */
+.slide[data-type="quote"] {
+  text-align: center;
+}
+
+.quote-text {
+  font-size: 1.5em;
+  font-weight: 300;
+  font-style: italic;
+  color: var(--text-primary);
+  max-width: 80%;
+  line-height: 1.5;
+  position: relative;
+  padding: 0.5em 1em;
+  margin: 0 auto;
+}
+
+.quote-text::before {
+  content: '\201C';
+  position: absolute;
+  left: -0.3em;
+  top: -0.2em;
+  font-size: 3.5em;
+  color: var(--amber);
+  font-weight: 800;
+  line-height: 1;
+  opacity: 0.3;
+}
+
+.quote-source {
+  margin-top: var(--space-4);
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  font-weight: 500;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.quote-source::before { content: '\2014\00a0'; }
+
+/* ── Key Fact ────────────────────────────────────── */
+.slide[data-type="keyfact"] {
+  text-align: center;
+}
+
+.slide[data-type="keyfact"] p {
+  font-size: 1.5em;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.35;
+}
+
+.slide[data-type="keyfact"] strong {
+  color: var(--amber-dark);
+}
+
+[data-theme="dark"] .slide[data-type="keyfact"] strong {
+  color: var(--amber);
+}
+
+/* ── Hero ────────────────────────────────────────── */
+.slide[data-type="hero"] {
+  text-align: center;
+}
+
+/* ── Example / Code ──────────────────────────────── */
+.slide[data-type="example"] {
+  border-left: 4px solid var(--info);
+}
+
+.slide[data-type="code"] pre,
+.slide pre {
+  background: var(--gray-900);
+  color: #E6EDF3;
+  border-radius: var(--radius-md);
+  padding: var(--space-4) var(--space-5);
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  line-height: 1.55;
+  margin: var(--space-3) 0;
+  box-shadow: var(--shadow-sm);
+}
+
+.slide[data-type="code"] pre code,
+.slide pre code {
+  background: none;
+  color: inherit;
+  padding: 0;
+  font-family: var(--font-mono);
+}
+
+.slide code {
+  font-family: var(--font-mono);
+  background: var(--bg-secondary);
+  color: var(--navy);
+  padding: 0.1em 0.35em;
+  border-radius: var(--radius-sm);
+  font-size: 0.9em;
+}
+
+[data-theme="dark"] .slide code {
+  color: var(--accent-light);
+  background: var(--gray-800);
+}
+
+.slide .code-caption {
+  color: var(--text-muted);
+  font-size: 0.85em;
+  font-style: italic;
+  margin-top: var(--space-2);
+}
+
+/* ── Definition Cards ────────────────────────────── */
+.def-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-left: 4px solid var(--navy-light);
+  border-radius: 0 var(--radius-lg) var(--radius-lg) 0;
+  padding: var(--space-4) var(--space-5);
+  margin-bottom: var(--space-3);
+  transition: border-color var(--transition-fast);
+}
+
+.def-card.highlight {
+  border-left-color: var(--amber);
+}
+
+.def-term {
+  font-size: var(--text-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--navy-light);
+  margin-bottom: var(--space-2);
+}
+
+[data-theme="dark"] .def-term { color: var(--accent); }
+
+.def-text {
+  color: var(--text-primary);
+  line-height: 1.5;
+}
+
+/* ── Callouts on slides ──────────────────────────── */
+.slide .callout {
+  margin: var(--space-4) 0;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* ── Tables ──────────────────────────────────────── */
+.slide table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  margin: var(--space-4) 0;
+  font-size: 0.92em;
+}
+
+.slide table th {
+  background: var(--navy);
+  color: white;
+  padding: var(--space-3) var(--space-4);
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.9em;
+}
+
+.slide table td {
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border-color);
+  color: var(--text-secondary);
+}
+
+.slide table tr:nth-child(even) { background: var(--bg-secondary); }
+.slide table tr:last-child td { border-bottom: none; }
+
+/* ── Two-Column Layout ───────────────────────────── */
+.two-col {
+  display: flex;
+  gap: var(--space-8);
+  align-items: flex-start;
+}
+
+.col { flex: 1; min-width: 0; }
+
+@media (max-width: 768px) {
+  .two-col { flex-direction: column; gap: var(--space-4); }
+}
+
+/* ── ASCII-art / diagram ─────────────────────────── */
+.slide .diagram {
+  background: var(--gray-900);
+  color: #C9D1D9;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  line-height: 1.4;
+  padding: var(--space-4) var(--space-5);
+  border-radius: var(--radius-md);
+  white-space: pre;
+  overflow-x: auto;
+  margin: var(--space-3) 0;
+}
+
+/* ── Font Controls ───────────────────────────────── */
+.font-controls {
+  position: fixed;
+  bottom: var(--space-6);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: var(--space-2);
+  z-index: 100;
+  background: var(--bg-card);
+  padding: var(--space-2);
+  border-radius: 9999px;
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-md);
+  opacity: 0.5;
+  transition: opacity var(--transition-fast);
+}
+
+.font-controls:hover { opacity: 1; }
+
+.font-controls button {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.font-controls button:hover {
+  background: var(--navy);
+  color: white;
+  border-color: var(--navy);
+}
+
+/* ── Animations ──────────────────────────────────── */
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Print ───────────────────────────────────────── */
+@media print {
+  .progress-strip, .font-controls { display: none !important; }
+  .slide-viewport { position: static; overflow: visible; }
+  .slide {
+    display: block !important;
+    position: static !important;
+    page-break-after: always;
+    padding: 2cm;
+  }
+  .slide[data-type="section-title"] {
+    background: var(--navy) !important;
+    color: white !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+  .slide pre {
+    background: var(--gray-100) !important;
+    color: var(--gray-900) !important;
+    border: 1px solid var(--gray-400);
+  }
+}
+  </style>
+  <!-- END-INLINED-STYLES -->
 </head>
 <body>
   <nav class="progress-strip">
@@ -1122,5 +1932,148 @@ Instance 2 (FRESH DatabaseSessionService → same app.db)
 
 })();
 </script>
+
+  <!-- BEGIN-INLINED-SCRIPT -->
+<script>
+/* ADK Course — Slide Engine
+   Adapted from barcik-training-exin-ai-foundation/slides/js/slides.js.
+   Per-module decks; lightweight nav with keyboard, touch, hash routing,
+   font controls, theme toggle. */
+
+(function () {
+  'use strict';
+
+  const slides = document.querySelectorAll('.slide');
+  const total = slides.length;
+  let current = 0;
+
+  function goTo(index) {
+    if (index < 0 || index >= total) return;
+    slides[current].classList.remove('active');
+    current = index;
+    slides[current].classList.add('active');
+    updateCounter();
+    window.scrollTo(0, 0);
+    history.replaceState(null, '', '#slide-' + (current + 1));
+  }
+
+  function next() { goTo(current + 1); }
+  function prev() { goTo(current - 1); }
+
+  document.addEventListener('keydown', function (e) {
+    if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+      case ' ':
+        e.preventDefault();
+        next();
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        e.preventDefault();
+        prev();
+        break;
+      case 'Home':
+        e.preventDefault();
+        goTo(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        goTo(total - 1);
+        break;
+    }
+  });
+
+  var viewport = document.querySelector('.slide-viewport');
+  if (viewport) {
+    viewport.addEventListener('click', function (e) {
+      if (e.target === this || e.target.classList.contains('slide')) {
+        var rect = this.getBoundingClientRect();
+        var x = e.clientX - rect.left;
+        if (x > rect.width * 0.75) next();
+        else if (x < rect.width * 0.25) prev();
+      }
+    });
+  }
+
+  var counter = document.querySelector('.slide-counter');
+  function updateCounter() {
+    if (counter) counter.textContent = (current + 1) + ' / ' + total;
+  }
+
+  var baseFontSize = parseInt(localStorage.getItem('adkSlideFontSize')) || 18;
+  applyFontSize();
+
+  window.adjustFont = function (delta) {
+    if (delta === 0) {
+      baseFontSize = 18;
+    } else {
+      baseFontSize = Math.max(14, Math.min(28, baseFontSize + delta));
+    }
+    applyFontSize();
+    localStorage.setItem('adkSlideFontSize', baseFontSize);
+  };
+
+  function applyFontSize() {
+    document.documentElement.style.setProperty('--slide-font-size', baseFontSize + 'px');
+  }
+
+  var themeBtn = document.querySelector('.theme-toggle');
+  var savedTheme = localStorage.getItem('adkTheme');
+  if (savedTheme) {
+    document.documentElement.setAttribute('data-theme', savedTheme);
+  }
+
+  if (themeBtn) {
+    themeBtn.addEventListener('click', function () {
+      var html = document.documentElement;
+      var nextTheme = html.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+      html.setAttribute('data-theme', nextTheme);
+      localStorage.setItem('adkTheme', nextTheme);
+    });
+  }
+
+  var touchStartX = 0;
+  var touchStartY = 0;
+
+  document.addEventListener('touchstart', function (e) {
+    touchStartX = e.changedTouches[0].screenX;
+    touchStartY = e.changedTouches[0].screenY;
+  }, { passive: true });
+
+  document.addEventListener('touchend', function (e) {
+    var dx = e.changedTouches[0].screenX - touchStartX;
+    var dy = e.changedTouches[0].screenY - touchStartY;
+    if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > 50) {
+      if (dx < 0) next();
+      else prev();
+    }
+  }, { passive: true });
+
+  var hash = window.location.hash;
+  if (hash && hash.startsWith('#slide-')) {
+    var n = parseInt(hash.replace('#slide-', ''));
+    if (!isNaN(n) && n >= 1 && n <= total) {
+      current = n - 1;
+    }
+  }
+
+  slides[current].classList.add('active');
+  updateCounter();
+
+  window.addEventListener('hashchange', function () {
+    var h = window.location.hash;
+    if (h && h.startsWith('#slide-')) {
+      var n = parseInt(h.replace('#slide-', ''));
+      if (!isNaN(n) && n >= 1 && n <= total && n - 1 !== current) {
+        goTo(n - 1);
+      }
+    }
+  });
+
+})();
+</script>
+<!-- END-INLINED-SCRIPT -->
 </body>
 </html>

--- a/slides/module-09-evaluation/index.html
+++ b/slides/module-09-evaluation/index.html
@@ -796,6 +796,816 @@ body {
   }
 }
   </style>
+
+  <!-- BEGIN-INLINED-STYLES -->
+  <style>
+  /* shared.css — generated; edit slides/shared/shared.css */
+/* ADK Course — Shared Design Tokens
+   Adapted from barcik-training-exin-ai-foundation/css/shared.css.
+   Family-consistent navy with amber accent (distinct from EXIN gold). */
+
+@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;500;600;700;800&display=swap');
+
+:root {
+  /* Brand colors */
+  --navy: #1E3A5F;
+  --navy-light: #2A5280;
+  --navy-dark: #122542;
+  --amber: #F59E0B;
+  --amber-light: #FBBF24;
+  --amber-dark: #B45309;
+  --white: #FFFFFF;
+  --gray-50: #F8F9FA;
+  --gray-100: #F1F3F5;
+  --gray-200: #E9ECEF;
+  --gray-300: #DEE2E6;
+  --gray-400: #CED4DA;
+  --gray-500: #ADB5BD;
+  --gray-600: #868E96;
+  --gray-700: #495057;
+  --gray-800: #343A40;
+  --gray-900: #212529;
+
+  /* Semantic */
+  --bg-primary: var(--white);
+  --bg-secondary: var(--gray-50);
+  --bg-card: var(--white);
+  --text-primary: var(--gray-900);
+  --text-secondary: var(--gray-700);
+  --text-muted: var(--gray-600);
+  --border-color: var(--gray-200);
+  --accent: var(--navy);
+  --accent-light: var(--navy-light);
+  --highlight: var(--amber);
+  --highlight-bg: #FEF3C7;
+  --success: #2E7D32;
+  --success-bg: #E8F5E9;
+  --error: #C62828;
+  --error-bg: #FFEBEE;
+  --info: #1565C0;
+  --info-bg: #E3F2FD;
+
+  /* Typography */
+  --font-sans: 'Nunito', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+  --text-3xl: 1.875rem;
+  --text-4xl: 2.25rem;
+
+  /* Spacing */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-10: 2.5rem;
+  --space-12: 3rem;
+  --space-16: 4rem;
+
+  /* Radius */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.07);
+  --shadow-lg: 0 10px 15px rgba(0,0,0,0.1);
+
+  /* Transitions */
+  --transition-fast: 150ms ease;
+  --transition-normal: 250ms ease;
+  --transition-slow: 350ms ease;
+}
+
+[data-theme="dark"] {
+  --bg-primary: #0D1117;
+  --bg-secondary: #161B22;
+  --bg-card: #1C2128;
+  --text-primary: #E6EDF3;
+  --text-secondary: #B1BAC4;
+  --text-muted: #8B949E;
+  --border-color: #30363D;
+  --accent: #58A6FF;
+  --accent-light: #79C0FF;
+  --highlight: var(--amber);
+  --highlight-bg: #2D2200;
+  --success: #56D364;
+  --success-bg: #0D2818;
+  --error: #F85149;
+  --error-bg: #2D1214;
+  --info: #58A6FF;
+  --info-bg: #0D1B2E;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.3);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.4);
+  --shadow-lg: 0 10px 15px rgba(0,0,0,0.5);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg-primary: #0D1117;
+    --bg-secondary: #161B22;
+    --bg-card: #1C2128;
+    --text-primary: #E6EDF3;
+    --text-secondary: #B1BAC4;
+    --text-muted: #8B949E;
+    --border-color: #30363D;
+    --accent: #58A6FF;
+    --accent-light: #79C0FF;
+    --highlight: var(--amber);
+    --highlight-bg: #2D2200;
+    --success: #56D364;
+    --success-bg: #0D2818;
+    --error: #F85149;
+    --error-bg: #2D1214;
+    --info: #58A6FF;
+    --info-bg: #0D1B2E;
+  }
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  line-height: 1.6;
+  color: var(--text-primary);
+  background-color: var(--bg-primary);
+  -webkit-font-smoothing: antialiased;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow var(--transition-normal);
+}
+
+.card:hover {
+  box-shadow: var(--shadow-md);
+}
+
+.callout {
+  padding: var(--space-4) var(--space-6);
+  border-radius: var(--radius-md);
+  margin: var(--space-4) 0;
+  border-left: 4px solid;
+}
+
+.callout-key { background: var(--highlight-bg); border-color: var(--amber); }
+.callout-gotcha { background: var(--error-bg); border-color: var(--error); }
+.callout-tip { background: var(--info-bg); border-color: var(--info); }
+.callout-success { background: var(--success-bg); border-color: var(--success); }
+
+.callout-title {
+  font-weight: 700;
+  font-size: var(--text-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: var(--space-2);
+}
+
+.text-center { text-align: center; }
+.text-muted { color: var(--text-muted); }
+.font-mono { font-family: var(--font-mono); }
+.mt-4 { margin-top: var(--space-4); }
+.mt-8 { margin-top: var(--space-8); }
+.mb-4 { margin-bottom: var(--space-4); }
+.mb-8 { margin-bottom: var(--space-8); }
+.mx-auto { margin-left: auto; margin-right: auto; }
+.max-w-4xl { max-width: 56rem; }
+.hidden { display: none !important; }
+  /* slides.css — generated; edit slides/shared/slides.css */
+/* ADK Course — Slide Presentation Theme
+   Adapted from barcik-training-exin-ai-foundation/slides/css/slides.css.
+   Adds data-type="code" slide variant for Python snippets. */
+
+:root {
+  --slide-font-size: 18px;
+  --strip-height: 48px;
+}
+
+body {
+  margin: 0;
+  overflow: hidden;
+  background: var(--bg-primary);
+}
+
+/* ── Progress Strip ──────────────────────────────── */
+.progress-strip {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  height: var(--strip-height);
+  background: var(--navy);
+  display: flex;
+  align-items: center;
+  z-index: 100;
+  padding: 0 var(--space-4);
+  gap: var(--space-4);
+  box-shadow: var(--shadow-md);
+  font-family: var(--font-sans);
+}
+
+.progress-home {
+  color: var(--amber);
+  text-decoration: none;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: var(--radius-md);
+  white-space: nowrap;
+  transition: all var(--transition-fast);
+}
+
+.progress-home:hover {
+  background: rgba(255,255,255,0.1);
+  border-color: var(--amber);
+}
+
+.progress-title {
+  color: rgba(255,255,255,0.85);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  flex: 1;
+  text-align: center;
+}
+
+.progress-title .quick-path-badge {
+  display: inline-block;
+  background: var(--amber);
+  color: var(--navy-dark);
+  font-size: 0.68rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.15rem 0.55rem;
+  border-radius: 9999px;
+  margin-left: 0.6rem;
+  vertical-align: 2px;
+}
+
+.progress-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.slide-counter {
+  color: rgba(255,255,255,0.6);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  font-family: var(--font-mono);
+  white-space: nowrap;
+}
+
+.progress-strip .theme-toggle {
+  background: rgba(255,255,255,0.1);
+  color: rgba(255,255,255,0.7);
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: var(--radius-md);
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-xs);
+  cursor: pointer;
+  font-family: var(--font-sans);
+  transition: all var(--transition-fast);
+}
+
+.progress-strip .theme-toggle:hover {
+  background: rgba(255,255,255,0.2);
+  color: white;
+}
+
+/* ── Viewport ────────────────────────────────────── */
+.slide-viewport {
+  position: fixed;
+  top: var(--strip-height);
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow: hidden;
+}
+
+/* ── Slide Base ──────────────────────────────────── */
+.slide {
+  display: none;
+  position: absolute;
+  inset: 0;
+  overflow-y: auto;
+  padding: var(--space-10) var(--space-16);
+  font-size: var(--slide-font-size);
+  line-height: 1.6;
+  font-family: var(--font-sans);
+  color: var(--text-primary);
+  background: var(--bg-primary);
+}
+
+.slide.active {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  animation: fadeIn 0.25s ease;
+}
+
+.slide > * {
+  max-width: 1100px;
+  width: 100% !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
+  box-sizing: border-box;
+  text-align: inherit;
+}
+
+.slide > .topic-badge {
+  width: auto !important;
+  max-width: none;
+  align-self: center;
+}
+
+/* ── Section Title ───────────────────────────────── */
+.slide[data-type="section-title"] {
+  background: linear-gradient(135deg, var(--navy) 0%, var(--navy-light) 100%);
+  text-align: center;
+}
+
+.slide[data-type="section-title"] h1,
+.slide[data-type="section-title"] h2,
+.slide[data-type="section-title"] h3 {
+  color: white;
+}
+
+.slide[data-type="section-title"] p {
+  color: rgba(255,255,255,0.85);
+}
+
+.slide[data-type="section-title"] .topic-badge {
+  display: inline-block;
+  background: var(--amber);
+  color: var(--navy-dark);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  padding: var(--space-2) var(--space-4);
+  border-radius: 9999px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: var(--space-4);
+  width: auto !important;
+}
+
+.slide[data-type="section-title"] .highlight-text {
+  color: var(--amber);
+  font-weight: 600;
+}
+
+/* ── Typography ──────────────────────────────────── */
+.slide h1 {
+  font-size: 2.4em;
+  font-weight: 800;
+  color: var(--navy);
+  margin-bottom: var(--space-4);
+  line-height: 1.15;
+}
+
+.slide h2 {
+  font-size: 1.6em;
+  font-weight: 700;
+  color: var(--navy);
+  margin-bottom: var(--space-4);
+  padding-bottom: var(--space-2);
+  border-bottom: 3px solid var(--amber);
+}
+
+.slide h3 {
+  font-size: 1.2em;
+  font-weight: 600;
+  color: var(--navy-light);
+  margin-bottom: var(--space-3);
+}
+
+.slide p {
+  margin-bottom: var(--space-3);
+  color: var(--text-secondary);
+}
+
+.slide strong {
+  color: var(--navy);
+  font-weight: 700;
+}
+
+.slide em {
+  color: var(--amber-dark);
+  font-style: italic;
+}
+
+.slide ul, .slide ol {
+  margin-left: 1.2em;
+  margin-bottom: var(--space-4);
+}
+
+.slide li {
+  margin-bottom: var(--space-2);
+  color: var(--text-secondary);
+}
+
+.slide li::marker {
+  color: var(--amber);
+}
+
+[data-theme="dark"] .slide h1,
+[data-theme="dark"] .slide h2 { color: var(--text-primary); }
+[data-theme="dark"] .slide h3 { color: var(--text-secondary); }
+[data-theme="dark"] .slide strong { color: var(--text-primary); }
+[data-theme="dark"] .slide h2 { border-bottom-color: var(--amber); }
+
+.highlight-text {
+  color: var(--amber-dark);
+  font-weight: 600;
+}
+
+[data-theme="dark"] .highlight-text {
+  color: var(--amber);
+}
+
+/* ── Grid ────────────────────────────────────────── */
+.slide[data-type="grid"] .grid-layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: var(--space-4);
+  margin-top: var(--space-4);
+}
+
+.grid-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5);
+  transition: all var(--transition-normal);
+}
+
+.grid-card:hover {
+  box-shadow: var(--shadow-md);
+  transform: translateY(-2px);
+  border-color: var(--accent);
+}
+
+.grid-card.highlight {
+  border-color: var(--amber);
+  box-shadow: 0 0 0 1px var(--amber), var(--shadow-sm);
+}
+
+.grid-card-title {
+  font-weight: 700;
+  color: var(--text-primary);
+  font-size: 1.05em;
+  margin-bottom: var(--space-2);
+}
+
+.grid-card-body {
+  color: var(--text-secondary);
+  font-size: 0.9em;
+  line-height: 1.5;
+}
+
+/* ── Split ───────────────────────────────────────── */
+.slide[data-type="split"] .split-layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-8);
+  margin-top: var(--space-4);
+}
+
+@media (max-width: 768px) {
+  .slide[data-type="split"] .split-layout { grid-template-columns: 1fr; }
+}
+
+/* ── Comparison ──────────────────────────────────── */
+.slide[data-type="comparison"] .comparison-layout {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: var(--space-6);
+  align-items: start;
+  margin-top: var(--space-4);
+}
+
+.vs-left, .vs-right {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+}
+
+.vs-divider {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5em;
+  font-weight: 800;
+  color: var(--text-muted);
+  align-self: center;
+}
+
+@media (max-width: 768px) {
+  .slide[data-type="comparison"] .comparison-layout {
+    grid-template-columns: 1fr;
+  }
+  .vs-divider { display: none; }
+}
+
+/* ── Quote ───────────────────────────────────────── */
+.slide[data-type="quote"] {
+  text-align: center;
+}
+
+.quote-text {
+  font-size: 1.5em;
+  font-weight: 300;
+  font-style: italic;
+  color: var(--text-primary);
+  max-width: 80%;
+  line-height: 1.5;
+  position: relative;
+  padding: 0.5em 1em;
+  margin: 0 auto;
+}
+
+.quote-text::before {
+  content: '\201C';
+  position: absolute;
+  left: -0.3em;
+  top: -0.2em;
+  font-size: 3.5em;
+  color: var(--amber);
+  font-weight: 800;
+  line-height: 1;
+  opacity: 0.3;
+}
+
+.quote-source {
+  margin-top: var(--space-4);
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  font-weight: 500;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.quote-source::before { content: '\2014\00a0'; }
+
+/* ── Key Fact ────────────────────────────────────── */
+.slide[data-type="keyfact"] {
+  text-align: center;
+}
+
+.slide[data-type="keyfact"] p {
+  font-size: 1.5em;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.35;
+}
+
+.slide[data-type="keyfact"] strong {
+  color: var(--amber-dark);
+}
+
+[data-theme="dark"] .slide[data-type="keyfact"] strong {
+  color: var(--amber);
+}
+
+/* ── Hero ────────────────────────────────────────── */
+.slide[data-type="hero"] {
+  text-align: center;
+}
+
+/* ── Example / Code ──────────────────────────────── */
+.slide[data-type="example"] {
+  border-left: 4px solid var(--info);
+}
+
+.slide[data-type="code"] pre,
+.slide pre {
+  background: var(--gray-900);
+  color: #E6EDF3;
+  border-radius: var(--radius-md);
+  padding: var(--space-4) var(--space-5);
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  line-height: 1.55;
+  margin: var(--space-3) 0;
+  box-shadow: var(--shadow-sm);
+}
+
+.slide[data-type="code"] pre code,
+.slide pre code {
+  background: none;
+  color: inherit;
+  padding: 0;
+  font-family: var(--font-mono);
+}
+
+.slide code {
+  font-family: var(--font-mono);
+  background: var(--bg-secondary);
+  color: var(--navy);
+  padding: 0.1em 0.35em;
+  border-radius: var(--radius-sm);
+  font-size: 0.9em;
+}
+
+[data-theme="dark"] .slide code {
+  color: var(--accent-light);
+  background: var(--gray-800);
+}
+
+.slide .code-caption {
+  color: var(--text-muted);
+  font-size: 0.85em;
+  font-style: italic;
+  margin-top: var(--space-2);
+}
+
+/* ── Definition Cards ────────────────────────────── */
+.def-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-left: 4px solid var(--navy-light);
+  border-radius: 0 var(--radius-lg) var(--radius-lg) 0;
+  padding: var(--space-4) var(--space-5);
+  margin-bottom: var(--space-3);
+  transition: border-color var(--transition-fast);
+}
+
+.def-card.highlight {
+  border-left-color: var(--amber);
+}
+
+.def-term {
+  font-size: var(--text-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--navy-light);
+  margin-bottom: var(--space-2);
+}
+
+[data-theme="dark"] .def-term { color: var(--accent); }
+
+.def-text {
+  color: var(--text-primary);
+  line-height: 1.5;
+}
+
+/* ── Callouts on slides ──────────────────────────── */
+.slide .callout {
+  margin: var(--space-4) 0;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* ── Tables ──────────────────────────────────────── */
+.slide table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  margin: var(--space-4) 0;
+  font-size: 0.92em;
+}
+
+.slide table th {
+  background: var(--navy);
+  color: white;
+  padding: var(--space-3) var(--space-4);
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.9em;
+}
+
+.slide table td {
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border-color);
+  color: var(--text-secondary);
+}
+
+.slide table tr:nth-child(even) { background: var(--bg-secondary); }
+.slide table tr:last-child td { border-bottom: none; }
+
+/* ── Two-Column Layout ───────────────────────────── */
+.two-col {
+  display: flex;
+  gap: var(--space-8);
+  align-items: flex-start;
+}
+
+.col { flex: 1; min-width: 0; }
+
+@media (max-width: 768px) {
+  .two-col { flex-direction: column; gap: var(--space-4); }
+}
+
+/* ── ASCII-art / diagram ─────────────────────────── */
+.slide .diagram {
+  background: var(--gray-900);
+  color: #C9D1D9;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  line-height: 1.4;
+  padding: var(--space-4) var(--space-5);
+  border-radius: var(--radius-md);
+  white-space: pre;
+  overflow-x: auto;
+  margin: var(--space-3) 0;
+}
+
+/* ── Font Controls ───────────────────────────────── */
+.font-controls {
+  position: fixed;
+  bottom: var(--space-6);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: var(--space-2);
+  z-index: 100;
+  background: var(--bg-card);
+  padding: var(--space-2);
+  border-radius: 9999px;
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-md);
+  opacity: 0.5;
+  transition: opacity var(--transition-fast);
+}
+
+.font-controls:hover { opacity: 1; }
+
+.font-controls button {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.font-controls button:hover {
+  background: var(--navy);
+  color: white;
+  border-color: var(--navy);
+}
+
+/* ── Animations ──────────────────────────────────── */
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Print ───────────────────────────────────────── */
+@media print {
+  .progress-strip, .font-controls { display: none !important; }
+  .slide-viewport { position: static; overflow: visible; }
+  .slide {
+    display: block !important;
+    position: static !important;
+    page-break-after: always;
+    padding: 2cm;
+  }
+  .slide[data-type="section-title"] {
+    background: var(--navy) !important;
+    color: white !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+  .slide pre {
+    background: var(--gray-100) !important;
+    color: var(--gray-900) !important;
+    border: 1px solid var(--gray-400);
+  }
+}
+  </style>
+  <!-- END-INLINED-STYLES -->
 </head>
 <body>
   <nav class="progress-strip">
@@ -1114,5 +1924,148 @@ def judge(prompt, expected, actual) -> float:
 
 })();
 </script>
+
+  <!-- BEGIN-INLINED-SCRIPT -->
+<script>
+/* ADK Course — Slide Engine
+   Adapted from barcik-training-exin-ai-foundation/slides/js/slides.js.
+   Per-module decks; lightweight nav with keyboard, touch, hash routing,
+   font controls, theme toggle. */
+
+(function () {
+  'use strict';
+
+  const slides = document.querySelectorAll('.slide');
+  const total = slides.length;
+  let current = 0;
+
+  function goTo(index) {
+    if (index < 0 || index >= total) return;
+    slides[current].classList.remove('active');
+    current = index;
+    slides[current].classList.add('active');
+    updateCounter();
+    window.scrollTo(0, 0);
+    history.replaceState(null, '', '#slide-' + (current + 1));
+  }
+
+  function next() { goTo(current + 1); }
+  function prev() { goTo(current - 1); }
+
+  document.addEventListener('keydown', function (e) {
+    if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+      case ' ':
+        e.preventDefault();
+        next();
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        e.preventDefault();
+        prev();
+        break;
+      case 'Home':
+        e.preventDefault();
+        goTo(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        goTo(total - 1);
+        break;
+    }
+  });
+
+  var viewport = document.querySelector('.slide-viewport');
+  if (viewport) {
+    viewport.addEventListener('click', function (e) {
+      if (e.target === this || e.target.classList.contains('slide')) {
+        var rect = this.getBoundingClientRect();
+        var x = e.clientX - rect.left;
+        if (x > rect.width * 0.75) next();
+        else if (x < rect.width * 0.25) prev();
+      }
+    });
+  }
+
+  var counter = document.querySelector('.slide-counter');
+  function updateCounter() {
+    if (counter) counter.textContent = (current + 1) + ' / ' + total;
+  }
+
+  var baseFontSize = parseInt(localStorage.getItem('adkSlideFontSize')) || 18;
+  applyFontSize();
+
+  window.adjustFont = function (delta) {
+    if (delta === 0) {
+      baseFontSize = 18;
+    } else {
+      baseFontSize = Math.max(14, Math.min(28, baseFontSize + delta));
+    }
+    applyFontSize();
+    localStorage.setItem('adkSlideFontSize', baseFontSize);
+  };
+
+  function applyFontSize() {
+    document.documentElement.style.setProperty('--slide-font-size', baseFontSize + 'px');
+  }
+
+  var themeBtn = document.querySelector('.theme-toggle');
+  var savedTheme = localStorage.getItem('adkTheme');
+  if (savedTheme) {
+    document.documentElement.setAttribute('data-theme', savedTheme);
+  }
+
+  if (themeBtn) {
+    themeBtn.addEventListener('click', function () {
+      var html = document.documentElement;
+      var nextTheme = html.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+      html.setAttribute('data-theme', nextTheme);
+      localStorage.setItem('adkTheme', nextTheme);
+    });
+  }
+
+  var touchStartX = 0;
+  var touchStartY = 0;
+
+  document.addEventListener('touchstart', function (e) {
+    touchStartX = e.changedTouches[0].screenX;
+    touchStartY = e.changedTouches[0].screenY;
+  }, { passive: true });
+
+  document.addEventListener('touchend', function (e) {
+    var dx = e.changedTouches[0].screenX - touchStartX;
+    var dy = e.changedTouches[0].screenY - touchStartY;
+    if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > 50) {
+      if (dx < 0) next();
+      else prev();
+    }
+  }, { passive: true });
+
+  var hash = window.location.hash;
+  if (hash && hash.startsWith('#slide-')) {
+    var n = parseInt(hash.replace('#slide-', ''));
+    if (!isNaN(n) && n >= 1 && n <= total) {
+      current = n - 1;
+    }
+  }
+
+  slides[current].classList.add('active');
+  updateCounter();
+
+  window.addEventListener('hashchange', function () {
+    var h = window.location.hash;
+    if (h && h.startsWith('#slide-')) {
+      var n = parseInt(h.replace('#slide-', ''));
+      if (!isNaN(n) && n >= 1 && n <= total && n - 1 !== current) {
+        goTo(n - 1);
+      }
+    }
+  });
+
+})();
+</script>
+<!-- END-INLINED-SCRIPT -->
 </body>
 </html>

--- a/slides/module-10-deployment/index.html
+++ b/slides/module-10-deployment/index.html
@@ -796,6 +796,816 @@ body {
   }
 }
   </style>
+
+  <!-- BEGIN-INLINED-STYLES -->
+  <style>
+  /* shared.css — generated; edit slides/shared/shared.css */
+/* ADK Course — Shared Design Tokens
+   Adapted from barcik-training-exin-ai-foundation/css/shared.css.
+   Family-consistent navy with amber accent (distinct from EXIN gold). */
+
+@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;500;600;700;800&display=swap');
+
+:root {
+  /* Brand colors */
+  --navy: #1E3A5F;
+  --navy-light: #2A5280;
+  --navy-dark: #122542;
+  --amber: #F59E0B;
+  --amber-light: #FBBF24;
+  --amber-dark: #B45309;
+  --white: #FFFFFF;
+  --gray-50: #F8F9FA;
+  --gray-100: #F1F3F5;
+  --gray-200: #E9ECEF;
+  --gray-300: #DEE2E6;
+  --gray-400: #CED4DA;
+  --gray-500: #ADB5BD;
+  --gray-600: #868E96;
+  --gray-700: #495057;
+  --gray-800: #343A40;
+  --gray-900: #212529;
+
+  /* Semantic */
+  --bg-primary: var(--white);
+  --bg-secondary: var(--gray-50);
+  --bg-card: var(--white);
+  --text-primary: var(--gray-900);
+  --text-secondary: var(--gray-700);
+  --text-muted: var(--gray-600);
+  --border-color: var(--gray-200);
+  --accent: var(--navy);
+  --accent-light: var(--navy-light);
+  --highlight: var(--amber);
+  --highlight-bg: #FEF3C7;
+  --success: #2E7D32;
+  --success-bg: #E8F5E9;
+  --error: #C62828;
+  --error-bg: #FFEBEE;
+  --info: #1565C0;
+  --info-bg: #E3F2FD;
+
+  /* Typography */
+  --font-sans: 'Nunito', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+  --text-3xl: 1.875rem;
+  --text-4xl: 2.25rem;
+
+  /* Spacing */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-10: 2.5rem;
+  --space-12: 3rem;
+  --space-16: 4rem;
+
+  /* Radius */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.07);
+  --shadow-lg: 0 10px 15px rgba(0,0,0,0.1);
+
+  /* Transitions */
+  --transition-fast: 150ms ease;
+  --transition-normal: 250ms ease;
+  --transition-slow: 350ms ease;
+}
+
+[data-theme="dark"] {
+  --bg-primary: #0D1117;
+  --bg-secondary: #161B22;
+  --bg-card: #1C2128;
+  --text-primary: #E6EDF3;
+  --text-secondary: #B1BAC4;
+  --text-muted: #8B949E;
+  --border-color: #30363D;
+  --accent: #58A6FF;
+  --accent-light: #79C0FF;
+  --highlight: var(--amber);
+  --highlight-bg: #2D2200;
+  --success: #56D364;
+  --success-bg: #0D2818;
+  --error: #F85149;
+  --error-bg: #2D1214;
+  --info: #58A6FF;
+  --info-bg: #0D1B2E;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.3);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.4);
+  --shadow-lg: 0 10px 15px rgba(0,0,0,0.5);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg-primary: #0D1117;
+    --bg-secondary: #161B22;
+    --bg-card: #1C2128;
+    --text-primary: #E6EDF3;
+    --text-secondary: #B1BAC4;
+    --text-muted: #8B949E;
+    --border-color: #30363D;
+    --accent: #58A6FF;
+    --accent-light: #79C0FF;
+    --highlight: var(--amber);
+    --highlight-bg: #2D2200;
+    --success: #56D364;
+    --success-bg: #0D2818;
+    --error: #F85149;
+    --error-bg: #2D1214;
+    --info: #58A6FF;
+    --info-bg: #0D1B2E;
+  }
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  line-height: 1.6;
+  color: var(--text-primary);
+  background-color: var(--bg-primary);
+  -webkit-font-smoothing: antialiased;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow var(--transition-normal);
+}
+
+.card:hover {
+  box-shadow: var(--shadow-md);
+}
+
+.callout {
+  padding: var(--space-4) var(--space-6);
+  border-radius: var(--radius-md);
+  margin: var(--space-4) 0;
+  border-left: 4px solid;
+}
+
+.callout-key { background: var(--highlight-bg); border-color: var(--amber); }
+.callout-gotcha { background: var(--error-bg); border-color: var(--error); }
+.callout-tip { background: var(--info-bg); border-color: var(--info); }
+.callout-success { background: var(--success-bg); border-color: var(--success); }
+
+.callout-title {
+  font-weight: 700;
+  font-size: var(--text-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: var(--space-2);
+}
+
+.text-center { text-align: center; }
+.text-muted { color: var(--text-muted); }
+.font-mono { font-family: var(--font-mono); }
+.mt-4 { margin-top: var(--space-4); }
+.mt-8 { margin-top: var(--space-8); }
+.mb-4 { margin-bottom: var(--space-4); }
+.mb-8 { margin-bottom: var(--space-8); }
+.mx-auto { margin-left: auto; margin-right: auto; }
+.max-w-4xl { max-width: 56rem; }
+.hidden { display: none !important; }
+  /* slides.css — generated; edit slides/shared/slides.css */
+/* ADK Course — Slide Presentation Theme
+   Adapted from barcik-training-exin-ai-foundation/slides/css/slides.css.
+   Adds data-type="code" slide variant for Python snippets. */
+
+:root {
+  --slide-font-size: 18px;
+  --strip-height: 48px;
+}
+
+body {
+  margin: 0;
+  overflow: hidden;
+  background: var(--bg-primary);
+}
+
+/* ── Progress Strip ──────────────────────────────── */
+.progress-strip {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  height: var(--strip-height);
+  background: var(--navy);
+  display: flex;
+  align-items: center;
+  z-index: 100;
+  padding: 0 var(--space-4);
+  gap: var(--space-4);
+  box-shadow: var(--shadow-md);
+  font-family: var(--font-sans);
+}
+
+.progress-home {
+  color: var(--amber);
+  text-decoration: none;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: var(--radius-md);
+  white-space: nowrap;
+  transition: all var(--transition-fast);
+}
+
+.progress-home:hover {
+  background: rgba(255,255,255,0.1);
+  border-color: var(--amber);
+}
+
+.progress-title {
+  color: rgba(255,255,255,0.85);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  flex: 1;
+  text-align: center;
+}
+
+.progress-title .quick-path-badge {
+  display: inline-block;
+  background: var(--amber);
+  color: var(--navy-dark);
+  font-size: 0.68rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.15rem 0.55rem;
+  border-radius: 9999px;
+  margin-left: 0.6rem;
+  vertical-align: 2px;
+}
+
+.progress-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.slide-counter {
+  color: rgba(255,255,255,0.6);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  font-family: var(--font-mono);
+  white-space: nowrap;
+}
+
+.progress-strip .theme-toggle {
+  background: rgba(255,255,255,0.1);
+  color: rgba(255,255,255,0.7);
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: var(--radius-md);
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-xs);
+  cursor: pointer;
+  font-family: var(--font-sans);
+  transition: all var(--transition-fast);
+}
+
+.progress-strip .theme-toggle:hover {
+  background: rgba(255,255,255,0.2);
+  color: white;
+}
+
+/* ── Viewport ────────────────────────────────────── */
+.slide-viewport {
+  position: fixed;
+  top: var(--strip-height);
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow: hidden;
+}
+
+/* ── Slide Base ──────────────────────────────────── */
+.slide {
+  display: none;
+  position: absolute;
+  inset: 0;
+  overflow-y: auto;
+  padding: var(--space-10) var(--space-16);
+  font-size: var(--slide-font-size);
+  line-height: 1.6;
+  font-family: var(--font-sans);
+  color: var(--text-primary);
+  background: var(--bg-primary);
+}
+
+.slide.active {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  animation: fadeIn 0.25s ease;
+}
+
+.slide > * {
+  max-width: 1100px;
+  width: 100% !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
+  box-sizing: border-box;
+  text-align: inherit;
+}
+
+.slide > .topic-badge {
+  width: auto !important;
+  max-width: none;
+  align-self: center;
+}
+
+/* ── Section Title ───────────────────────────────── */
+.slide[data-type="section-title"] {
+  background: linear-gradient(135deg, var(--navy) 0%, var(--navy-light) 100%);
+  text-align: center;
+}
+
+.slide[data-type="section-title"] h1,
+.slide[data-type="section-title"] h2,
+.slide[data-type="section-title"] h3 {
+  color: white;
+}
+
+.slide[data-type="section-title"] p {
+  color: rgba(255,255,255,0.85);
+}
+
+.slide[data-type="section-title"] .topic-badge {
+  display: inline-block;
+  background: var(--amber);
+  color: var(--navy-dark);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  padding: var(--space-2) var(--space-4);
+  border-radius: 9999px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: var(--space-4);
+  width: auto !important;
+}
+
+.slide[data-type="section-title"] .highlight-text {
+  color: var(--amber);
+  font-weight: 600;
+}
+
+/* ── Typography ──────────────────────────────────── */
+.slide h1 {
+  font-size: 2.4em;
+  font-weight: 800;
+  color: var(--navy);
+  margin-bottom: var(--space-4);
+  line-height: 1.15;
+}
+
+.slide h2 {
+  font-size: 1.6em;
+  font-weight: 700;
+  color: var(--navy);
+  margin-bottom: var(--space-4);
+  padding-bottom: var(--space-2);
+  border-bottom: 3px solid var(--amber);
+}
+
+.slide h3 {
+  font-size: 1.2em;
+  font-weight: 600;
+  color: var(--navy-light);
+  margin-bottom: var(--space-3);
+}
+
+.slide p {
+  margin-bottom: var(--space-3);
+  color: var(--text-secondary);
+}
+
+.slide strong {
+  color: var(--navy);
+  font-weight: 700;
+}
+
+.slide em {
+  color: var(--amber-dark);
+  font-style: italic;
+}
+
+.slide ul, .slide ol {
+  margin-left: 1.2em;
+  margin-bottom: var(--space-4);
+}
+
+.slide li {
+  margin-bottom: var(--space-2);
+  color: var(--text-secondary);
+}
+
+.slide li::marker {
+  color: var(--amber);
+}
+
+[data-theme="dark"] .slide h1,
+[data-theme="dark"] .slide h2 { color: var(--text-primary); }
+[data-theme="dark"] .slide h3 { color: var(--text-secondary); }
+[data-theme="dark"] .slide strong { color: var(--text-primary); }
+[data-theme="dark"] .slide h2 { border-bottom-color: var(--amber); }
+
+.highlight-text {
+  color: var(--amber-dark);
+  font-weight: 600;
+}
+
+[data-theme="dark"] .highlight-text {
+  color: var(--amber);
+}
+
+/* ── Grid ────────────────────────────────────────── */
+.slide[data-type="grid"] .grid-layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: var(--space-4);
+  margin-top: var(--space-4);
+}
+
+.grid-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5);
+  transition: all var(--transition-normal);
+}
+
+.grid-card:hover {
+  box-shadow: var(--shadow-md);
+  transform: translateY(-2px);
+  border-color: var(--accent);
+}
+
+.grid-card.highlight {
+  border-color: var(--amber);
+  box-shadow: 0 0 0 1px var(--amber), var(--shadow-sm);
+}
+
+.grid-card-title {
+  font-weight: 700;
+  color: var(--text-primary);
+  font-size: 1.05em;
+  margin-bottom: var(--space-2);
+}
+
+.grid-card-body {
+  color: var(--text-secondary);
+  font-size: 0.9em;
+  line-height: 1.5;
+}
+
+/* ── Split ───────────────────────────────────────── */
+.slide[data-type="split"] .split-layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-8);
+  margin-top: var(--space-4);
+}
+
+@media (max-width: 768px) {
+  .slide[data-type="split"] .split-layout { grid-template-columns: 1fr; }
+}
+
+/* ── Comparison ──────────────────────────────────── */
+.slide[data-type="comparison"] .comparison-layout {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: var(--space-6);
+  align-items: start;
+  margin-top: var(--space-4);
+}
+
+.vs-left, .vs-right {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+}
+
+.vs-divider {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5em;
+  font-weight: 800;
+  color: var(--text-muted);
+  align-self: center;
+}
+
+@media (max-width: 768px) {
+  .slide[data-type="comparison"] .comparison-layout {
+    grid-template-columns: 1fr;
+  }
+  .vs-divider { display: none; }
+}
+
+/* ── Quote ───────────────────────────────────────── */
+.slide[data-type="quote"] {
+  text-align: center;
+}
+
+.quote-text {
+  font-size: 1.5em;
+  font-weight: 300;
+  font-style: italic;
+  color: var(--text-primary);
+  max-width: 80%;
+  line-height: 1.5;
+  position: relative;
+  padding: 0.5em 1em;
+  margin: 0 auto;
+}
+
+.quote-text::before {
+  content: '\201C';
+  position: absolute;
+  left: -0.3em;
+  top: -0.2em;
+  font-size: 3.5em;
+  color: var(--amber);
+  font-weight: 800;
+  line-height: 1;
+  opacity: 0.3;
+}
+
+.quote-source {
+  margin-top: var(--space-4);
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  font-weight: 500;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.quote-source::before { content: '\2014\00a0'; }
+
+/* ── Key Fact ────────────────────────────────────── */
+.slide[data-type="keyfact"] {
+  text-align: center;
+}
+
+.slide[data-type="keyfact"] p {
+  font-size: 1.5em;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.35;
+}
+
+.slide[data-type="keyfact"] strong {
+  color: var(--amber-dark);
+}
+
+[data-theme="dark"] .slide[data-type="keyfact"] strong {
+  color: var(--amber);
+}
+
+/* ── Hero ────────────────────────────────────────── */
+.slide[data-type="hero"] {
+  text-align: center;
+}
+
+/* ── Example / Code ──────────────────────────────── */
+.slide[data-type="example"] {
+  border-left: 4px solid var(--info);
+}
+
+.slide[data-type="code"] pre,
+.slide pre {
+  background: var(--gray-900);
+  color: #E6EDF3;
+  border-radius: var(--radius-md);
+  padding: var(--space-4) var(--space-5);
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  line-height: 1.55;
+  margin: var(--space-3) 0;
+  box-shadow: var(--shadow-sm);
+}
+
+.slide[data-type="code"] pre code,
+.slide pre code {
+  background: none;
+  color: inherit;
+  padding: 0;
+  font-family: var(--font-mono);
+}
+
+.slide code {
+  font-family: var(--font-mono);
+  background: var(--bg-secondary);
+  color: var(--navy);
+  padding: 0.1em 0.35em;
+  border-radius: var(--radius-sm);
+  font-size: 0.9em;
+}
+
+[data-theme="dark"] .slide code {
+  color: var(--accent-light);
+  background: var(--gray-800);
+}
+
+.slide .code-caption {
+  color: var(--text-muted);
+  font-size: 0.85em;
+  font-style: italic;
+  margin-top: var(--space-2);
+}
+
+/* ── Definition Cards ────────────────────────────── */
+.def-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-left: 4px solid var(--navy-light);
+  border-radius: 0 var(--radius-lg) var(--radius-lg) 0;
+  padding: var(--space-4) var(--space-5);
+  margin-bottom: var(--space-3);
+  transition: border-color var(--transition-fast);
+}
+
+.def-card.highlight {
+  border-left-color: var(--amber);
+}
+
+.def-term {
+  font-size: var(--text-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--navy-light);
+  margin-bottom: var(--space-2);
+}
+
+[data-theme="dark"] .def-term { color: var(--accent); }
+
+.def-text {
+  color: var(--text-primary);
+  line-height: 1.5;
+}
+
+/* ── Callouts on slides ──────────────────────────── */
+.slide .callout {
+  margin: var(--space-4) 0;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* ── Tables ──────────────────────────────────────── */
+.slide table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  margin: var(--space-4) 0;
+  font-size: 0.92em;
+}
+
+.slide table th {
+  background: var(--navy);
+  color: white;
+  padding: var(--space-3) var(--space-4);
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.9em;
+}
+
+.slide table td {
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border-color);
+  color: var(--text-secondary);
+}
+
+.slide table tr:nth-child(even) { background: var(--bg-secondary); }
+.slide table tr:last-child td { border-bottom: none; }
+
+/* ── Two-Column Layout ───────────────────────────── */
+.two-col {
+  display: flex;
+  gap: var(--space-8);
+  align-items: flex-start;
+}
+
+.col { flex: 1; min-width: 0; }
+
+@media (max-width: 768px) {
+  .two-col { flex-direction: column; gap: var(--space-4); }
+}
+
+/* ── ASCII-art / diagram ─────────────────────────── */
+.slide .diagram {
+  background: var(--gray-900);
+  color: #C9D1D9;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  line-height: 1.4;
+  padding: var(--space-4) var(--space-5);
+  border-radius: var(--radius-md);
+  white-space: pre;
+  overflow-x: auto;
+  margin: var(--space-3) 0;
+}
+
+/* ── Font Controls ───────────────────────────────── */
+.font-controls {
+  position: fixed;
+  bottom: var(--space-6);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: var(--space-2);
+  z-index: 100;
+  background: var(--bg-card);
+  padding: var(--space-2);
+  border-radius: 9999px;
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-md);
+  opacity: 0.5;
+  transition: opacity var(--transition-fast);
+}
+
+.font-controls:hover { opacity: 1; }
+
+.font-controls button {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.font-controls button:hover {
+  background: var(--navy);
+  color: white;
+  border-color: var(--navy);
+}
+
+/* ── Animations ──────────────────────────────────── */
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Print ───────────────────────────────────────── */
+@media print {
+  .progress-strip, .font-controls { display: none !important; }
+  .slide-viewport { position: static; overflow: visible; }
+  .slide {
+    display: block !important;
+    position: static !important;
+    page-break-after: always;
+    padding: 2cm;
+  }
+  .slide[data-type="section-title"] {
+    background: var(--navy) !important;
+    color: white !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+  .slide pre {
+    background: var(--gray-100) !important;
+    color: var(--gray-900) !important;
+    border: 1px solid var(--gray-400);
+  }
+}
+  </style>
+  <!-- END-INLINED-STYLES -->
 </head>
 <body>
   <nav class="progress-strip">
@@ -1185,5 +1995,148 @@ CMD ["sh", "-c", "adk api_server /app --host 0.0.0.0 --port ${PORT}"]</code></pr
 
 })();
 </script>
+
+  <!-- BEGIN-INLINED-SCRIPT -->
+<script>
+/* ADK Course — Slide Engine
+   Adapted from barcik-training-exin-ai-foundation/slides/js/slides.js.
+   Per-module decks; lightweight nav with keyboard, touch, hash routing,
+   font controls, theme toggle. */
+
+(function () {
+  'use strict';
+
+  const slides = document.querySelectorAll('.slide');
+  const total = slides.length;
+  let current = 0;
+
+  function goTo(index) {
+    if (index < 0 || index >= total) return;
+    slides[current].classList.remove('active');
+    current = index;
+    slides[current].classList.add('active');
+    updateCounter();
+    window.scrollTo(0, 0);
+    history.replaceState(null, '', '#slide-' + (current + 1));
+  }
+
+  function next() { goTo(current + 1); }
+  function prev() { goTo(current - 1); }
+
+  document.addEventListener('keydown', function (e) {
+    if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+      case ' ':
+        e.preventDefault();
+        next();
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        e.preventDefault();
+        prev();
+        break;
+      case 'Home':
+        e.preventDefault();
+        goTo(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        goTo(total - 1);
+        break;
+    }
+  });
+
+  var viewport = document.querySelector('.slide-viewport');
+  if (viewport) {
+    viewport.addEventListener('click', function (e) {
+      if (e.target === this || e.target.classList.contains('slide')) {
+        var rect = this.getBoundingClientRect();
+        var x = e.clientX - rect.left;
+        if (x > rect.width * 0.75) next();
+        else if (x < rect.width * 0.25) prev();
+      }
+    });
+  }
+
+  var counter = document.querySelector('.slide-counter');
+  function updateCounter() {
+    if (counter) counter.textContent = (current + 1) + ' / ' + total;
+  }
+
+  var baseFontSize = parseInt(localStorage.getItem('adkSlideFontSize')) || 18;
+  applyFontSize();
+
+  window.adjustFont = function (delta) {
+    if (delta === 0) {
+      baseFontSize = 18;
+    } else {
+      baseFontSize = Math.max(14, Math.min(28, baseFontSize + delta));
+    }
+    applyFontSize();
+    localStorage.setItem('adkSlideFontSize', baseFontSize);
+  };
+
+  function applyFontSize() {
+    document.documentElement.style.setProperty('--slide-font-size', baseFontSize + 'px');
+  }
+
+  var themeBtn = document.querySelector('.theme-toggle');
+  var savedTheme = localStorage.getItem('adkTheme');
+  if (savedTheme) {
+    document.documentElement.setAttribute('data-theme', savedTheme);
+  }
+
+  if (themeBtn) {
+    themeBtn.addEventListener('click', function () {
+      var html = document.documentElement;
+      var nextTheme = html.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+      html.setAttribute('data-theme', nextTheme);
+      localStorage.setItem('adkTheme', nextTheme);
+    });
+  }
+
+  var touchStartX = 0;
+  var touchStartY = 0;
+
+  document.addEventListener('touchstart', function (e) {
+    touchStartX = e.changedTouches[0].screenX;
+    touchStartY = e.changedTouches[0].screenY;
+  }, { passive: true });
+
+  document.addEventListener('touchend', function (e) {
+    var dx = e.changedTouches[0].screenX - touchStartX;
+    var dy = e.changedTouches[0].screenY - touchStartY;
+    if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > 50) {
+      if (dx < 0) next();
+      else prev();
+    }
+  }, { passive: true });
+
+  var hash = window.location.hash;
+  if (hash && hash.startsWith('#slide-')) {
+    var n = parseInt(hash.replace('#slide-', ''));
+    if (!isNaN(n) && n >= 1 && n <= total) {
+      current = n - 1;
+    }
+  }
+
+  slides[current].classList.add('active');
+  updateCounter();
+
+  window.addEventListener('hashchange', function () {
+    var h = window.location.hash;
+    if (h && h.startsWith('#slide-')) {
+      var n = parseInt(h.replace('#slide-', ''));
+      if (!isNaN(n) && n >= 1 && n <= total && n - 1 !== current) {
+        goTo(n - 1);
+      }
+    }
+  });
+
+})();
+</script>
+<!-- END-INLINED-SCRIPT -->
 </body>
 </html>

--- a/slides/module-11-gemini-grounding/index.html
+++ b/slides/module-11-gemini-grounding/index.html
@@ -796,11 +796,821 @@ body {
   }
 }
   </style>
+
+  <!-- BEGIN-INLINED-STYLES -->
+  <style>
+  /* shared.css — generated; edit slides/shared/shared.css */
+/* ADK Course — Shared Design Tokens
+   Adapted from barcik-training-exin-ai-foundation/css/shared.css.
+   Family-consistent navy with amber accent (distinct from EXIN gold). */
+
+@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;500;600;700;800&display=swap');
+
+:root {
+  /* Brand colors */
+  --navy: #1E3A5F;
+  --navy-light: #2A5280;
+  --navy-dark: #122542;
+  --amber: #F59E0B;
+  --amber-light: #FBBF24;
+  --amber-dark: #B45309;
+  --white: #FFFFFF;
+  --gray-50: #F8F9FA;
+  --gray-100: #F1F3F5;
+  --gray-200: #E9ECEF;
+  --gray-300: #DEE2E6;
+  --gray-400: #CED4DA;
+  --gray-500: #ADB5BD;
+  --gray-600: #868E96;
+  --gray-700: #495057;
+  --gray-800: #343A40;
+  --gray-900: #212529;
+
+  /* Semantic */
+  --bg-primary: var(--white);
+  --bg-secondary: var(--gray-50);
+  --bg-card: var(--white);
+  --text-primary: var(--gray-900);
+  --text-secondary: var(--gray-700);
+  --text-muted: var(--gray-600);
+  --border-color: var(--gray-200);
+  --accent: var(--navy);
+  --accent-light: var(--navy-light);
+  --highlight: var(--amber);
+  --highlight-bg: #FEF3C7;
+  --success: #2E7D32;
+  --success-bg: #E8F5E9;
+  --error: #C62828;
+  --error-bg: #FFEBEE;
+  --info: #1565C0;
+  --info-bg: #E3F2FD;
+
+  /* Typography */
+  --font-sans: 'Nunito', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+  --text-3xl: 1.875rem;
+  --text-4xl: 2.25rem;
+
+  /* Spacing */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-10: 2.5rem;
+  --space-12: 3rem;
+  --space-16: 4rem;
+
+  /* Radius */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.07);
+  --shadow-lg: 0 10px 15px rgba(0,0,0,0.1);
+
+  /* Transitions */
+  --transition-fast: 150ms ease;
+  --transition-normal: 250ms ease;
+  --transition-slow: 350ms ease;
+}
+
+[data-theme="dark"] {
+  --bg-primary: #0D1117;
+  --bg-secondary: #161B22;
+  --bg-card: #1C2128;
+  --text-primary: #E6EDF3;
+  --text-secondary: #B1BAC4;
+  --text-muted: #8B949E;
+  --border-color: #30363D;
+  --accent: #58A6FF;
+  --accent-light: #79C0FF;
+  --highlight: var(--amber);
+  --highlight-bg: #2D2200;
+  --success: #56D364;
+  --success-bg: #0D2818;
+  --error: #F85149;
+  --error-bg: #2D1214;
+  --info: #58A6FF;
+  --info-bg: #0D1B2E;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.3);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.4);
+  --shadow-lg: 0 10px 15px rgba(0,0,0,0.5);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg-primary: #0D1117;
+    --bg-secondary: #161B22;
+    --bg-card: #1C2128;
+    --text-primary: #E6EDF3;
+    --text-secondary: #B1BAC4;
+    --text-muted: #8B949E;
+    --border-color: #30363D;
+    --accent: #58A6FF;
+    --accent-light: #79C0FF;
+    --highlight: var(--amber);
+    --highlight-bg: #2D2200;
+    --success: #56D364;
+    --success-bg: #0D2818;
+    --error: #F85149;
+    --error-bg: #2D1214;
+    --info: #58A6FF;
+    --info-bg: #0D1B2E;
+  }
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  line-height: 1.6;
+  color: var(--text-primary);
+  background-color: var(--bg-primary);
+  -webkit-font-smoothing: antialiased;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow var(--transition-normal);
+}
+
+.card:hover {
+  box-shadow: var(--shadow-md);
+}
+
+.callout {
+  padding: var(--space-4) var(--space-6);
+  border-radius: var(--radius-md);
+  margin: var(--space-4) 0;
+  border-left: 4px solid;
+}
+
+.callout-key { background: var(--highlight-bg); border-color: var(--amber); }
+.callout-gotcha { background: var(--error-bg); border-color: var(--error); }
+.callout-tip { background: var(--info-bg); border-color: var(--info); }
+.callout-success { background: var(--success-bg); border-color: var(--success); }
+
+.callout-title {
+  font-weight: 700;
+  font-size: var(--text-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: var(--space-2);
+}
+
+.text-center { text-align: center; }
+.text-muted { color: var(--text-muted); }
+.font-mono { font-family: var(--font-mono); }
+.mt-4 { margin-top: var(--space-4); }
+.mt-8 { margin-top: var(--space-8); }
+.mb-4 { margin-bottom: var(--space-4); }
+.mb-8 { margin-bottom: var(--space-8); }
+.mx-auto { margin-left: auto; margin-right: auto; }
+.max-w-4xl { max-width: 56rem; }
+.hidden { display: none !important; }
+  /* slides.css — generated; edit slides/shared/slides.css */
+/* ADK Course — Slide Presentation Theme
+   Adapted from barcik-training-exin-ai-foundation/slides/css/slides.css.
+   Adds data-type="code" slide variant for Python snippets. */
+
+:root {
+  --slide-font-size: 18px;
+  --strip-height: 48px;
+}
+
+body {
+  margin: 0;
+  overflow: hidden;
+  background: var(--bg-primary);
+}
+
+/* ── Progress Strip ──────────────────────────────── */
+.progress-strip {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  height: var(--strip-height);
+  background: var(--navy);
+  display: flex;
+  align-items: center;
+  z-index: 100;
+  padding: 0 var(--space-4);
+  gap: var(--space-4);
+  box-shadow: var(--shadow-md);
+  font-family: var(--font-sans);
+}
+
+.progress-home {
+  color: var(--amber);
+  text-decoration: none;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: var(--radius-md);
+  white-space: nowrap;
+  transition: all var(--transition-fast);
+}
+
+.progress-home:hover {
+  background: rgba(255,255,255,0.1);
+  border-color: var(--amber);
+}
+
+.progress-title {
+  color: rgba(255,255,255,0.85);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  flex: 1;
+  text-align: center;
+}
+
+.progress-title .quick-path-badge {
+  display: inline-block;
+  background: var(--amber);
+  color: var(--navy-dark);
+  font-size: 0.68rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.15rem 0.55rem;
+  border-radius: 9999px;
+  margin-left: 0.6rem;
+  vertical-align: 2px;
+}
+
+.progress-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.slide-counter {
+  color: rgba(255,255,255,0.6);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  font-family: var(--font-mono);
+  white-space: nowrap;
+}
+
+.progress-strip .theme-toggle {
+  background: rgba(255,255,255,0.1);
+  color: rgba(255,255,255,0.7);
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: var(--radius-md);
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-xs);
+  cursor: pointer;
+  font-family: var(--font-sans);
+  transition: all var(--transition-fast);
+}
+
+.progress-strip .theme-toggle:hover {
+  background: rgba(255,255,255,0.2);
+  color: white;
+}
+
+/* ── Viewport ────────────────────────────────────── */
+.slide-viewport {
+  position: fixed;
+  top: var(--strip-height);
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow: hidden;
+}
+
+/* ── Slide Base ──────────────────────────────────── */
+.slide {
+  display: none;
+  position: absolute;
+  inset: 0;
+  overflow-y: auto;
+  padding: var(--space-10) var(--space-16);
+  font-size: var(--slide-font-size);
+  line-height: 1.6;
+  font-family: var(--font-sans);
+  color: var(--text-primary);
+  background: var(--bg-primary);
+}
+
+.slide.active {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  animation: fadeIn 0.25s ease;
+}
+
+.slide > * {
+  max-width: 1100px;
+  width: 100% !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
+  box-sizing: border-box;
+  text-align: inherit;
+}
+
+.slide > .topic-badge {
+  width: auto !important;
+  max-width: none;
+  align-self: center;
+}
+
+/* ── Section Title ───────────────────────────────── */
+.slide[data-type="section-title"] {
+  background: linear-gradient(135deg, var(--navy) 0%, var(--navy-light) 100%);
+  text-align: center;
+}
+
+.slide[data-type="section-title"] h1,
+.slide[data-type="section-title"] h2,
+.slide[data-type="section-title"] h3 {
+  color: white;
+}
+
+.slide[data-type="section-title"] p {
+  color: rgba(255,255,255,0.85);
+}
+
+.slide[data-type="section-title"] .topic-badge {
+  display: inline-block;
+  background: var(--amber);
+  color: var(--navy-dark);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  padding: var(--space-2) var(--space-4);
+  border-radius: 9999px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: var(--space-4);
+  width: auto !important;
+}
+
+.slide[data-type="section-title"] .highlight-text {
+  color: var(--amber);
+  font-weight: 600;
+}
+
+/* ── Typography ──────────────────────────────────── */
+.slide h1 {
+  font-size: 2.4em;
+  font-weight: 800;
+  color: var(--navy);
+  margin-bottom: var(--space-4);
+  line-height: 1.15;
+}
+
+.slide h2 {
+  font-size: 1.6em;
+  font-weight: 700;
+  color: var(--navy);
+  margin-bottom: var(--space-4);
+  padding-bottom: var(--space-2);
+  border-bottom: 3px solid var(--amber);
+}
+
+.slide h3 {
+  font-size: 1.2em;
+  font-weight: 600;
+  color: var(--navy-light);
+  margin-bottom: var(--space-3);
+}
+
+.slide p {
+  margin-bottom: var(--space-3);
+  color: var(--text-secondary);
+}
+
+.slide strong {
+  color: var(--navy);
+  font-weight: 700;
+}
+
+.slide em {
+  color: var(--amber-dark);
+  font-style: italic;
+}
+
+.slide ul, .slide ol {
+  margin-left: 1.2em;
+  margin-bottom: var(--space-4);
+}
+
+.slide li {
+  margin-bottom: var(--space-2);
+  color: var(--text-secondary);
+}
+
+.slide li::marker {
+  color: var(--amber);
+}
+
+[data-theme="dark"] .slide h1,
+[data-theme="dark"] .slide h2 { color: var(--text-primary); }
+[data-theme="dark"] .slide h3 { color: var(--text-secondary); }
+[data-theme="dark"] .slide strong { color: var(--text-primary); }
+[data-theme="dark"] .slide h2 { border-bottom-color: var(--amber); }
+
+.highlight-text {
+  color: var(--amber-dark);
+  font-weight: 600;
+}
+
+[data-theme="dark"] .highlight-text {
+  color: var(--amber);
+}
+
+/* ── Grid ────────────────────────────────────────── */
+.slide[data-type="grid"] .grid-layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: var(--space-4);
+  margin-top: var(--space-4);
+}
+
+.grid-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5);
+  transition: all var(--transition-normal);
+}
+
+.grid-card:hover {
+  box-shadow: var(--shadow-md);
+  transform: translateY(-2px);
+  border-color: var(--accent);
+}
+
+.grid-card.highlight {
+  border-color: var(--amber);
+  box-shadow: 0 0 0 1px var(--amber), var(--shadow-sm);
+}
+
+.grid-card-title {
+  font-weight: 700;
+  color: var(--text-primary);
+  font-size: 1.05em;
+  margin-bottom: var(--space-2);
+}
+
+.grid-card-body {
+  color: var(--text-secondary);
+  font-size: 0.9em;
+  line-height: 1.5;
+}
+
+/* ── Split ───────────────────────────────────────── */
+.slide[data-type="split"] .split-layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-8);
+  margin-top: var(--space-4);
+}
+
+@media (max-width: 768px) {
+  .slide[data-type="split"] .split-layout { grid-template-columns: 1fr; }
+}
+
+/* ── Comparison ──────────────────────────────────── */
+.slide[data-type="comparison"] .comparison-layout {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: var(--space-6);
+  align-items: start;
+  margin-top: var(--space-4);
+}
+
+.vs-left, .vs-right {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+}
+
+.vs-divider {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5em;
+  font-weight: 800;
+  color: var(--text-muted);
+  align-self: center;
+}
+
+@media (max-width: 768px) {
+  .slide[data-type="comparison"] .comparison-layout {
+    grid-template-columns: 1fr;
+  }
+  .vs-divider { display: none; }
+}
+
+/* ── Quote ───────────────────────────────────────── */
+.slide[data-type="quote"] {
+  text-align: center;
+}
+
+.quote-text {
+  font-size: 1.5em;
+  font-weight: 300;
+  font-style: italic;
+  color: var(--text-primary);
+  max-width: 80%;
+  line-height: 1.5;
+  position: relative;
+  padding: 0.5em 1em;
+  margin: 0 auto;
+}
+
+.quote-text::before {
+  content: '\201C';
+  position: absolute;
+  left: -0.3em;
+  top: -0.2em;
+  font-size: 3.5em;
+  color: var(--amber);
+  font-weight: 800;
+  line-height: 1;
+  opacity: 0.3;
+}
+
+.quote-source {
+  margin-top: var(--space-4);
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  font-weight: 500;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.quote-source::before { content: '\2014\00a0'; }
+
+/* ── Key Fact ────────────────────────────────────── */
+.slide[data-type="keyfact"] {
+  text-align: center;
+}
+
+.slide[data-type="keyfact"] p {
+  font-size: 1.5em;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.35;
+}
+
+.slide[data-type="keyfact"] strong {
+  color: var(--amber-dark);
+}
+
+[data-theme="dark"] .slide[data-type="keyfact"] strong {
+  color: var(--amber);
+}
+
+/* ── Hero ────────────────────────────────────────── */
+.slide[data-type="hero"] {
+  text-align: center;
+}
+
+/* ── Example / Code ──────────────────────────────── */
+.slide[data-type="example"] {
+  border-left: 4px solid var(--info);
+}
+
+.slide[data-type="code"] pre,
+.slide pre {
+  background: var(--gray-900);
+  color: #E6EDF3;
+  border-radius: var(--radius-md);
+  padding: var(--space-4) var(--space-5);
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  line-height: 1.55;
+  margin: var(--space-3) 0;
+  box-shadow: var(--shadow-sm);
+}
+
+.slide[data-type="code"] pre code,
+.slide pre code {
+  background: none;
+  color: inherit;
+  padding: 0;
+  font-family: var(--font-mono);
+}
+
+.slide code {
+  font-family: var(--font-mono);
+  background: var(--bg-secondary);
+  color: var(--navy);
+  padding: 0.1em 0.35em;
+  border-radius: var(--radius-sm);
+  font-size: 0.9em;
+}
+
+[data-theme="dark"] .slide code {
+  color: var(--accent-light);
+  background: var(--gray-800);
+}
+
+.slide .code-caption {
+  color: var(--text-muted);
+  font-size: 0.85em;
+  font-style: italic;
+  margin-top: var(--space-2);
+}
+
+/* ── Definition Cards ────────────────────────────── */
+.def-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-left: 4px solid var(--navy-light);
+  border-radius: 0 var(--radius-lg) var(--radius-lg) 0;
+  padding: var(--space-4) var(--space-5);
+  margin-bottom: var(--space-3);
+  transition: border-color var(--transition-fast);
+}
+
+.def-card.highlight {
+  border-left-color: var(--amber);
+}
+
+.def-term {
+  font-size: var(--text-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--navy-light);
+  margin-bottom: var(--space-2);
+}
+
+[data-theme="dark"] .def-term { color: var(--accent); }
+
+.def-text {
+  color: var(--text-primary);
+  line-height: 1.5;
+}
+
+/* ── Callouts on slides ──────────────────────────── */
+.slide .callout {
+  margin: var(--space-4) 0;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* ── Tables ──────────────────────────────────────── */
+.slide table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  margin: var(--space-4) 0;
+  font-size: 0.92em;
+}
+
+.slide table th {
+  background: var(--navy);
+  color: white;
+  padding: var(--space-3) var(--space-4);
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.9em;
+}
+
+.slide table td {
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border-color);
+  color: var(--text-secondary);
+}
+
+.slide table tr:nth-child(even) { background: var(--bg-secondary); }
+.slide table tr:last-child td { border-bottom: none; }
+
+/* ── Two-Column Layout ───────────────────────────── */
+.two-col {
+  display: flex;
+  gap: var(--space-8);
+  align-items: flex-start;
+}
+
+.col { flex: 1; min-width: 0; }
+
+@media (max-width: 768px) {
+  .two-col { flex-direction: column; gap: var(--space-4); }
+}
+
+/* ── ASCII-art / diagram ─────────────────────────── */
+.slide .diagram {
+  background: var(--gray-900);
+  color: #C9D1D9;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  line-height: 1.4;
+  padding: var(--space-4) var(--space-5);
+  border-radius: var(--radius-md);
+  white-space: pre;
+  overflow-x: auto;
+  margin: var(--space-3) 0;
+}
+
+/* ── Font Controls ───────────────────────────────── */
+.font-controls {
+  position: fixed;
+  bottom: var(--space-6);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: var(--space-2);
+  z-index: 100;
+  background: var(--bg-card);
+  padding: var(--space-2);
+  border-radius: 9999px;
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-md);
+  opacity: 0.5;
+  transition: opacity var(--transition-fast);
+}
+
+.font-controls:hover { opacity: 1; }
+
+.font-controls button {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.font-controls button:hover {
+  background: var(--navy);
+  color: white;
+  border-color: var(--navy);
+}
+
+/* ── Animations ──────────────────────────────────── */
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Print ───────────────────────────────────────── */
+@media print {
+  .progress-strip, .font-controls { display: none !important; }
+  .slide-viewport { position: static; overflow: visible; }
+  .slide {
+    display: block !important;
+    position: static !important;
+    page-break-after: always;
+    padding: 2cm;
+  }
+  .slide[data-type="section-title"] {
+    background: var(--navy) !important;
+    color: white !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+  .slide pre {
+    background: var(--gray-100) !important;
+    color: var(--gray-900) !important;
+    border: 1px solid var(--gray-400);
+  }
+}
+  </style>
+  <!-- END-INLINED-STYLES -->
 </head>
 <body>
   <nav class="progress-strip">
     <a href="../../index.html" class="progress-home">Course</a>
-    <div class="progress-title">M11 — Gemini Grounding + Caching</div>
+    <div class="progress-title">M11 — Gemini Grounding + Caching<span class="quick-path-badge">⚡ Quick path</span></div>
     <div class="progress-meta">
       <span class="slide-counter">1 / 1</span>
       <button class="theme-toggle">Theme</button>
@@ -1139,5 +1949,148 @@ resp = client.models.generate_content(
 
 })();
 </script>
+
+  <!-- BEGIN-INLINED-SCRIPT -->
+<script>
+/* ADK Course — Slide Engine
+   Adapted from barcik-training-exin-ai-foundation/slides/js/slides.js.
+   Per-module decks; lightweight nav with keyboard, touch, hash routing,
+   font controls, theme toggle. */
+
+(function () {
+  'use strict';
+
+  const slides = document.querySelectorAll('.slide');
+  const total = slides.length;
+  let current = 0;
+
+  function goTo(index) {
+    if (index < 0 || index >= total) return;
+    slides[current].classList.remove('active');
+    current = index;
+    slides[current].classList.add('active');
+    updateCounter();
+    window.scrollTo(0, 0);
+    history.replaceState(null, '', '#slide-' + (current + 1));
+  }
+
+  function next() { goTo(current + 1); }
+  function prev() { goTo(current - 1); }
+
+  document.addEventListener('keydown', function (e) {
+    if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+      case ' ':
+        e.preventDefault();
+        next();
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        e.preventDefault();
+        prev();
+        break;
+      case 'Home':
+        e.preventDefault();
+        goTo(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        goTo(total - 1);
+        break;
+    }
+  });
+
+  var viewport = document.querySelector('.slide-viewport');
+  if (viewport) {
+    viewport.addEventListener('click', function (e) {
+      if (e.target === this || e.target.classList.contains('slide')) {
+        var rect = this.getBoundingClientRect();
+        var x = e.clientX - rect.left;
+        if (x > rect.width * 0.75) next();
+        else if (x < rect.width * 0.25) prev();
+      }
+    });
+  }
+
+  var counter = document.querySelector('.slide-counter');
+  function updateCounter() {
+    if (counter) counter.textContent = (current + 1) + ' / ' + total;
+  }
+
+  var baseFontSize = parseInt(localStorage.getItem('adkSlideFontSize')) || 18;
+  applyFontSize();
+
+  window.adjustFont = function (delta) {
+    if (delta === 0) {
+      baseFontSize = 18;
+    } else {
+      baseFontSize = Math.max(14, Math.min(28, baseFontSize + delta));
+    }
+    applyFontSize();
+    localStorage.setItem('adkSlideFontSize', baseFontSize);
+  };
+
+  function applyFontSize() {
+    document.documentElement.style.setProperty('--slide-font-size', baseFontSize + 'px');
+  }
+
+  var themeBtn = document.querySelector('.theme-toggle');
+  var savedTheme = localStorage.getItem('adkTheme');
+  if (savedTheme) {
+    document.documentElement.setAttribute('data-theme', savedTheme);
+  }
+
+  if (themeBtn) {
+    themeBtn.addEventListener('click', function () {
+      var html = document.documentElement;
+      var nextTheme = html.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+      html.setAttribute('data-theme', nextTheme);
+      localStorage.setItem('adkTheme', nextTheme);
+    });
+  }
+
+  var touchStartX = 0;
+  var touchStartY = 0;
+
+  document.addEventListener('touchstart', function (e) {
+    touchStartX = e.changedTouches[0].screenX;
+    touchStartY = e.changedTouches[0].screenY;
+  }, { passive: true });
+
+  document.addEventListener('touchend', function (e) {
+    var dx = e.changedTouches[0].screenX - touchStartX;
+    var dy = e.changedTouches[0].screenY - touchStartY;
+    if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > 50) {
+      if (dx < 0) next();
+      else prev();
+    }
+  }, { passive: true });
+
+  var hash = window.location.hash;
+  if (hash && hash.startsWith('#slide-')) {
+    var n = parseInt(hash.replace('#slide-', ''));
+    if (!isNaN(n) && n >= 1 && n <= total) {
+      current = n - 1;
+    }
+  }
+
+  slides[current].classList.add('active');
+  updateCounter();
+
+  window.addEventListener('hashchange', function () {
+    var h = window.location.hash;
+    if (h && h.startsWith('#slide-')) {
+      var n = parseInt(h.replace('#slide-', ''));
+      if (!isNaN(n) && n >= 1 && n <= total && n - 1 !== current) {
+        goTo(n - 1);
+      }
+    }
+  });
+
+})();
+</script>
+<!-- END-INLINED-SCRIPT -->
 </body>
 </html>

--- a/slides/module-12-thinking-budgets/index.html
+++ b/slides/module-12-thinking-budgets/index.html
@@ -796,6 +796,816 @@ body {
   }
 }
   </style>
+
+  <!-- BEGIN-INLINED-STYLES -->
+  <style>
+  /* shared.css — generated; edit slides/shared/shared.css */
+/* ADK Course — Shared Design Tokens
+   Adapted from barcik-training-exin-ai-foundation/css/shared.css.
+   Family-consistent navy with amber accent (distinct from EXIN gold). */
+
+@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;500;600;700;800&display=swap');
+
+:root {
+  /* Brand colors */
+  --navy: #1E3A5F;
+  --navy-light: #2A5280;
+  --navy-dark: #122542;
+  --amber: #F59E0B;
+  --amber-light: #FBBF24;
+  --amber-dark: #B45309;
+  --white: #FFFFFF;
+  --gray-50: #F8F9FA;
+  --gray-100: #F1F3F5;
+  --gray-200: #E9ECEF;
+  --gray-300: #DEE2E6;
+  --gray-400: #CED4DA;
+  --gray-500: #ADB5BD;
+  --gray-600: #868E96;
+  --gray-700: #495057;
+  --gray-800: #343A40;
+  --gray-900: #212529;
+
+  /* Semantic */
+  --bg-primary: var(--white);
+  --bg-secondary: var(--gray-50);
+  --bg-card: var(--white);
+  --text-primary: var(--gray-900);
+  --text-secondary: var(--gray-700);
+  --text-muted: var(--gray-600);
+  --border-color: var(--gray-200);
+  --accent: var(--navy);
+  --accent-light: var(--navy-light);
+  --highlight: var(--amber);
+  --highlight-bg: #FEF3C7;
+  --success: #2E7D32;
+  --success-bg: #E8F5E9;
+  --error: #C62828;
+  --error-bg: #FFEBEE;
+  --info: #1565C0;
+  --info-bg: #E3F2FD;
+
+  /* Typography */
+  --font-sans: 'Nunito', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+  --text-3xl: 1.875rem;
+  --text-4xl: 2.25rem;
+
+  /* Spacing */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-10: 2.5rem;
+  --space-12: 3rem;
+  --space-16: 4rem;
+
+  /* Radius */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.07);
+  --shadow-lg: 0 10px 15px rgba(0,0,0,0.1);
+
+  /* Transitions */
+  --transition-fast: 150ms ease;
+  --transition-normal: 250ms ease;
+  --transition-slow: 350ms ease;
+}
+
+[data-theme="dark"] {
+  --bg-primary: #0D1117;
+  --bg-secondary: #161B22;
+  --bg-card: #1C2128;
+  --text-primary: #E6EDF3;
+  --text-secondary: #B1BAC4;
+  --text-muted: #8B949E;
+  --border-color: #30363D;
+  --accent: #58A6FF;
+  --accent-light: #79C0FF;
+  --highlight: var(--amber);
+  --highlight-bg: #2D2200;
+  --success: #56D364;
+  --success-bg: #0D2818;
+  --error: #F85149;
+  --error-bg: #2D1214;
+  --info: #58A6FF;
+  --info-bg: #0D1B2E;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.3);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.4);
+  --shadow-lg: 0 10px 15px rgba(0,0,0,0.5);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg-primary: #0D1117;
+    --bg-secondary: #161B22;
+    --bg-card: #1C2128;
+    --text-primary: #E6EDF3;
+    --text-secondary: #B1BAC4;
+    --text-muted: #8B949E;
+    --border-color: #30363D;
+    --accent: #58A6FF;
+    --accent-light: #79C0FF;
+    --highlight: var(--amber);
+    --highlight-bg: #2D2200;
+    --success: #56D364;
+    --success-bg: #0D2818;
+    --error: #F85149;
+    --error-bg: #2D1214;
+    --info: #58A6FF;
+    --info-bg: #0D1B2E;
+  }
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  line-height: 1.6;
+  color: var(--text-primary);
+  background-color: var(--bg-primary);
+  -webkit-font-smoothing: antialiased;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow var(--transition-normal);
+}
+
+.card:hover {
+  box-shadow: var(--shadow-md);
+}
+
+.callout {
+  padding: var(--space-4) var(--space-6);
+  border-radius: var(--radius-md);
+  margin: var(--space-4) 0;
+  border-left: 4px solid;
+}
+
+.callout-key { background: var(--highlight-bg); border-color: var(--amber); }
+.callout-gotcha { background: var(--error-bg); border-color: var(--error); }
+.callout-tip { background: var(--info-bg); border-color: var(--info); }
+.callout-success { background: var(--success-bg); border-color: var(--success); }
+
+.callout-title {
+  font-weight: 700;
+  font-size: var(--text-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: var(--space-2);
+}
+
+.text-center { text-align: center; }
+.text-muted { color: var(--text-muted); }
+.font-mono { font-family: var(--font-mono); }
+.mt-4 { margin-top: var(--space-4); }
+.mt-8 { margin-top: var(--space-8); }
+.mb-4 { margin-bottom: var(--space-4); }
+.mb-8 { margin-bottom: var(--space-8); }
+.mx-auto { margin-left: auto; margin-right: auto; }
+.max-w-4xl { max-width: 56rem; }
+.hidden { display: none !important; }
+  /* slides.css — generated; edit slides/shared/slides.css */
+/* ADK Course — Slide Presentation Theme
+   Adapted from barcik-training-exin-ai-foundation/slides/css/slides.css.
+   Adds data-type="code" slide variant for Python snippets. */
+
+:root {
+  --slide-font-size: 18px;
+  --strip-height: 48px;
+}
+
+body {
+  margin: 0;
+  overflow: hidden;
+  background: var(--bg-primary);
+}
+
+/* ── Progress Strip ──────────────────────────────── */
+.progress-strip {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  height: var(--strip-height);
+  background: var(--navy);
+  display: flex;
+  align-items: center;
+  z-index: 100;
+  padding: 0 var(--space-4);
+  gap: var(--space-4);
+  box-shadow: var(--shadow-md);
+  font-family: var(--font-sans);
+}
+
+.progress-home {
+  color: var(--amber);
+  text-decoration: none;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: var(--radius-md);
+  white-space: nowrap;
+  transition: all var(--transition-fast);
+}
+
+.progress-home:hover {
+  background: rgba(255,255,255,0.1);
+  border-color: var(--amber);
+}
+
+.progress-title {
+  color: rgba(255,255,255,0.85);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  flex: 1;
+  text-align: center;
+}
+
+.progress-title .quick-path-badge {
+  display: inline-block;
+  background: var(--amber);
+  color: var(--navy-dark);
+  font-size: 0.68rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.15rem 0.55rem;
+  border-radius: 9999px;
+  margin-left: 0.6rem;
+  vertical-align: 2px;
+}
+
+.progress-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.slide-counter {
+  color: rgba(255,255,255,0.6);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  font-family: var(--font-mono);
+  white-space: nowrap;
+}
+
+.progress-strip .theme-toggle {
+  background: rgba(255,255,255,0.1);
+  color: rgba(255,255,255,0.7);
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: var(--radius-md);
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-xs);
+  cursor: pointer;
+  font-family: var(--font-sans);
+  transition: all var(--transition-fast);
+}
+
+.progress-strip .theme-toggle:hover {
+  background: rgba(255,255,255,0.2);
+  color: white;
+}
+
+/* ── Viewport ────────────────────────────────────── */
+.slide-viewport {
+  position: fixed;
+  top: var(--strip-height);
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow: hidden;
+}
+
+/* ── Slide Base ──────────────────────────────────── */
+.slide {
+  display: none;
+  position: absolute;
+  inset: 0;
+  overflow-y: auto;
+  padding: var(--space-10) var(--space-16);
+  font-size: var(--slide-font-size);
+  line-height: 1.6;
+  font-family: var(--font-sans);
+  color: var(--text-primary);
+  background: var(--bg-primary);
+}
+
+.slide.active {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  animation: fadeIn 0.25s ease;
+}
+
+.slide > * {
+  max-width: 1100px;
+  width: 100% !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
+  box-sizing: border-box;
+  text-align: inherit;
+}
+
+.slide > .topic-badge {
+  width: auto !important;
+  max-width: none;
+  align-self: center;
+}
+
+/* ── Section Title ───────────────────────────────── */
+.slide[data-type="section-title"] {
+  background: linear-gradient(135deg, var(--navy) 0%, var(--navy-light) 100%);
+  text-align: center;
+}
+
+.slide[data-type="section-title"] h1,
+.slide[data-type="section-title"] h2,
+.slide[data-type="section-title"] h3 {
+  color: white;
+}
+
+.slide[data-type="section-title"] p {
+  color: rgba(255,255,255,0.85);
+}
+
+.slide[data-type="section-title"] .topic-badge {
+  display: inline-block;
+  background: var(--amber);
+  color: var(--navy-dark);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  padding: var(--space-2) var(--space-4);
+  border-radius: 9999px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: var(--space-4);
+  width: auto !important;
+}
+
+.slide[data-type="section-title"] .highlight-text {
+  color: var(--amber);
+  font-weight: 600;
+}
+
+/* ── Typography ──────────────────────────────────── */
+.slide h1 {
+  font-size: 2.4em;
+  font-weight: 800;
+  color: var(--navy);
+  margin-bottom: var(--space-4);
+  line-height: 1.15;
+}
+
+.slide h2 {
+  font-size: 1.6em;
+  font-weight: 700;
+  color: var(--navy);
+  margin-bottom: var(--space-4);
+  padding-bottom: var(--space-2);
+  border-bottom: 3px solid var(--amber);
+}
+
+.slide h3 {
+  font-size: 1.2em;
+  font-weight: 600;
+  color: var(--navy-light);
+  margin-bottom: var(--space-3);
+}
+
+.slide p {
+  margin-bottom: var(--space-3);
+  color: var(--text-secondary);
+}
+
+.slide strong {
+  color: var(--navy);
+  font-weight: 700;
+}
+
+.slide em {
+  color: var(--amber-dark);
+  font-style: italic;
+}
+
+.slide ul, .slide ol {
+  margin-left: 1.2em;
+  margin-bottom: var(--space-4);
+}
+
+.slide li {
+  margin-bottom: var(--space-2);
+  color: var(--text-secondary);
+}
+
+.slide li::marker {
+  color: var(--amber);
+}
+
+[data-theme="dark"] .slide h1,
+[data-theme="dark"] .slide h2 { color: var(--text-primary); }
+[data-theme="dark"] .slide h3 { color: var(--text-secondary); }
+[data-theme="dark"] .slide strong { color: var(--text-primary); }
+[data-theme="dark"] .slide h2 { border-bottom-color: var(--amber); }
+
+.highlight-text {
+  color: var(--amber-dark);
+  font-weight: 600;
+}
+
+[data-theme="dark"] .highlight-text {
+  color: var(--amber);
+}
+
+/* ── Grid ────────────────────────────────────────── */
+.slide[data-type="grid"] .grid-layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: var(--space-4);
+  margin-top: var(--space-4);
+}
+
+.grid-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5);
+  transition: all var(--transition-normal);
+}
+
+.grid-card:hover {
+  box-shadow: var(--shadow-md);
+  transform: translateY(-2px);
+  border-color: var(--accent);
+}
+
+.grid-card.highlight {
+  border-color: var(--amber);
+  box-shadow: 0 0 0 1px var(--amber), var(--shadow-sm);
+}
+
+.grid-card-title {
+  font-weight: 700;
+  color: var(--text-primary);
+  font-size: 1.05em;
+  margin-bottom: var(--space-2);
+}
+
+.grid-card-body {
+  color: var(--text-secondary);
+  font-size: 0.9em;
+  line-height: 1.5;
+}
+
+/* ── Split ───────────────────────────────────────── */
+.slide[data-type="split"] .split-layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-8);
+  margin-top: var(--space-4);
+}
+
+@media (max-width: 768px) {
+  .slide[data-type="split"] .split-layout { grid-template-columns: 1fr; }
+}
+
+/* ── Comparison ──────────────────────────────────── */
+.slide[data-type="comparison"] .comparison-layout {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: var(--space-6);
+  align-items: start;
+  margin-top: var(--space-4);
+}
+
+.vs-left, .vs-right {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+}
+
+.vs-divider {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5em;
+  font-weight: 800;
+  color: var(--text-muted);
+  align-self: center;
+}
+
+@media (max-width: 768px) {
+  .slide[data-type="comparison"] .comparison-layout {
+    grid-template-columns: 1fr;
+  }
+  .vs-divider { display: none; }
+}
+
+/* ── Quote ───────────────────────────────────────── */
+.slide[data-type="quote"] {
+  text-align: center;
+}
+
+.quote-text {
+  font-size: 1.5em;
+  font-weight: 300;
+  font-style: italic;
+  color: var(--text-primary);
+  max-width: 80%;
+  line-height: 1.5;
+  position: relative;
+  padding: 0.5em 1em;
+  margin: 0 auto;
+}
+
+.quote-text::before {
+  content: '\201C';
+  position: absolute;
+  left: -0.3em;
+  top: -0.2em;
+  font-size: 3.5em;
+  color: var(--amber);
+  font-weight: 800;
+  line-height: 1;
+  opacity: 0.3;
+}
+
+.quote-source {
+  margin-top: var(--space-4);
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  font-weight: 500;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.quote-source::before { content: '\2014\00a0'; }
+
+/* ── Key Fact ────────────────────────────────────── */
+.slide[data-type="keyfact"] {
+  text-align: center;
+}
+
+.slide[data-type="keyfact"] p {
+  font-size: 1.5em;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.35;
+}
+
+.slide[data-type="keyfact"] strong {
+  color: var(--amber-dark);
+}
+
+[data-theme="dark"] .slide[data-type="keyfact"] strong {
+  color: var(--amber);
+}
+
+/* ── Hero ────────────────────────────────────────── */
+.slide[data-type="hero"] {
+  text-align: center;
+}
+
+/* ── Example / Code ──────────────────────────────── */
+.slide[data-type="example"] {
+  border-left: 4px solid var(--info);
+}
+
+.slide[data-type="code"] pre,
+.slide pre {
+  background: var(--gray-900);
+  color: #E6EDF3;
+  border-radius: var(--radius-md);
+  padding: var(--space-4) var(--space-5);
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  line-height: 1.55;
+  margin: var(--space-3) 0;
+  box-shadow: var(--shadow-sm);
+}
+
+.slide[data-type="code"] pre code,
+.slide pre code {
+  background: none;
+  color: inherit;
+  padding: 0;
+  font-family: var(--font-mono);
+}
+
+.slide code {
+  font-family: var(--font-mono);
+  background: var(--bg-secondary);
+  color: var(--navy);
+  padding: 0.1em 0.35em;
+  border-radius: var(--radius-sm);
+  font-size: 0.9em;
+}
+
+[data-theme="dark"] .slide code {
+  color: var(--accent-light);
+  background: var(--gray-800);
+}
+
+.slide .code-caption {
+  color: var(--text-muted);
+  font-size: 0.85em;
+  font-style: italic;
+  margin-top: var(--space-2);
+}
+
+/* ── Definition Cards ────────────────────────────── */
+.def-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-left: 4px solid var(--navy-light);
+  border-radius: 0 var(--radius-lg) var(--radius-lg) 0;
+  padding: var(--space-4) var(--space-5);
+  margin-bottom: var(--space-3);
+  transition: border-color var(--transition-fast);
+}
+
+.def-card.highlight {
+  border-left-color: var(--amber);
+}
+
+.def-term {
+  font-size: var(--text-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--navy-light);
+  margin-bottom: var(--space-2);
+}
+
+[data-theme="dark"] .def-term { color: var(--accent); }
+
+.def-text {
+  color: var(--text-primary);
+  line-height: 1.5;
+}
+
+/* ── Callouts on slides ──────────────────────────── */
+.slide .callout {
+  margin: var(--space-4) 0;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* ── Tables ──────────────────────────────────────── */
+.slide table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  margin: var(--space-4) 0;
+  font-size: 0.92em;
+}
+
+.slide table th {
+  background: var(--navy);
+  color: white;
+  padding: var(--space-3) var(--space-4);
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.9em;
+}
+
+.slide table td {
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border-color);
+  color: var(--text-secondary);
+}
+
+.slide table tr:nth-child(even) { background: var(--bg-secondary); }
+.slide table tr:last-child td { border-bottom: none; }
+
+/* ── Two-Column Layout ───────────────────────────── */
+.two-col {
+  display: flex;
+  gap: var(--space-8);
+  align-items: flex-start;
+}
+
+.col { flex: 1; min-width: 0; }
+
+@media (max-width: 768px) {
+  .two-col { flex-direction: column; gap: var(--space-4); }
+}
+
+/* ── ASCII-art / diagram ─────────────────────────── */
+.slide .diagram {
+  background: var(--gray-900);
+  color: #C9D1D9;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  line-height: 1.4;
+  padding: var(--space-4) var(--space-5);
+  border-radius: var(--radius-md);
+  white-space: pre;
+  overflow-x: auto;
+  margin: var(--space-3) 0;
+}
+
+/* ── Font Controls ───────────────────────────────── */
+.font-controls {
+  position: fixed;
+  bottom: var(--space-6);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: var(--space-2);
+  z-index: 100;
+  background: var(--bg-card);
+  padding: var(--space-2);
+  border-radius: 9999px;
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-md);
+  opacity: 0.5;
+  transition: opacity var(--transition-fast);
+}
+
+.font-controls:hover { opacity: 1; }
+
+.font-controls button {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.font-controls button:hover {
+  background: var(--navy);
+  color: white;
+  border-color: var(--navy);
+}
+
+/* ── Animations ──────────────────────────────────── */
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Print ───────────────────────────────────────── */
+@media print {
+  .progress-strip, .font-controls { display: none !important; }
+  .slide-viewport { position: static; overflow: visible; }
+  .slide {
+    display: block !important;
+    position: static !important;
+    page-break-after: always;
+    padding: 2cm;
+  }
+  .slide[data-type="section-title"] {
+    background: var(--navy) !important;
+    color: white !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+  .slide pre {
+    background: var(--gray-100) !important;
+    color: var(--gray-900) !important;
+    border: 1px solid var(--gray-400);
+  }
+}
+  </style>
+  <!-- END-INLINED-STYLES -->
 </head>
 <body>
   <nav class="progress-strip">
@@ -1099,5 +1909,148 @@ thinking_agent = LlmAgent(
 
 })();
 </script>
+
+  <!-- BEGIN-INLINED-SCRIPT -->
+<script>
+/* ADK Course — Slide Engine
+   Adapted from barcik-training-exin-ai-foundation/slides/js/slides.js.
+   Per-module decks; lightweight nav with keyboard, touch, hash routing,
+   font controls, theme toggle. */
+
+(function () {
+  'use strict';
+
+  const slides = document.querySelectorAll('.slide');
+  const total = slides.length;
+  let current = 0;
+
+  function goTo(index) {
+    if (index < 0 || index >= total) return;
+    slides[current].classList.remove('active');
+    current = index;
+    slides[current].classList.add('active');
+    updateCounter();
+    window.scrollTo(0, 0);
+    history.replaceState(null, '', '#slide-' + (current + 1));
+  }
+
+  function next() { goTo(current + 1); }
+  function prev() { goTo(current - 1); }
+
+  document.addEventListener('keydown', function (e) {
+    if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+      case ' ':
+        e.preventDefault();
+        next();
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        e.preventDefault();
+        prev();
+        break;
+      case 'Home':
+        e.preventDefault();
+        goTo(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        goTo(total - 1);
+        break;
+    }
+  });
+
+  var viewport = document.querySelector('.slide-viewport');
+  if (viewport) {
+    viewport.addEventListener('click', function (e) {
+      if (e.target === this || e.target.classList.contains('slide')) {
+        var rect = this.getBoundingClientRect();
+        var x = e.clientX - rect.left;
+        if (x > rect.width * 0.75) next();
+        else if (x < rect.width * 0.25) prev();
+      }
+    });
+  }
+
+  var counter = document.querySelector('.slide-counter');
+  function updateCounter() {
+    if (counter) counter.textContent = (current + 1) + ' / ' + total;
+  }
+
+  var baseFontSize = parseInt(localStorage.getItem('adkSlideFontSize')) || 18;
+  applyFontSize();
+
+  window.adjustFont = function (delta) {
+    if (delta === 0) {
+      baseFontSize = 18;
+    } else {
+      baseFontSize = Math.max(14, Math.min(28, baseFontSize + delta));
+    }
+    applyFontSize();
+    localStorage.setItem('adkSlideFontSize', baseFontSize);
+  };
+
+  function applyFontSize() {
+    document.documentElement.style.setProperty('--slide-font-size', baseFontSize + 'px');
+  }
+
+  var themeBtn = document.querySelector('.theme-toggle');
+  var savedTheme = localStorage.getItem('adkTheme');
+  if (savedTheme) {
+    document.documentElement.setAttribute('data-theme', savedTheme);
+  }
+
+  if (themeBtn) {
+    themeBtn.addEventListener('click', function () {
+      var html = document.documentElement;
+      var nextTheme = html.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+      html.setAttribute('data-theme', nextTheme);
+      localStorage.setItem('adkTheme', nextTheme);
+    });
+  }
+
+  var touchStartX = 0;
+  var touchStartY = 0;
+
+  document.addEventListener('touchstart', function (e) {
+    touchStartX = e.changedTouches[0].screenX;
+    touchStartY = e.changedTouches[0].screenY;
+  }, { passive: true });
+
+  document.addEventListener('touchend', function (e) {
+    var dx = e.changedTouches[0].screenX - touchStartX;
+    var dy = e.changedTouches[0].screenY - touchStartY;
+    if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > 50) {
+      if (dx < 0) next();
+      else prev();
+    }
+  }, { passive: true });
+
+  var hash = window.location.hash;
+  if (hash && hash.startsWith('#slide-')) {
+    var n = parseInt(hash.replace('#slide-', ''));
+    if (!isNaN(n) && n >= 1 && n <= total) {
+      current = n - 1;
+    }
+  }
+
+  slides[current].classList.add('active');
+  updateCounter();
+
+  window.addEventListener('hashchange', function () {
+    var h = window.location.hash;
+    if (h && h.startsWith('#slide-')) {
+      var n = parseInt(h.replace('#slide-', ''));
+      if (!isNaN(n) && n >= 1 && n <= total && n - 1 !== current) {
+        goTo(n - 1);
+      }
+    }
+  });
+
+})();
+</script>
+<!-- END-INLINED-SCRIPT -->
 </body>
 </html>

--- a/slides/module-13-live-voice/index.html
+++ b/slides/module-13-live-voice/index.html
@@ -796,6 +796,816 @@ body {
   }
 }
   </style>
+
+  <!-- BEGIN-INLINED-STYLES -->
+  <style>
+  /* shared.css — generated; edit slides/shared/shared.css */
+/* ADK Course — Shared Design Tokens
+   Adapted from barcik-training-exin-ai-foundation/css/shared.css.
+   Family-consistent navy with amber accent (distinct from EXIN gold). */
+
+@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;500;600;700;800&display=swap');
+
+:root {
+  /* Brand colors */
+  --navy: #1E3A5F;
+  --navy-light: #2A5280;
+  --navy-dark: #122542;
+  --amber: #F59E0B;
+  --amber-light: #FBBF24;
+  --amber-dark: #B45309;
+  --white: #FFFFFF;
+  --gray-50: #F8F9FA;
+  --gray-100: #F1F3F5;
+  --gray-200: #E9ECEF;
+  --gray-300: #DEE2E6;
+  --gray-400: #CED4DA;
+  --gray-500: #ADB5BD;
+  --gray-600: #868E96;
+  --gray-700: #495057;
+  --gray-800: #343A40;
+  --gray-900: #212529;
+
+  /* Semantic */
+  --bg-primary: var(--white);
+  --bg-secondary: var(--gray-50);
+  --bg-card: var(--white);
+  --text-primary: var(--gray-900);
+  --text-secondary: var(--gray-700);
+  --text-muted: var(--gray-600);
+  --border-color: var(--gray-200);
+  --accent: var(--navy);
+  --accent-light: var(--navy-light);
+  --highlight: var(--amber);
+  --highlight-bg: #FEF3C7;
+  --success: #2E7D32;
+  --success-bg: #E8F5E9;
+  --error: #C62828;
+  --error-bg: #FFEBEE;
+  --info: #1565C0;
+  --info-bg: #E3F2FD;
+
+  /* Typography */
+  --font-sans: 'Nunito', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+  --text-3xl: 1.875rem;
+  --text-4xl: 2.25rem;
+
+  /* Spacing */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-10: 2.5rem;
+  --space-12: 3rem;
+  --space-16: 4rem;
+
+  /* Radius */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.07);
+  --shadow-lg: 0 10px 15px rgba(0,0,0,0.1);
+
+  /* Transitions */
+  --transition-fast: 150ms ease;
+  --transition-normal: 250ms ease;
+  --transition-slow: 350ms ease;
+}
+
+[data-theme="dark"] {
+  --bg-primary: #0D1117;
+  --bg-secondary: #161B22;
+  --bg-card: #1C2128;
+  --text-primary: #E6EDF3;
+  --text-secondary: #B1BAC4;
+  --text-muted: #8B949E;
+  --border-color: #30363D;
+  --accent: #58A6FF;
+  --accent-light: #79C0FF;
+  --highlight: var(--amber);
+  --highlight-bg: #2D2200;
+  --success: #56D364;
+  --success-bg: #0D2818;
+  --error: #F85149;
+  --error-bg: #2D1214;
+  --info: #58A6FF;
+  --info-bg: #0D1B2E;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.3);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.4);
+  --shadow-lg: 0 10px 15px rgba(0,0,0,0.5);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg-primary: #0D1117;
+    --bg-secondary: #161B22;
+    --bg-card: #1C2128;
+    --text-primary: #E6EDF3;
+    --text-secondary: #B1BAC4;
+    --text-muted: #8B949E;
+    --border-color: #30363D;
+    --accent: #58A6FF;
+    --accent-light: #79C0FF;
+    --highlight: var(--amber);
+    --highlight-bg: #2D2200;
+    --success: #56D364;
+    --success-bg: #0D2818;
+    --error: #F85149;
+    --error-bg: #2D1214;
+    --info: #58A6FF;
+    --info-bg: #0D1B2E;
+  }
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  line-height: 1.6;
+  color: var(--text-primary);
+  background-color: var(--bg-primary);
+  -webkit-font-smoothing: antialiased;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow var(--transition-normal);
+}
+
+.card:hover {
+  box-shadow: var(--shadow-md);
+}
+
+.callout {
+  padding: var(--space-4) var(--space-6);
+  border-radius: var(--radius-md);
+  margin: var(--space-4) 0;
+  border-left: 4px solid;
+}
+
+.callout-key { background: var(--highlight-bg); border-color: var(--amber); }
+.callout-gotcha { background: var(--error-bg); border-color: var(--error); }
+.callout-tip { background: var(--info-bg); border-color: var(--info); }
+.callout-success { background: var(--success-bg); border-color: var(--success); }
+
+.callout-title {
+  font-weight: 700;
+  font-size: var(--text-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: var(--space-2);
+}
+
+.text-center { text-align: center; }
+.text-muted { color: var(--text-muted); }
+.font-mono { font-family: var(--font-mono); }
+.mt-4 { margin-top: var(--space-4); }
+.mt-8 { margin-top: var(--space-8); }
+.mb-4 { margin-bottom: var(--space-4); }
+.mb-8 { margin-bottom: var(--space-8); }
+.mx-auto { margin-left: auto; margin-right: auto; }
+.max-w-4xl { max-width: 56rem; }
+.hidden { display: none !important; }
+  /* slides.css — generated; edit slides/shared/slides.css */
+/* ADK Course — Slide Presentation Theme
+   Adapted from barcik-training-exin-ai-foundation/slides/css/slides.css.
+   Adds data-type="code" slide variant for Python snippets. */
+
+:root {
+  --slide-font-size: 18px;
+  --strip-height: 48px;
+}
+
+body {
+  margin: 0;
+  overflow: hidden;
+  background: var(--bg-primary);
+}
+
+/* ── Progress Strip ──────────────────────────────── */
+.progress-strip {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  height: var(--strip-height);
+  background: var(--navy);
+  display: flex;
+  align-items: center;
+  z-index: 100;
+  padding: 0 var(--space-4);
+  gap: var(--space-4);
+  box-shadow: var(--shadow-md);
+  font-family: var(--font-sans);
+}
+
+.progress-home {
+  color: var(--amber);
+  text-decoration: none;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: var(--radius-md);
+  white-space: nowrap;
+  transition: all var(--transition-fast);
+}
+
+.progress-home:hover {
+  background: rgba(255,255,255,0.1);
+  border-color: var(--amber);
+}
+
+.progress-title {
+  color: rgba(255,255,255,0.85);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  flex: 1;
+  text-align: center;
+}
+
+.progress-title .quick-path-badge {
+  display: inline-block;
+  background: var(--amber);
+  color: var(--navy-dark);
+  font-size: 0.68rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.15rem 0.55rem;
+  border-radius: 9999px;
+  margin-left: 0.6rem;
+  vertical-align: 2px;
+}
+
+.progress-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.slide-counter {
+  color: rgba(255,255,255,0.6);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  font-family: var(--font-mono);
+  white-space: nowrap;
+}
+
+.progress-strip .theme-toggle {
+  background: rgba(255,255,255,0.1);
+  color: rgba(255,255,255,0.7);
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: var(--radius-md);
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-xs);
+  cursor: pointer;
+  font-family: var(--font-sans);
+  transition: all var(--transition-fast);
+}
+
+.progress-strip .theme-toggle:hover {
+  background: rgba(255,255,255,0.2);
+  color: white;
+}
+
+/* ── Viewport ────────────────────────────────────── */
+.slide-viewport {
+  position: fixed;
+  top: var(--strip-height);
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow: hidden;
+}
+
+/* ── Slide Base ──────────────────────────────────── */
+.slide {
+  display: none;
+  position: absolute;
+  inset: 0;
+  overflow-y: auto;
+  padding: var(--space-10) var(--space-16);
+  font-size: var(--slide-font-size);
+  line-height: 1.6;
+  font-family: var(--font-sans);
+  color: var(--text-primary);
+  background: var(--bg-primary);
+}
+
+.slide.active {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  animation: fadeIn 0.25s ease;
+}
+
+.slide > * {
+  max-width: 1100px;
+  width: 100% !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
+  box-sizing: border-box;
+  text-align: inherit;
+}
+
+.slide > .topic-badge {
+  width: auto !important;
+  max-width: none;
+  align-self: center;
+}
+
+/* ── Section Title ───────────────────────────────── */
+.slide[data-type="section-title"] {
+  background: linear-gradient(135deg, var(--navy) 0%, var(--navy-light) 100%);
+  text-align: center;
+}
+
+.slide[data-type="section-title"] h1,
+.slide[data-type="section-title"] h2,
+.slide[data-type="section-title"] h3 {
+  color: white;
+}
+
+.slide[data-type="section-title"] p {
+  color: rgba(255,255,255,0.85);
+}
+
+.slide[data-type="section-title"] .topic-badge {
+  display: inline-block;
+  background: var(--amber);
+  color: var(--navy-dark);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  padding: var(--space-2) var(--space-4);
+  border-radius: 9999px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: var(--space-4);
+  width: auto !important;
+}
+
+.slide[data-type="section-title"] .highlight-text {
+  color: var(--amber);
+  font-weight: 600;
+}
+
+/* ── Typography ──────────────────────────────────── */
+.slide h1 {
+  font-size: 2.4em;
+  font-weight: 800;
+  color: var(--navy);
+  margin-bottom: var(--space-4);
+  line-height: 1.15;
+}
+
+.slide h2 {
+  font-size: 1.6em;
+  font-weight: 700;
+  color: var(--navy);
+  margin-bottom: var(--space-4);
+  padding-bottom: var(--space-2);
+  border-bottom: 3px solid var(--amber);
+}
+
+.slide h3 {
+  font-size: 1.2em;
+  font-weight: 600;
+  color: var(--navy-light);
+  margin-bottom: var(--space-3);
+}
+
+.slide p {
+  margin-bottom: var(--space-3);
+  color: var(--text-secondary);
+}
+
+.slide strong {
+  color: var(--navy);
+  font-weight: 700;
+}
+
+.slide em {
+  color: var(--amber-dark);
+  font-style: italic;
+}
+
+.slide ul, .slide ol {
+  margin-left: 1.2em;
+  margin-bottom: var(--space-4);
+}
+
+.slide li {
+  margin-bottom: var(--space-2);
+  color: var(--text-secondary);
+}
+
+.slide li::marker {
+  color: var(--amber);
+}
+
+[data-theme="dark"] .slide h1,
+[data-theme="dark"] .slide h2 { color: var(--text-primary); }
+[data-theme="dark"] .slide h3 { color: var(--text-secondary); }
+[data-theme="dark"] .slide strong { color: var(--text-primary); }
+[data-theme="dark"] .slide h2 { border-bottom-color: var(--amber); }
+
+.highlight-text {
+  color: var(--amber-dark);
+  font-weight: 600;
+}
+
+[data-theme="dark"] .highlight-text {
+  color: var(--amber);
+}
+
+/* ── Grid ────────────────────────────────────────── */
+.slide[data-type="grid"] .grid-layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: var(--space-4);
+  margin-top: var(--space-4);
+}
+
+.grid-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5);
+  transition: all var(--transition-normal);
+}
+
+.grid-card:hover {
+  box-shadow: var(--shadow-md);
+  transform: translateY(-2px);
+  border-color: var(--accent);
+}
+
+.grid-card.highlight {
+  border-color: var(--amber);
+  box-shadow: 0 0 0 1px var(--amber), var(--shadow-sm);
+}
+
+.grid-card-title {
+  font-weight: 700;
+  color: var(--text-primary);
+  font-size: 1.05em;
+  margin-bottom: var(--space-2);
+}
+
+.grid-card-body {
+  color: var(--text-secondary);
+  font-size: 0.9em;
+  line-height: 1.5;
+}
+
+/* ── Split ───────────────────────────────────────── */
+.slide[data-type="split"] .split-layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-8);
+  margin-top: var(--space-4);
+}
+
+@media (max-width: 768px) {
+  .slide[data-type="split"] .split-layout { grid-template-columns: 1fr; }
+}
+
+/* ── Comparison ──────────────────────────────────── */
+.slide[data-type="comparison"] .comparison-layout {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: var(--space-6);
+  align-items: start;
+  margin-top: var(--space-4);
+}
+
+.vs-left, .vs-right {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+}
+
+.vs-divider {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5em;
+  font-weight: 800;
+  color: var(--text-muted);
+  align-self: center;
+}
+
+@media (max-width: 768px) {
+  .slide[data-type="comparison"] .comparison-layout {
+    grid-template-columns: 1fr;
+  }
+  .vs-divider { display: none; }
+}
+
+/* ── Quote ───────────────────────────────────────── */
+.slide[data-type="quote"] {
+  text-align: center;
+}
+
+.quote-text {
+  font-size: 1.5em;
+  font-weight: 300;
+  font-style: italic;
+  color: var(--text-primary);
+  max-width: 80%;
+  line-height: 1.5;
+  position: relative;
+  padding: 0.5em 1em;
+  margin: 0 auto;
+}
+
+.quote-text::before {
+  content: '\201C';
+  position: absolute;
+  left: -0.3em;
+  top: -0.2em;
+  font-size: 3.5em;
+  color: var(--amber);
+  font-weight: 800;
+  line-height: 1;
+  opacity: 0.3;
+}
+
+.quote-source {
+  margin-top: var(--space-4);
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  font-weight: 500;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.quote-source::before { content: '\2014\00a0'; }
+
+/* ── Key Fact ────────────────────────────────────── */
+.slide[data-type="keyfact"] {
+  text-align: center;
+}
+
+.slide[data-type="keyfact"] p {
+  font-size: 1.5em;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.35;
+}
+
+.slide[data-type="keyfact"] strong {
+  color: var(--amber-dark);
+}
+
+[data-theme="dark"] .slide[data-type="keyfact"] strong {
+  color: var(--amber);
+}
+
+/* ── Hero ────────────────────────────────────────── */
+.slide[data-type="hero"] {
+  text-align: center;
+}
+
+/* ── Example / Code ──────────────────────────────── */
+.slide[data-type="example"] {
+  border-left: 4px solid var(--info);
+}
+
+.slide[data-type="code"] pre,
+.slide pre {
+  background: var(--gray-900);
+  color: #E6EDF3;
+  border-radius: var(--radius-md);
+  padding: var(--space-4) var(--space-5);
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  line-height: 1.55;
+  margin: var(--space-3) 0;
+  box-shadow: var(--shadow-sm);
+}
+
+.slide[data-type="code"] pre code,
+.slide pre code {
+  background: none;
+  color: inherit;
+  padding: 0;
+  font-family: var(--font-mono);
+}
+
+.slide code {
+  font-family: var(--font-mono);
+  background: var(--bg-secondary);
+  color: var(--navy);
+  padding: 0.1em 0.35em;
+  border-radius: var(--radius-sm);
+  font-size: 0.9em;
+}
+
+[data-theme="dark"] .slide code {
+  color: var(--accent-light);
+  background: var(--gray-800);
+}
+
+.slide .code-caption {
+  color: var(--text-muted);
+  font-size: 0.85em;
+  font-style: italic;
+  margin-top: var(--space-2);
+}
+
+/* ── Definition Cards ────────────────────────────── */
+.def-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-left: 4px solid var(--navy-light);
+  border-radius: 0 var(--radius-lg) var(--radius-lg) 0;
+  padding: var(--space-4) var(--space-5);
+  margin-bottom: var(--space-3);
+  transition: border-color var(--transition-fast);
+}
+
+.def-card.highlight {
+  border-left-color: var(--amber);
+}
+
+.def-term {
+  font-size: var(--text-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--navy-light);
+  margin-bottom: var(--space-2);
+}
+
+[data-theme="dark"] .def-term { color: var(--accent); }
+
+.def-text {
+  color: var(--text-primary);
+  line-height: 1.5;
+}
+
+/* ── Callouts on slides ──────────────────────────── */
+.slide .callout {
+  margin: var(--space-4) 0;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* ── Tables ──────────────────────────────────────── */
+.slide table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  margin: var(--space-4) 0;
+  font-size: 0.92em;
+}
+
+.slide table th {
+  background: var(--navy);
+  color: white;
+  padding: var(--space-3) var(--space-4);
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.9em;
+}
+
+.slide table td {
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border-color);
+  color: var(--text-secondary);
+}
+
+.slide table tr:nth-child(even) { background: var(--bg-secondary); }
+.slide table tr:last-child td { border-bottom: none; }
+
+/* ── Two-Column Layout ───────────────────────────── */
+.two-col {
+  display: flex;
+  gap: var(--space-8);
+  align-items: flex-start;
+}
+
+.col { flex: 1; min-width: 0; }
+
+@media (max-width: 768px) {
+  .two-col { flex-direction: column; gap: var(--space-4); }
+}
+
+/* ── ASCII-art / diagram ─────────────────────────── */
+.slide .diagram {
+  background: var(--gray-900);
+  color: #C9D1D9;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  line-height: 1.4;
+  padding: var(--space-4) var(--space-5);
+  border-radius: var(--radius-md);
+  white-space: pre;
+  overflow-x: auto;
+  margin: var(--space-3) 0;
+}
+
+/* ── Font Controls ───────────────────────────────── */
+.font-controls {
+  position: fixed;
+  bottom: var(--space-6);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: var(--space-2);
+  z-index: 100;
+  background: var(--bg-card);
+  padding: var(--space-2);
+  border-radius: 9999px;
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-md);
+  opacity: 0.5;
+  transition: opacity var(--transition-fast);
+}
+
+.font-controls:hover { opacity: 1; }
+
+.font-controls button {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.font-controls button:hover {
+  background: var(--navy);
+  color: white;
+  border-color: var(--navy);
+}
+
+/* ── Animations ──────────────────────────────────── */
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Print ───────────────────────────────────────── */
+@media print {
+  .progress-strip, .font-controls { display: none !important; }
+  .slide-viewport { position: static; overflow: visible; }
+  .slide {
+    display: block !important;
+    position: static !important;
+    page-break-after: always;
+    padding: 2cm;
+  }
+  .slide[data-type="section-title"] {
+    background: var(--navy) !important;
+    color: white !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+  .slide pre {
+    background: var(--gray-100) !important;
+    color: var(--gray-900) !important;
+    border: 1px solid var(--gray-400);
+  }
+}
+  </style>
+  <!-- END-INLINED-STYLES -->
 </head>
 <body>
   <nav class="progress-strip">
@@ -1121,5 +1931,148 @@ Audio out   ◀──WebSocket──   stream response audio</pre>
 
 })();
 </script>
+
+  <!-- BEGIN-INLINED-SCRIPT -->
+<script>
+/* ADK Course — Slide Engine
+   Adapted from barcik-training-exin-ai-foundation/slides/js/slides.js.
+   Per-module decks; lightweight nav with keyboard, touch, hash routing,
+   font controls, theme toggle. */
+
+(function () {
+  'use strict';
+
+  const slides = document.querySelectorAll('.slide');
+  const total = slides.length;
+  let current = 0;
+
+  function goTo(index) {
+    if (index < 0 || index >= total) return;
+    slides[current].classList.remove('active');
+    current = index;
+    slides[current].classList.add('active');
+    updateCounter();
+    window.scrollTo(0, 0);
+    history.replaceState(null, '', '#slide-' + (current + 1));
+  }
+
+  function next() { goTo(current + 1); }
+  function prev() { goTo(current - 1); }
+
+  document.addEventListener('keydown', function (e) {
+    if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+      case ' ':
+        e.preventDefault();
+        next();
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        e.preventDefault();
+        prev();
+        break;
+      case 'Home':
+        e.preventDefault();
+        goTo(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        goTo(total - 1);
+        break;
+    }
+  });
+
+  var viewport = document.querySelector('.slide-viewport');
+  if (viewport) {
+    viewport.addEventListener('click', function (e) {
+      if (e.target === this || e.target.classList.contains('slide')) {
+        var rect = this.getBoundingClientRect();
+        var x = e.clientX - rect.left;
+        if (x > rect.width * 0.75) next();
+        else if (x < rect.width * 0.25) prev();
+      }
+    });
+  }
+
+  var counter = document.querySelector('.slide-counter');
+  function updateCounter() {
+    if (counter) counter.textContent = (current + 1) + ' / ' + total;
+  }
+
+  var baseFontSize = parseInt(localStorage.getItem('adkSlideFontSize')) || 18;
+  applyFontSize();
+
+  window.adjustFont = function (delta) {
+    if (delta === 0) {
+      baseFontSize = 18;
+    } else {
+      baseFontSize = Math.max(14, Math.min(28, baseFontSize + delta));
+    }
+    applyFontSize();
+    localStorage.setItem('adkSlideFontSize', baseFontSize);
+  };
+
+  function applyFontSize() {
+    document.documentElement.style.setProperty('--slide-font-size', baseFontSize + 'px');
+  }
+
+  var themeBtn = document.querySelector('.theme-toggle');
+  var savedTheme = localStorage.getItem('adkTheme');
+  if (savedTheme) {
+    document.documentElement.setAttribute('data-theme', savedTheme);
+  }
+
+  if (themeBtn) {
+    themeBtn.addEventListener('click', function () {
+      var html = document.documentElement;
+      var nextTheme = html.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+      html.setAttribute('data-theme', nextTheme);
+      localStorage.setItem('adkTheme', nextTheme);
+    });
+  }
+
+  var touchStartX = 0;
+  var touchStartY = 0;
+
+  document.addEventListener('touchstart', function (e) {
+    touchStartX = e.changedTouches[0].screenX;
+    touchStartY = e.changedTouches[0].screenY;
+  }, { passive: true });
+
+  document.addEventListener('touchend', function (e) {
+    var dx = e.changedTouches[0].screenX - touchStartX;
+    var dy = e.changedTouches[0].screenY - touchStartY;
+    if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > 50) {
+      if (dx < 0) next();
+      else prev();
+    }
+  }, { passive: true });
+
+  var hash = window.location.hash;
+  if (hash && hash.startsWith('#slide-')) {
+    var n = parseInt(hash.replace('#slide-', ''));
+    if (!isNaN(n) && n >= 1 && n <= total) {
+      current = n - 1;
+    }
+  }
+
+  slides[current].classList.add('active');
+  updateCounter();
+
+  window.addEventListener('hashchange', function () {
+    var h = window.location.hash;
+    if (h && h.startsWith('#slide-')) {
+      var n = parseInt(h.replace('#slide-', ''));
+      if (!isNaN(n) && n >= 1 && n <= total && n - 1 !== current) {
+        goTo(n - 1);
+      }
+    }
+  });
+
+})();
+</script>
+<!-- END-INLINED-SCRIPT -->
 </body>
 </html>

--- a/slides/module-14-a2a/index.html
+++ b/slides/module-14-a2a/index.html
@@ -796,6 +796,816 @@ body {
   }
 }
   </style>
+
+  <!-- BEGIN-INLINED-STYLES -->
+  <style>
+  /* shared.css — generated; edit slides/shared/shared.css */
+/* ADK Course — Shared Design Tokens
+   Adapted from barcik-training-exin-ai-foundation/css/shared.css.
+   Family-consistent navy with amber accent (distinct from EXIN gold). */
+
+@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;500;600;700;800&display=swap');
+
+:root {
+  /* Brand colors */
+  --navy: #1E3A5F;
+  --navy-light: #2A5280;
+  --navy-dark: #122542;
+  --amber: #F59E0B;
+  --amber-light: #FBBF24;
+  --amber-dark: #B45309;
+  --white: #FFFFFF;
+  --gray-50: #F8F9FA;
+  --gray-100: #F1F3F5;
+  --gray-200: #E9ECEF;
+  --gray-300: #DEE2E6;
+  --gray-400: #CED4DA;
+  --gray-500: #ADB5BD;
+  --gray-600: #868E96;
+  --gray-700: #495057;
+  --gray-800: #343A40;
+  --gray-900: #212529;
+
+  /* Semantic */
+  --bg-primary: var(--white);
+  --bg-secondary: var(--gray-50);
+  --bg-card: var(--white);
+  --text-primary: var(--gray-900);
+  --text-secondary: var(--gray-700);
+  --text-muted: var(--gray-600);
+  --border-color: var(--gray-200);
+  --accent: var(--navy);
+  --accent-light: var(--navy-light);
+  --highlight: var(--amber);
+  --highlight-bg: #FEF3C7;
+  --success: #2E7D32;
+  --success-bg: #E8F5E9;
+  --error: #C62828;
+  --error-bg: #FFEBEE;
+  --info: #1565C0;
+  --info-bg: #E3F2FD;
+
+  /* Typography */
+  --font-sans: 'Nunito', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+  --text-3xl: 1.875rem;
+  --text-4xl: 2.25rem;
+
+  /* Spacing */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-10: 2.5rem;
+  --space-12: 3rem;
+  --space-16: 4rem;
+
+  /* Radius */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.07);
+  --shadow-lg: 0 10px 15px rgba(0,0,0,0.1);
+
+  /* Transitions */
+  --transition-fast: 150ms ease;
+  --transition-normal: 250ms ease;
+  --transition-slow: 350ms ease;
+}
+
+[data-theme="dark"] {
+  --bg-primary: #0D1117;
+  --bg-secondary: #161B22;
+  --bg-card: #1C2128;
+  --text-primary: #E6EDF3;
+  --text-secondary: #B1BAC4;
+  --text-muted: #8B949E;
+  --border-color: #30363D;
+  --accent: #58A6FF;
+  --accent-light: #79C0FF;
+  --highlight: var(--amber);
+  --highlight-bg: #2D2200;
+  --success: #56D364;
+  --success-bg: #0D2818;
+  --error: #F85149;
+  --error-bg: #2D1214;
+  --info: #58A6FF;
+  --info-bg: #0D1B2E;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.3);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.4);
+  --shadow-lg: 0 10px 15px rgba(0,0,0,0.5);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg-primary: #0D1117;
+    --bg-secondary: #161B22;
+    --bg-card: #1C2128;
+    --text-primary: #E6EDF3;
+    --text-secondary: #B1BAC4;
+    --text-muted: #8B949E;
+    --border-color: #30363D;
+    --accent: #58A6FF;
+    --accent-light: #79C0FF;
+    --highlight: var(--amber);
+    --highlight-bg: #2D2200;
+    --success: #56D364;
+    --success-bg: #0D2818;
+    --error: #F85149;
+    --error-bg: #2D1214;
+    --info: #58A6FF;
+    --info-bg: #0D1B2E;
+  }
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  line-height: 1.6;
+  color: var(--text-primary);
+  background-color: var(--bg-primary);
+  -webkit-font-smoothing: antialiased;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow var(--transition-normal);
+}
+
+.card:hover {
+  box-shadow: var(--shadow-md);
+}
+
+.callout {
+  padding: var(--space-4) var(--space-6);
+  border-radius: var(--radius-md);
+  margin: var(--space-4) 0;
+  border-left: 4px solid;
+}
+
+.callout-key { background: var(--highlight-bg); border-color: var(--amber); }
+.callout-gotcha { background: var(--error-bg); border-color: var(--error); }
+.callout-tip { background: var(--info-bg); border-color: var(--info); }
+.callout-success { background: var(--success-bg); border-color: var(--success); }
+
+.callout-title {
+  font-weight: 700;
+  font-size: var(--text-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: var(--space-2);
+}
+
+.text-center { text-align: center; }
+.text-muted { color: var(--text-muted); }
+.font-mono { font-family: var(--font-mono); }
+.mt-4 { margin-top: var(--space-4); }
+.mt-8 { margin-top: var(--space-8); }
+.mb-4 { margin-bottom: var(--space-4); }
+.mb-8 { margin-bottom: var(--space-8); }
+.mx-auto { margin-left: auto; margin-right: auto; }
+.max-w-4xl { max-width: 56rem; }
+.hidden { display: none !important; }
+  /* slides.css — generated; edit slides/shared/slides.css */
+/* ADK Course — Slide Presentation Theme
+   Adapted from barcik-training-exin-ai-foundation/slides/css/slides.css.
+   Adds data-type="code" slide variant for Python snippets. */
+
+:root {
+  --slide-font-size: 18px;
+  --strip-height: 48px;
+}
+
+body {
+  margin: 0;
+  overflow: hidden;
+  background: var(--bg-primary);
+}
+
+/* ── Progress Strip ──────────────────────────────── */
+.progress-strip {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  height: var(--strip-height);
+  background: var(--navy);
+  display: flex;
+  align-items: center;
+  z-index: 100;
+  padding: 0 var(--space-4);
+  gap: var(--space-4);
+  box-shadow: var(--shadow-md);
+  font-family: var(--font-sans);
+}
+
+.progress-home {
+  color: var(--amber);
+  text-decoration: none;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: var(--radius-md);
+  white-space: nowrap;
+  transition: all var(--transition-fast);
+}
+
+.progress-home:hover {
+  background: rgba(255,255,255,0.1);
+  border-color: var(--amber);
+}
+
+.progress-title {
+  color: rgba(255,255,255,0.85);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  flex: 1;
+  text-align: center;
+}
+
+.progress-title .quick-path-badge {
+  display: inline-block;
+  background: var(--amber);
+  color: var(--navy-dark);
+  font-size: 0.68rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.15rem 0.55rem;
+  border-radius: 9999px;
+  margin-left: 0.6rem;
+  vertical-align: 2px;
+}
+
+.progress-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.slide-counter {
+  color: rgba(255,255,255,0.6);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  font-family: var(--font-mono);
+  white-space: nowrap;
+}
+
+.progress-strip .theme-toggle {
+  background: rgba(255,255,255,0.1);
+  color: rgba(255,255,255,0.7);
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: var(--radius-md);
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-xs);
+  cursor: pointer;
+  font-family: var(--font-sans);
+  transition: all var(--transition-fast);
+}
+
+.progress-strip .theme-toggle:hover {
+  background: rgba(255,255,255,0.2);
+  color: white;
+}
+
+/* ── Viewport ────────────────────────────────────── */
+.slide-viewport {
+  position: fixed;
+  top: var(--strip-height);
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow: hidden;
+}
+
+/* ── Slide Base ──────────────────────────────────── */
+.slide {
+  display: none;
+  position: absolute;
+  inset: 0;
+  overflow-y: auto;
+  padding: var(--space-10) var(--space-16);
+  font-size: var(--slide-font-size);
+  line-height: 1.6;
+  font-family: var(--font-sans);
+  color: var(--text-primary);
+  background: var(--bg-primary);
+}
+
+.slide.active {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  animation: fadeIn 0.25s ease;
+}
+
+.slide > * {
+  max-width: 1100px;
+  width: 100% !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
+  box-sizing: border-box;
+  text-align: inherit;
+}
+
+.slide > .topic-badge {
+  width: auto !important;
+  max-width: none;
+  align-self: center;
+}
+
+/* ── Section Title ───────────────────────────────── */
+.slide[data-type="section-title"] {
+  background: linear-gradient(135deg, var(--navy) 0%, var(--navy-light) 100%);
+  text-align: center;
+}
+
+.slide[data-type="section-title"] h1,
+.slide[data-type="section-title"] h2,
+.slide[data-type="section-title"] h3 {
+  color: white;
+}
+
+.slide[data-type="section-title"] p {
+  color: rgba(255,255,255,0.85);
+}
+
+.slide[data-type="section-title"] .topic-badge {
+  display: inline-block;
+  background: var(--amber);
+  color: var(--navy-dark);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  padding: var(--space-2) var(--space-4);
+  border-radius: 9999px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: var(--space-4);
+  width: auto !important;
+}
+
+.slide[data-type="section-title"] .highlight-text {
+  color: var(--amber);
+  font-weight: 600;
+}
+
+/* ── Typography ──────────────────────────────────── */
+.slide h1 {
+  font-size: 2.4em;
+  font-weight: 800;
+  color: var(--navy);
+  margin-bottom: var(--space-4);
+  line-height: 1.15;
+}
+
+.slide h2 {
+  font-size: 1.6em;
+  font-weight: 700;
+  color: var(--navy);
+  margin-bottom: var(--space-4);
+  padding-bottom: var(--space-2);
+  border-bottom: 3px solid var(--amber);
+}
+
+.slide h3 {
+  font-size: 1.2em;
+  font-weight: 600;
+  color: var(--navy-light);
+  margin-bottom: var(--space-3);
+}
+
+.slide p {
+  margin-bottom: var(--space-3);
+  color: var(--text-secondary);
+}
+
+.slide strong {
+  color: var(--navy);
+  font-weight: 700;
+}
+
+.slide em {
+  color: var(--amber-dark);
+  font-style: italic;
+}
+
+.slide ul, .slide ol {
+  margin-left: 1.2em;
+  margin-bottom: var(--space-4);
+}
+
+.slide li {
+  margin-bottom: var(--space-2);
+  color: var(--text-secondary);
+}
+
+.slide li::marker {
+  color: var(--amber);
+}
+
+[data-theme="dark"] .slide h1,
+[data-theme="dark"] .slide h2 { color: var(--text-primary); }
+[data-theme="dark"] .slide h3 { color: var(--text-secondary); }
+[data-theme="dark"] .slide strong { color: var(--text-primary); }
+[data-theme="dark"] .slide h2 { border-bottom-color: var(--amber); }
+
+.highlight-text {
+  color: var(--amber-dark);
+  font-weight: 600;
+}
+
+[data-theme="dark"] .highlight-text {
+  color: var(--amber);
+}
+
+/* ── Grid ────────────────────────────────────────── */
+.slide[data-type="grid"] .grid-layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: var(--space-4);
+  margin-top: var(--space-4);
+}
+
+.grid-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5);
+  transition: all var(--transition-normal);
+}
+
+.grid-card:hover {
+  box-shadow: var(--shadow-md);
+  transform: translateY(-2px);
+  border-color: var(--accent);
+}
+
+.grid-card.highlight {
+  border-color: var(--amber);
+  box-shadow: 0 0 0 1px var(--amber), var(--shadow-sm);
+}
+
+.grid-card-title {
+  font-weight: 700;
+  color: var(--text-primary);
+  font-size: 1.05em;
+  margin-bottom: var(--space-2);
+}
+
+.grid-card-body {
+  color: var(--text-secondary);
+  font-size: 0.9em;
+  line-height: 1.5;
+}
+
+/* ── Split ───────────────────────────────────────── */
+.slide[data-type="split"] .split-layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-8);
+  margin-top: var(--space-4);
+}
+
+@media (max-width: 768px) {
+  .slide[data-type="split"] .split-layout { grid-template-columns: 1fr; }
+}
+
+/* ── Comparison ──────────────────────────────────── */
+.slide[data-type="comparison"] .comparison-layout {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: var(--space-6);
+  align-items: start;
+  margin-top: var(--space-4);
+}
+
+.vs-left, .vs-right {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+}
+
+.vs-divider {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5em;
+  font-weight: 800;
+  color: var(--text-muted);
+  align-self: center;
+}
+
+@media (max-width: 768px) {
+  .slide[data-type="comparison"] .comparison-layout {
+    grid-template-columns: 1fr;
+  }
+  .vs-divider { display: none; }
+}
+
+/* ── Quote ───────────────────────────────────────── */
+.slide[data-type="quote"] {
+  text-align: center;
+}
+
+.quote-text {
+  font-size: 1.5em;
+  font-weight: 300;
+  font-style: italic;
+  color: var(--text-primary);
+  max-width: 80%;
+  line-height: 1.5;
+  position: relative;
+  padding: 0.5em 1em;
+  margin: 0 auto;
+}
+
+.quote-text::before {
+  content: '\201C';
+  position: absolute;
+  left: -0.3em;
+  top: -0.2em;
+  font-size: 3.5em;
+  color: var(--amber);
+  font-weight: 800;
+  line-height: 1;
+  opacity: 0.3;
+}
+
+.quote-source {
+  margin-top: var(--space-4);
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  font-weight: 500;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.quote-source::before { content: '\2014\00a0'; }
+
+/* ── Key Fact ────────────────────────────────────── */
+.slide[data-type="keyfact"] {
+  text-align: center;
+}
+
+.slide[data-type="keyfact"] p {
+  font-size: 1.5em;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.35;
+}
+
+.slide[data-type="keyfact"] strong {
+  color: var(--amber-dark);
+}
+
+[data-theme="dark"] .slide[data-type="keyfact"] strong {
+  color: var(--amber);
+}
+
+/* ── Hero ────────────────────────────────────────── */
+.slide[data-type="hero"] {
+  text-align: center;
+}
+
+/* ── Example / Code ──────────────────────────────── */
+.slide[data-type="example"] {
+  border-left: 4px solid var(--info);
+}
+
+.slide[data-type="code"] pre,
+.slide pre {
+  background: var(--gray-900);
+  color: #E6EDF3;
+  border-radius: var(--radius-md);
+  padding: var(--space-4) var(--space-5);
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  line-height: 1.55;
+  margin: var(--space-3) 0;
+  box-shadow: var(--shadow-sm);
+}
+
+.slide[data-type="code"] pre code,
+.slide pre code {
+  background: none;
+  color: inherit;
+  padding: 0;
+  font-family: var(--font-mono);
+}
+
+.slide code {
+  font-family: var(--font-mono);
+  background: var(--bg-secondary);
+  color: var(--navy);
+  padding: 0.1em 0.35em;
+  border-radius: var(--radius-sm);
+  font-size: 0.9em;
+}
+
+[data-theme="dark"] .slide code {
+  color: var(--accent-light);
+  background: var(--gray-800);
+}
+
+.slide .code-caption {
+  color: var(--text-muted);
+  font-size: 0.85em;
+  font-style: italic;
+  margin-top: var(--space-2);
+}
+
+/* ── Definition Cards ────────────────────────────── */
+.def-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-left: 4px solid var(--navy-light);
+  border-radius: 0 var(--radius-lg) var(--radius-lg) 0;
+  padding: var(--space-4) var(--space-5);
+  margin-bottom: var(--space-3);
+  transition: border-color var(--transition-fast);
+}
+
+.def-card.highlight {
+  border-left-color: var(--amber);
+}
+
+.def-term {
+  font-size: var(--text-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--navy-light);
+  margin-bottom: var(--space-2);
+}
+
+[data-theme="dark"] .def-term { color: var(--accent); }
+
+.def-text {
+  color: var(--text-primary);
+  line-height: 1.5;
+}
+
+/* ── Callouts on slides ──────────────────────────── */
+.slide .callout {
+  margin: var(--space-4) 0;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* ── Tables ──────────────────────────────────────── */
+.slide table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  margin: var(--space-4) 0;
+  font-size: 0.92em;
+}
+
+.slide table th {
+  background: var(--navy);
+  color: white;
+  padding: var(--space-3) var(--space-4);
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.9em;
+}
+
+.slide table td {
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border-color);
+  color: var(--text-secondary);
+}
+
+.slide table tr:nth-child(even) { background: var(--bg-secondary); }
+.slide table tr:last-child td { border-bottom: none; }
+
+/* ── Two-Column Layout ───────────────────────────── */
+.two-col {
+  display: flex;
+  gap: var(--space-8);
+  align-items: flex-start;
+}
+
+.col { flex: 1; min-width: 0; }
+
+@media (max-width: 768px) {
+  .two-col { flex-direction: column; gap: var(--space-4); }
+}
+
+/* ── ASCII-art / diagram ─────────────────────────── */
+.slide .diagram {
+  background: var(--gray-900);
+  color: #C9D1D9;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  line-height: 1.4;
+  padding: var(--space-4) var(--space-5);
+  border-radius: var(--radius-md);
+  white-space: pre;
+  overflow-x: auto;
+  margin: var(--space-3) 0;
+}
+
+/* ── Font Controls ───────────────────────────────── */
+.font-controls {
+  position: fixed;
+  bottom: var(--space-6);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: var(--space-2);
+  z-index: 100;
+  background: var(--bg-card);
+  padding: var(--space-2);
+  border-radius: 9999px;
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-md);
+  opacity: 0.5;
+  transition: opacity var(--transition-fast);
+}
+
+.font-controls:hover { opacity: 1; }
+
+.font-controls button {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.font-controls button:hover {
+  background: var(--navy);
+  color: white;
+  border-color: var(--navy);
+}
+
+/* ── Animations ──────────────────────────────────── */
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Print ───────────────────────────────────────── */
+@media print {
+  .progress-strip, .font-controls { display: none !important; }
+  .slide-viewport { position: static; overflow: visible; }
+  .slide {
+    display: block !important;
+    position: static !important;
+    page-break-after: always;
+    padding: 2cm;
+  }
+  .slide[data-type="section-title"] {
+    background: var(--navy) !important;
+    color: white !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+  .slide pre {
+    background: var(--gray-100) !important;
+    color: var(--gray-900) !important;
+    border: 1px solid var(--gray-400);
+  }
+}
+  </style>
+  <!-- END-INLINED-STYLES -->
 </head>
 <body>
   <nav class="progress-strip">
@@ -1161,5 +1971,148 @@ runner = Runner(agent=remote, ...)</code></pre>
 
 })();
 </script>
+
+  <!-- BEGIN-INLINED-SCRIPT -->
+<script>
+/* ADK Course — Slide Engine
+   Adapted from barcik-training-exin-ai-foundation/slides/js/slides.js.
+   Per-module decks; lightweight nav with keyboard, touch, hash routing,
+   font controls, theme toggle. */
+
+(function () {
+  'use strict';
+
+  const slides = document.querySelectorAll('.slide');
+  const total = slides.length;
+  let current = 0;
+
+  function goTo(index) {
+    if (index < 0 || index >= total) return;
+    slides[current].classList.remove('active');
+    current = index;
+    slides[current].classList.add('active');
+    updateCounter();
+    window.scrollTo(0, 0);
+    history.replaceState(null, '', '#slide-' + (current + 1));
+  }
+
+  function next() { goTo(current + 1); }
+  function prev() { goTo(current - 1); }
+
+  document.addEventListener('keydown', function (e) {
+    if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+      case ' ':
+        e.preventDefault();
+        next();
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        e.preventDefault();
+        prev();
+        break;
+      case 'Home':
+        e.preventDefault();
+        goTo(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        goTo(total - 1);
+        break;
+    }
+  });
+
+  var viewport = document.querySelector('.slide-viewport');
+  if (viewport) {
+    viewport.addEventListener('click', function (e) {
+      if (e.target === this || e.target.classList.contains('slide')) {
+        var rect = this.getBoundingClientRect();
+        var x = e.clientX - rect.left;
+        if (x > rect.width * 0.75) next();
+        else if (x < rect.width * 0.25) prev();
+      }
+    });
+  }
+
+  var counter = document.querySelector('.slide-counter');
+  function updateCounter() {
+    if (counter) counter.textContent = (current + 1) + ' / ' + total;
+  }
+
+  var baseFontSize = parseInt(localStorage.getItem('adkSlideFontSize')) || 18;
+  applyFontSize();
+
+  window.adjustFont = function (delta) {
+    if (delta === 0) {
+      baseFontSize = 18;
+    } else {
+      baseFontSize = Math.max(14, Math.min(28, baseFontSize + delta));
+    }
+    applyFontSize();
+    localStorage.setItem('adkSlideFontSize', baseFontSize);
+  };
+
+  function applyFontSize() {
+    document.documentElement.style.setProperty('--slide-font-size', baseFontSize + 'px');
+  }
+
+  var themeBtn = document.querySelector('.theme-toggle');
+  var savedTheme = localStorage.getItem('adkTheme');
+  if (savedTheme) {
+    document.documentElement.setAttribute('data-theme', savedTheme);
+  }
+
+  if (themeBtn) {
+    themeBtn.addEventListener('click', function () {
+      var html = document.documentElement;
+      var nextTheme = html.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+      html.setAttribute('data-theme', nextTheme);
+      localStorage.setItem('adkTheme', nextTheme);
+    });
+  }
+
+  var touchStartX = 0;
+  var touchStartY = 0;
+
+  document.addEventListener('touchstart', function (e) {
+    touchStartX = e.changedTouches[0].screenX;
+    touchStartY = e.changedTouches[0].screenY;
+  }, { passive: true });
+
+  document.addEventListener('touchend', function (e) {
+    var dx = e.changedTouches[0].screenX - touchStartX;
+    var dy = e.changedTouches[0].screenY - touchStartY;
+    if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > 50) {
+      if (dx < 0) next();
+      else prev();
+    }
+  }, { passive: true });
+
+  var hash = window.location.hash;
+  if (hash && hash.startsWith('#slide-')) {
+    var n = parseInt(hash.replace('#slide-', ''));
+    if (!isNaN(n) && n >= 1 && n <= total) {
+      current = n - 1;
+    }
+  }
+
+  slides[current].classList.add('active');
+  updateCounter();
+
+  window.addEventListener('hashchange', function () {
+    var h = window.location.hash;
+    if (h && h.startsWith('#slide-')) {
+      var n = parseInt(h.replace('#slide-', ''));
+      if (!isNaN(n) && n >= 1 && n <= total && n - 1 !== current) {
+        goTo(n - 1);
+      }
+    }
+  });
+
+})();
+</script>
+<!-- END-INLINED-SCRIPT -->
 </body>
 </html>

--- a/slides/shared/shared.css
+++ b/slides/shared/shared.css
@@ -2,6 +2,8 @@
    Adapted from barcik-training-exin-ai-foundation/css/shared.css.
    Family-consistent navy with amber accent (distinct from EXIN gold). */
 
+@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;500;600;700;800&display=swap');
+
 :root {
   /* Brand colors */
   --navy: #1E3A5F;
@@ -42,7 +44,7 @@
   --info-bg: #E3F2FD;
 
   /* Typography */
-  --font-sans: 'Segoe UI', system-ui, -apple-system, sans-serif;
+  --font-sans: 'Nunito', 'Segoe UI', system-ui, -apple-system, sans-serif;
   --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
   --text-xs: 0.75rem;
   --text-sm: 0.875rem;

--- a/slides/shared/slides.css
+++ b/slides/shared/slides.css
@@ -53,6 +53,20 @@ body {
   text-align: center;
 }
 
+.progress-title .quick-path-badge {
+  display: inline-block;
+  background: var(--amber);
+  color: var(--navy-dark);
+  font-size: 0.68rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.15rem 0.55rem;
+  border-radius: 9999px;
+  margin-left: 0.6rem;
+  vertical-align: 2px;
+}
+
 .progress-meta {
   display: flex;
   align-items: center;

--- a/textbook/_sources/tools/build_html.py
+++ b/textbook/_sources/tools/build_html.py
@@ -19,6 +19,8 @@ BOOK_TITLE = "Google ADK — A Practical Course"
 BOOK_SUBTITLE = "Vendor-agnostic agent development with the Google Agent Development Kit"
 
 CSS = """
+@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;500;600;700;800&display=swap');
+
 :root {
     --navy: #1e3a5f;
     --navy-light: #2a5280;
@@ -77,7 +79,7 @@ body {
 }
 
 #sidebar-header h2 {
-    font-family: 'Helvetica Neue', Arial, sans-serif;
+    font-family: 'Nunito', 'Helvetica Neue', Arial, sans-serif;
     font-size: 0.95rem;
     font-weight: 700;
     color: var(--navy);
@@ -100,7 +102,7 @@ body {
 #sidebar nav ul li a {
     display: block;
     padding: 0.55rem 1.5rem;
-    font-family: 'Helvetica Neue', Arial, sans-serif;
+    font-family: 'Nunito', 'Helvetica Neue', Arial, sans-serif;
     font-size: 0.85rem;
     color: var(--text-light);
     text-decoration: none;
@@ -160,7 +162,7 @@ body {
 }
 
 .chapter-number {
-    font-family: 'Helvetica Neue', Arial, sans-serif;
+    font-family: 'Nunito', 'Helvetica Neue', Arial, sans-serif;
     font-size: 0.82rem;
     font-weight: 700;
     color: var(--amber-dark);
@@ -169,8 +171,27 @@ body {
     margin-bottom: 0.5rem;
 }
 
+.chapter-number .quick-path-badge {
+    display: inline-block;
+    background: var(--amber);
+    color: white;
+    font-size: 0.68rem;
+    font-weight: 800;
+    padding: 0.18rem 0.55rem;
+    border-radius: 9999px;
+    margin-left: 0.6rem;
+    vertical-align: 1px;
+    letter-spacing: 0.06em;
+}
+
+#sidebar nav ul li a.quick-path::after {
+    content: '⚡';
+    margin-left: 0.4rem;
+    color: var(--amber-dark);
+}
+
 h1 {
-    font-family: 'Helvetica Neue', Arial, sans-serif;
+    font-family: 'Nunito', 'Helvetica Neue', Arial, sans-serif;
     font-size: 2.2rem;
     font-weight: 700;
     color: var(--navy);
@@ -179,7 +200,7 @@ h1 {
 }
 
 h2 {
-    font-family: 'Helvetica Neue', Arial, sans-serif;
+    font-family: 'Nunito', 'Helvetica Neue', Arial, sans-serif;
     font-size: 1.6rem;
     font-weight: 700;
     color: var(--navy);
@@ -189,7 +210,7 @@ h2 {
 }
 
 h3 {
-    font-family: 'Helvetica Neue', Arial, sans-serif;
+    font-family: 'Nunito', 'Helvetica Neue', Arial, sans-serif;
     font-size: 1.2rem;
     font-weight: 600;
     color: var(--navy-light);
@@ -243,7 +264,7 @@ table {
 thead { background: var(--navy); color: white; }
 
 th {
-    font-family: 'Helvetica Neue', Arial, sans-serif;
+    font-family: 'Nunito', 'Helvetica Neue', Arial, sans-serif;
     font-weight: 600;
     padding: 0.75rem 1rem;
     text-align: left;
@@ -401,6 +422,15 @@ def build():
         print(f"No chapter files found in {CHAPTERS_DIR}")
         return
 
+    # Filenames that belong to the 1-hour Quick path. Marked with a badge in
+    # both the sidebar and the chapter header. See README "Quick path".
+    QUICK_PATH_FILES = {
+        "01-mental-model.md",
+        "02-tools.md",
+        "05-workflow-agents.md",
+        "11-gemini-grounding-caching.md",
+    }
+
     chapters = []
     for f in files:
         with open(f, "r", encoding="utf-8") as fh:
@@ -408,17 +438,23 @@ def build():
         title = extract_title(content) or os.path.basename(f).replace(".md", "").replace("_", " ")
         html_content = md_to_html(content)
         ch_id = make_id(title)
-        chapters.append((title, ch_id, html_content))
+        is_quick = os.path.basename(f) in QUICK_PATH_FILES
+        chapters.append((title, ch_id, html_content, is_quick))
 
     nav_items = []
-    for i, (title, ch_id, _) in enumerate(chapters):
+    for i, (title, ch_id, _, is_quick) in enumerate(chapters):
         label = title if i == 0 else f"{i}. {title}"
-        nav_items.append(f'<li><a href="#{ch_id}">{label}</a></li>')
+        cls = ' class="quick-path"' if is_quick else ''
+        nav_items.append(f'<li><a href="#{ch_id}"{cls}>{label}</a></li>')
     nav_html = "\n".join(nav_items)
 
     sections = []
-    for i, (title, ch_id, html_content) in enumerate(chapters):
-        ch_num = "" if i == 0 else f'<div class="chapter-number">Chapter {i}</div>'
+    for i, (title, ch_id, html_content, is_quick) in enumerate(chapters):
+        badge = '<span class="quick-path-badge">⚡ Quick path</span>' if is_quick else ''
+        if i == 0:
+            ch_num = ""
+        else:
+            ch_num = f'<div class="chapter-number">Chapter {i}{badge}</div>'
         sections.append(f'''
         <section class="chapter" id="{ch_id}">
             {ch_num}

--- a/textbook/index.html
+++ b/textbook/index.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Google ADK — A Practical Course</title>
     <style>
+@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;500;600;700;800&display=swap');
+
 :root {
     --navy: #1e3a5f;
     --navy-light: #2a5280;
@@ -63,7 +65,7 @@ body {
 }
 
 #sidebar-header h2 {
-    font-family: 'Helvetica Neue', Arial, sans-serif;
+    font-family: 'Nunito', 'Helvetica Neue', Arial, sans-serif;
     font-size: 0.95rem;
     font-weight: 700;
     color: var(--navy);
@@ -86,7 +88,7 @@ body {
 #sidebar nav ul li a {
     display: block;
     padding: 0.55rem 1.5rem;
-    font-family: 'Helvetica Neue', Arial, sans-serif;
+    font-family: 'Nunito', 'Helvetica Neue', Arial, sans-serif;
     font-size: 0.85rem;
     color: var(--text-light);
     text-decoration: none;
@@ -146,7 +148,7 @@ body {
 }
 
 .chapter-number {
-    font-family: 'Helvetica Neue', Arial, sans-serif;
+    font-family: 'Nunito', 'Helvetica Neue', Arial, sans-serif;
     font-size: 0.82rem;
     font-weight: 700;
     color: var(--amber-dark);
@@ -155,8 +157,27 @@ body {
     margin-bottom: 0.5rem;
 }
 
+.chapter-number .quick-path-badge {
+    display: inline-block;
+    background: var(--amber);
+    color: white;
+    font-size: 0.68rem;
+    font-weight: 800;
+    padding: 0.18rem 0.55rem;
+    border-radius: 9999px;
+    margin-left: 0.6rem;
+    vertical-align: 1px;
+    letter-spacing: 0.06em;
+}
+
+#sidebar nav ul li a.quick-path::after {
+    content: '⚡';
+    margin-left: 0.4rem;
+    color: var(--amber-dark);
+}
+
 h1 {
-    font-family: 'Helvetica Neue', Arial, sans-serif;
+    font-family: 'Nunito', 'Helvetica Neue', Arial, sans-serif;
     font-size: 2.2rem;
     font-weight: 700;
     color: var(--navy);
@@ -165,7 +186,7 @@ h1 {
 }
 
 h2 {
-    font-family: 'Helvetica Neue', Arial, sans-serif;
+    font-family: 'Nunito', 'Helvetica Neue', Arial, sans-serif;
     font-size: 1.6rem;
     font-weight: 700;
     color: var(--navy);
@@ -175,7 +196,7 @@ h2 {
 }
 
 h3 {
-    font-family: 'Helvetica Neue', Arial, sans-serif;
+    font-family: 'Nunito', 'Helvetica Neue', Arial, sans-serif;
     font-size: 1.2rem;
     font-weight: 600;
     color: var(--navy-light);
@@ -229,7 +250,7 @@ table {
 thead { background: var(--navy); color: white; }
 
 th {
-    font-family: 'Helvetica Neue', Arial, sans-serif;
+    font-family: 'Nunito', 'Helvetica Neue', Arial, sans-serif;
     font-weight: 600;
     padding: 0.75rem 1rem;
     text-align: left;
@@ -312,17 +333,17 @@ hr {
         <nav>
             <ul>
                 <li><a href="#introduction">Introduction</a></li>
-<li><a href="#why-agents-why-adk">1. Why agents, why ADK</a></li>
-<li><a href="#tools-as-verbs">2. Tools as verbs</a></li>
+<li><a href="#why-agents-why-adk" class="quick-path">1. Why agents, why ADK</a></li>
+<li><a href="#tools-as-verbs" class="quick-path">2. Tools as verbs</a></li>
 <li><a href="#sessions-state-events-artifacts">3. Sessions, State, Events, Artifacts</a></li>
 <li><a href="#the-one-line-model-swap">4. The one-line model swap</a></li>
-<li><a href="#workflow-agents">5. Workflow agents</a></li>
+<li><a href="#workflow-agents" class="quick-path">5. Workflow agents</a></li>
 <li><a href="#multi-agent-hierarchies">6. Multi-agent hierarchies</a></li>
 <li><a href="#callbacks-as-middleware">7. Callbacks as middleware</a></li>
 <li><a href="#memory">8. Memory</a></li>
 <li><a href="#evaluation">9. Evaluation</a></li>
 <li><a href="#deployment">10. Deployment</a></li>
-<li><a href="#gemini-unlocks-grounding-and-context-caching">11. Gemini unlocks — grounding and context caching</a></li>
+<li><a href="#gemini-unlocks-grounding-and-context-caching" class="quick-path">11. Gemini unlocks — grounding and context caching</a></li>
 <li><a href="#thinking-budgets">12. Thinking budgets</a></li>
 <li><a href="#live-api-voice-agent">13. Live API voice agent</a></li>
 <li><a href="#a2a-protocol-the-side-step">14. A2A protocol — the side step</a></li>
@@ -362,7 +383,7 @@ hr {
         </section>
 
         <section class="chapter" id="why-agents-why-adk">
-            <div class="chapter-number">Chapter 1</div>
+            <div class="chapter-number">Chapter 1<span class="quick-path-badge">⚡ Quick path</span></div>
             <h1>Why agents, why ADK</h1>
 <p>The first time anyone builds an agent by hand, they end up writing roughly the same sixty lines of code. A retry loop around the LLM call because the API occasionally times out. A JSON-output parser that crashes on the fourth edge case and needs a try-except wrapper. A manual conversation-history list that outgrows the context window after twelve turns and starts costing money in ways that surprise the billing department. A switch statement that dispatches tool calls to Python functions, because the model keeps emitting structured tool requests and somebody has to execute them. Error handling for the day the model hallucinates a tool that doesn&rsquo;t exist, and the handler that prompts it to try again without the hallucination.</p>
 <p>Sixty lines. Every time.</p>
@@ -454,7 +475,7 @@ async for event in runner.run_async(
         </section>
 
         <section class="chapter" id="tools-as-verbs">
-            <div class="chapter-number">Chapter 2</div>
+            <div class="chapter-number">Chapter 2<span class="quick-path-badge">⚡ Quick path</span></div>
             <h1>Tools as verbs</h1>
 <p>If Module 01 gave you the mental model of an agent, this chapter is where the agent starts doing things. An agent without tools is a chatbot — it can only produce text. An agent with tools can look up data, call APIs, run code, talk to other agents. All the interesting properties of agent software come from the tool boundary, and almost all the interesting bugs do too. This chapter covers the four flavors of tools ADK supports, when to reach for each, and one design rule that applies across all of them.</p>
 <h2>The tool mental model</h2>
@@ -986,7 +1007,7 @@ For any code question:
         </section>
 
         <section class="chapter" id="workflow-agents">
-            <div class="chapter-number">Chapter 5</div>
+            <div class="chapter-number">Chapter 5<span class="quick-path-badge">⚡ Quick path</span></div>
             <h1>Workflow agents</h1>
 <p>Four chapters in, every example has featured one agent doing the work. One agent is enough for toy problems, and nothing more. Real agent software is composition — several agents arranged into pipelines, fan-outs, refinement loops — because the interesting problems never fit one prompt.</p>
 <p>This chapter introduces ADK&rsquo;s three first-class composition primitives: <code>SequentialAgent</code>, <code>ParallelAgent</code>, and <code>LoopAgent</code>. Each takes a list of child agents and runs them according to a fixed control-flow pattern. You don&rsquo;t write orchestration code; you name the pattern.</p>
@@ -2074,7 +2095,7 @@ runner = Runner(
         </section>
 
         <section class="chapter" id="gemini-unlocks-grounding-and-context-caching">
-            <div class="chapter-number">Chapter 11</div>
+            <div class="chapter-number">Chapter 11<span class="quick-path-badge">⚡ Quick path</span></div>
             <h1>Gemini unlocks — grounding and context caching</h1>
 <p><strong>Part 2 of the course starts here.</strong></p>
 <p>Ten chapters of vendor-neutral ADK. Everything ran on whichever model you picked — Claude, GPT, Qwen, Gemma, Gemini — via the <code>LiteLlm</code> wrapper. Part 2 is honest about what you give up by staying neutral. Three Gemini-specific capabilities earn their own chapters because nothing else in the market replicates them:</p>


### PR DESCRIPTION
Two changes driven by user feedback.

## 1. Typography — Nunito

Slides felt robotic. Switched to **Nunito** across slides, portal, and textbook headings. Textbook body stays Georgia serif (long-form readability). Rebuilt all 14 decks; `build_slides.py` now properly idempotent (re-runs after shared-CSS changes re-inline).

## 2. Quick path — 1-hour intro track

For students who want a preview vs those who want the full course. Four modules thread together:

- **M01** Why agents, why ADK (mental model)
- **M02** Tools as verbs (core capability)
- **M05** Workflow agents (Generator+Critic wow)
- **M11** Gemini grounding (taste of Part 2)

Marked with ⚡ across all four artifact types:

- **README**: new "Two ways to take the course" section, suggested reading order
- **Portal** (`index.html`): amber callout card at top; ⚡ on quick-path cards in both grids
- **Slide decks**: 'Quick path' badge in header of M01/M02/M05/M11
- **Textbook**: sidebar + chapter-header markers on the 4 chapters
- **Notebooks**: first-cell blockquote note linking back to README

## Test plan

- [x] Nunito renders via `file://` in Safari (verified visually)
- [x] Nunito renders via `http://` (localhost server)
- [x] Quick-path badge appears on M01/M02/M05/M11 only
- [x] Textbook sidebar shows ⚡ on 4 chapters (verified via DOM inspection)
- [x] Notebook 01 still runs end-to-end after marker insertion
- [x] `build_slides.py` is idempotent — repeat runs produce no changes on unchanged source

🤖 Generated with [Claude Code](https://claude.com/claude-code)